### PR TITLE
Set higher timeout for notices component for invite acceptance

### DIFF
--- a/lib/components/notices-component.js
+++ b/lib/components/notices-component.js
@@ -6,7 +6,7 @@ import BaseContainer from '../base-container.js';
 
 export default class NoticesComponent extends BaseContainer {
 	constructor( driver ) {
-		const longExplicitWaitMS = config.get( 'explicitWaitMS' ) * 2;
+		const longExplicitWaitMS = config.get( 'explicitWaitMS' ) * 3;
 		const expectedElementSelector = By.css( '#notices' );
 		driver.wait( until.elementLocated( expectedElementSelector ), longExplicitWaitMS, `Could not locate the notices component after: ${longExplicitWaitMS}ms` );
 		super( driver, expectedElementSelector );


### PR DESCRIPTION
This is to cater for the slow behaviour shown in https://github.com/Automattic/wp-calypso/issues/5291