### PR TITLE
Added + sign to phone number for country code in domain signup

### DIFF
--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -43,7 +43,7 @@ test.describe( 'Managing Domains: (' + screenSize + ')', function() {
 		const expectedDomainName = blogName + '.com';
 		const firstName = 'End to End';
 		const lastName = 'Testing';
-		const phoneNumber = '0422888888';
+		const phoneNumber = '+0422888888';
 		const countryCode = 'AU';
 		const address = '888 Queen Street';
 		const city = 'Brisbane';


### PR DESCRIPTION
The API started returning an error without + at the start of the phone number string. r135650-wpcom