### PR TITLE
Add/email disable flag

### DIFF
--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -39,6 +39,10 @@ test.before( 'Start Browser', function() {
 	driver = driverManager.startBrowser();
 } );
 
+if ( process.env.DISABLE_EMAIL === 'true' ) {
+	test.describe = test.xdescribe;
+}
+
 test.describe( 'Invites: (' + screenSize + ')', function() {
 	this.timeout( mochaTimeOut );
 

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -39,11 +39,13 @@ test.before( 'Start Browser', function() {
 	driver = driverManager.startBrowser();
 } );
 
+// Faked out test.describe function to enable dynamic skipping of e-mail tests
+let testDescribe = test.describe;
 if ( process.env.DISABLE_EMAIL === 'true' ) {
-	test.describe = test.xdescribe;
+	testDescribe = test.xdescribe;
 }
 
-test.describe( 'Invites: (' + screenSize + ')', function() {
+testDescribe( 'Invites: (' + screenSize + ')', function() {
 	this.timeout( mochaTimeOut );
 
 	test.describe( 'Inviting New User as an Editor:', function() {

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -33,11 +33,13 @@ test.before( 'Start Browser', function() {
 	driver = driverManager.startBrowser();
 } );
 
+// Faked out test.describe function to enable dynamic skipping of e-mail tests
+let testDescribe = test.describe;
 if ( process.env.DISABLE_EMAIL === 'true' ) {
-	test.describe = test.xdescribe;
+	testDescribe = test.xdescribe;
 }
 
-test.describe( 'Sign Up (' + screenSize + ')', function() {
+testDescribe( 'Sign Up (' + screenSize + ')', function() {
 	this.timeout( mochaTimeOut );
 
 	test.describe( 'Sign up for a free site', function() {

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -33,6 +33,10 @@ test.before( 'Start Browser', function() {
 	driver = driverManager.startBrowser();
 } );
 
+if ( process.env.DISABLE_EMAIL === 'true' ) {
+	test.describe = test.xdescribe;
+}
+
 test.describe( 'Sign Up (' + screenSize + ')', function() {
 	this.timeout( mochaTimeOut );
 


### PR DESCRIPTION
New envvar DISABLE_EMAIL added.  Set to `true` to skip the invite and signup tests, in case the e-mail system is down.