### PR TITLE
Added logging for invite spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 screenshots/
+logs/
 node_modules/
 .idea/
 # image-uploads/

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
 general:
   artifacts:
     - "screenshots"
+    - "logs"
 
 checkout:
   post:

--- a/lib/after.js
+++ b/lib/after.js
@@ -9,7 +9,7 @@ import * as driverManager from './driver-manager';
 
 const afterHookTimeoutMS = config.get( 'afterHookTimeoutMS' );
 
-test.afterEach( function() {
+test.afterEach( 'Take Screenshot', function() {
 	this.timeout( afterHookTimeoutMS );
 
 	const driver = global.__BROWSER__;
@@ -59,6 +59,18 @@ test.afterEach( function() {
 		} catch ( e ) {
 			console.log( `Error when taking screenshot in base container: '${e}'` );
 		}
+	}
+} );
+
+test.afterEach( 'Capture Logs on Failure', function() {
+	this.timeout( afterHookTimeoutMS );
+	const driver = global.__BROWSER__;
+
+	if ( this.currentTest.state === 'failed' ) {
+		driver.manage().logs().get( 'browser' ).then( function( logs ) {
+			let location = mediaHelper.writeTextLogFile( JSON.stringify( logs ), 'failed-test' );
+			console.log( `BROWSER Logs saved to: '${location}'` );
+		} );
 	}
 } );
 

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -51,6 +51,8 @@ export function startBrowser() {
 	let driver;
 	let options;
 	let builder;
+	let pref = new webdriver.logging.Preferences();
+	pref.setLevel( 'browser', webdriver.logging.Level.ALL );
 	switch ( browser.toLowerCase() ) {
 		case 'chrome':
 			options = new chrome.Options();
@@ -58,7 +60,7 @@ export function startBrowser() {
 			options.addArguments( '--no-sandbox' );
 			builder = new webdriver.Builder();
 			builder.setChromeOptions( options );
-			global.__BROWSER__ = driver = builder.forBrowser( 'chrome' ).build();
+			global.__BROWSER__ = driver = builder.forBrowser( 'chrome' ).setLoggingPrefs( pref ).build();
 			break;
 		case 'firefox':
 			let profile = new firefox.Profile();
@@ -70,7 +72,7 @@ export function startBrowser() {
 			options.setProxy( this.getProxyType() );
 			builder = new webdriver.Builder();
 			builder.setFirefoxOptions( options );
-			global.__BROWSER__ = driver = builder.forBrowser( 'firefox' ).build();
+			global.__BROWSER__ = driver = builder.forBrowser( 'firefox' ).setLoggingPrefs( pref ).build();
 			break;
 		default:
 			throw new Error( `The specified browser: '${browser}' in the config is not supported. Supported browsers are 'chrome' and 'firefox'` );

--- a/lib/media-helper.js
+++ b/lib/media-helper.js
@@ -54,3 +54,20 @@ export function writeScreenshot( data, prefix, i18nScreenshot ) {
 
 	return screenshotPath;
 }
+
+export function writeTextLogFile( textContent, prefix ) {
+	if ( prefix === undefined ) {
+		prefix = '';
+	}
+	let directoryName = '../logs';
+	let logDir = path.resolve( __dirname, directoryName );
+	if ( ! fs.existsSync( logDir ) ) {
+		fs.mkdirSync( logDir );
+	}
+	let dateString = new Date().getTime().toString();
+	let fileName = `${dateString}-${prefix}-log.txt`;
+	let logPath = `${logDir}/${fileName}`;
+	fs.writeFileSync( logPath, textContent );
+
+	return logPath;
+}

--- a/lib/pages/accept-invite-page.js
+++ b/lib/pages/accept-invite-page.js
@@ -9,6 +9,7 @@ import * as MediaHelper from '../media-helper.js';
 export default class AcceptInvitePage extends BaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.invite-accept' ) );
+		driver.executeScript( `localStorage.setItem( 'debug', 'calypso:invite-accept:*' )` );
 	}
 
 	getEmailPreFilled() {

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -3,6 +3,7 @@ import test from 'selenium-webdriver/testing';
 
 import config from 'config';
 import * as driverManager from '../lib/driver-manager.js';
+import * as mediaHelper from '../lib/media-helper.js';
 
 import LoginFlow from '../lib/flows/login-flow.js';
 
@@ -143,6 +144,12 @@ test.describe( 'Invites: (' + screenSize + ')', function() {
 								this.noticesComponent = new NoticesComponent( driver );
 								this.noticesComponent.inviteMessageTitle().then( ( invitesMessageTitleDisplayed ) => {
 									assert.equal( true, invitesMessageTitleDisplayed.includes( 'Editor' ), `The invite message '${invitesMessageTitleDisplayed}' does not include 'Editor'` );
+								} );
+							} );
+
+							test.it( 'Capture browser logs', function() {
+								driver.manage().logs().get( 'browser' ).then( function( logs ) {
+									mediaHelper.writeTextLogFile( JSON.stringify( logs ), 'editor' );
 								} );
 							} );
 
@@ -302,6 +309,12 @@ test.describe( 'Invites: (' + screenSize + ')', function() {
 								this.readerPage = new ReaderPage( driver );
 							} );
 
+							test.it( 'Capture browser logs', function() {
+								driver.manage().logs().get( 'browser' ).then( function( logs ) {
+									mediaHelper.writeTextLogFile( JSON.stringify( logs ), 'follower' );
+								} );
+							} );
+
 							test.describe( 'As the original user, can see new user added to site', function() {
 								test.before( 'Log in as original user', function() {
 									driverManager.ensureNotLoggedIn( driver );
@@ -440,6 +453,12 @@ test.describe( 'Invites: (' + screenSize + ')', function() {
 
 							test.it( 'Can see the reader stream', function() {
 								this.readerPage = new ReaderPage( driver );
+							} );
+
+							test.it( 'Capture browser logs', function() {
+								driver.manage().logs().get( 'browser' ).then( function( logs ) {
+									mediaHelper.writeTextLogFile( JSON.stringify( logs ), 'viewer-private' );
+								} );
 							} );
 
 							test.it( 'Can visit and see the site', function() {
@@ -595,6 +614,12 @@ test.describe( 'Invites: (' + screenSize + ')', function() {
 								this.noticesComponent = new NoticesComponent( driver );
 								this.noticesComponent.inviteMessageTitle().then( ( invitesMessageTitleDisplayed ) => {
 									assert.equal( true, invitesMessageTitleDisplayed.includes( 'Contributor' ), `The invite message '${invitesMessageTitleDisplayed}' does not include 'Contributor'` );
+								} );
+							} );
+
+							test.it( 'Capture browser logs', function() {
+								driver.manage().logs().get( 'browser' ).then( function( logs ) {
+									mediaHelper.writeTextLogFile( JSON.stringify( logs ), 'contributor' );
 								} );
 							} );
 


### PR DESCRIPTION
This enables Calypso logs and captures them after the invite has been
accepted.

It also captures these logs on any test failure - to help us diagnose
what went wrong