### PR TITLE
Media: add upload tests for some basic filetypes

### DIFF
--- a/lib/media-helper.js
+++ b/lib/media-helper.js
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import webdriver from 'selenium-webdriver';
+import sanitize from 'sanitize-filename';
 
 export function createFile( notRandom ) {
 	let d = webdriver.promise.defer();
@@ -22,6 +23,27 @@ export function createFile( notRandom ) {
 	d.fulfill( {
 		imageName: newImageName,
 		fileName: newFileName,
+		file: newFile
+	} );
+
+	return d.promise;
+}
+
+export function createFileWithFilename( filename, skipNameCheck ) {
+
+	if ( ! skipNameCheck && sanitize( filename ) !== filename ) {
+		throw new Error( `Invalid filename given ${ filename }` );
+	}
+
+	const d = webdriver.promise.defer();
+	const originalFileName = 'image0.jpg';
+	const originalFile = path.resolve( __dirname, `../image-uploads/${originalFileName}` );
+	const newFile = path.resolve( __dirname, '../image-uploads/' + filename );
+	fs.copySync( originalFile, newFile );
+
+	d.fulfill( {
+		imageName: filename,
+		fileName: filename,
 		file: newFile
 	} );
 

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -3,11 +3,21 @@ import webdriver from 'selenium-webdriver';
 import config from 'config';
 
 import * as driverHelper from '../driver-helper.js';
+import { currentScreenSize } from '../driver-manager.js';
 
 const by = webdriver.By;
 const until = webdriver.until;
 
 import BaseContainer from '../base-container.js';
+const screenSize = currentScreenSize();
+
+const elementIsNotPresent = function( cssSelector ) {
+	return new until.Condition( 'for element to not be present', function( driver ) {
+		return driver.isElementPresent( by.css( cssSelector ) ).then( function( isPresent ) {
+			return ! isPresent;
+		} );
+	} );
+};
 
 export default class EditorPage extends BaseContainer {
 	constructor( driver ) {
@@ -45,6 +55,46 @@ export default class EditorPage extends BaseContainer {
 		this.driver.findElement( webdriver.By.id( 'tinymce' ) ).sendKeys( blogPostText );
 		this.driver.switchTo().defaultContent();
 	}
+
+	uploadMedia( fileDetails ) {
+		const driver = this.driver;
+		const newFile = fileDetails.file;
+		driverHelper.clickWhenClickable( driver, by.className( 'mce-media' ), this.explicitWaitMS );
+		driver.wait( until.elementLocated( by.className( 'media-library__upload-button' ) ), this.explicitWaitMS, 'Could not locate the media library upload button.' );
+		const fileNameInputSelector = webdriver.By.css( 'input[type="file"]' );
+		driver.findElement( fileNameInputSelector ).sendKeys( newFile );
+		driver.wait( elementIsNotPresent( '.media-library__list-item.is-transient' ), this.explicitWaitMS, 'Transient media is still present' );
+		driver.wait( elementIsNotPresent( '.media-library .notice.is-error' ), 500, 'Upload error message is present' );
+		driver.wait( until.elementLocated( by.css( '.media-library__list-item.is-selected' ) ), this.explicitWaitMS, 'Could not locate the newly uploaded item.' );
+	}
+
+	deleteMedia() {
+		const driver = this.driver;
+		let deleteSelector = webdriver.By.css( '.editor-media-modal__delete' );
+		if ( screenSize === 'mobile' ) {
+			const ellipsisSelector = webdriver.By.css( '.editor-media-modal__secondary-action.is-mobile' );
+			driver.wait( until.elementLocated( ellipsisSelector ), this.explicitWaitMS, 'Could not locate the ellipsis button' );
+			const ellipsisButton = driver.findElement( ellipsisSelector );
+			ellipsisButton.click();
+			deleteSelector = webdriver.By.xpath( "//button[contains(@class, 'popover__menu-item') and contains(text(), 'Delete' )]" );
+		}
+		driver.wait( until.elementLocated( deleteSelector ), this.explicitWaitMS, 'Could not locate the delete button in the media library' );
+		const deleteButton = driver.findElement( deleteSelector );
+		driver.wait( until.elementIsEnabled( deleteButton ), this.explicitWaitMS, 'The delete button is not enabled' );
+		deleteButton.click();
+		// Click on Accept Selector
+		const acceptSelector = by.css( '.accept-dialog + .dialog__action-buttons button.is-primary' );
+		driver.wait( until.elementLocated( acceptSelector ), this.explicitWaitMS, 'Could not locate the Ok button' );
+		driver.findElement( acceptSelector ).click();
+		driver.wait( elementIsNotPresent( '.media-library__list-item.is-selected' ), this.explicitWaitMS, 'Selected media is still present' );
+	}
+
+	dismissMediaModal() {
+		const driver = this.driver;
+		driver.findElement( by.css( '.editor-media-modal__secondary-actions + .button' ) ).click();
+		driver.wait( elementIsNotPresent( '.dialog__backdrop.is-full-screen' ), this.explicitWaitMS, 'Dialog is still present' );
+	}
+
 	enterPostImage( fileDetails ) {
 		let d = webdriver.promise.defer();
 		let driver = this.driver;
@@ -121,5 +171,13 @@ export default class EditorPage extends BaseContainer {
 	}
 	titleShown() {
 		return this.driver.findElement( by.css( '.editor-title__input' ) ).getAttribute( 'value' );
+	}
+
+	clickBackWithUnsavedChanges() {
+		const driver = this.driver;
+		const backButtonSelector = by.css( '.editor-sidebar__close' );
+		driver.wait( until.elementLocated( backButtonSelector ), this.explicitWaitMS, 'Could not locate the back button' );
+		driver.findElement( backButtonSelector ).click();
+		driver.switchTo().alert().accept();
 	}
 }

--- a/package.json
+++ b/package.json
@@ -25,12 +25,13 @@
     "esformatter-special-bangs": "^1.0.1",
     "eyes.selenium": "0.0.41",
     "fs-extra": "0.22.1",
-	"mailosaur": "^3.0.0",
+    "junit-viewer": "4.9.6",
+    "mailosaur": "^3.0.0",
     "node-slack-upload": "1.0.4",
     "random-qoutes-generator": "0.0.1",
+    "sanitize-filename": "1.6.0",
     "selenium-webdriver": "2.47.0",
-    "slack-notify": "0.1.4",
-    "junit-viewer": "4.9.6"
+    "slack-notify": "0.1.4"
   },
   "devDependencies": {
     "eslint": "<2.3.0",

--- a/specs/wp-media-upload-spec.js
+++ b/specs/wp-media-upload-spec.js
@@ -1,0 +1,119 @@
+import assert from 'assert';
+import test from 'selenium-webdriver/testing';
+import config from 'config';
+
+import LoginFlow from '../lib/flows/login-flow.js';
+
+import EditorPage from '../lib/pages/editor-page.js';
+
+import * as driverManager from '../lib/driver-manager.js';
+import * as mediaHelper from '../lib/media-helper.js';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+
+var driver;
+
+test.before( 'Start Browser', function() {
+	this.timeout( startBrowserTimeoutMS );
+	driver = driverManager.startBrowser();
+} );
+
+test.describe( 'Editor: Media Upload (' + screenSize + ')', function() {
+	this.timeout( mochaTimeOut );
+
+	test.describe( 'Image Upload:', function() {
+		this.bailSuite( true );
+		let editorPage;
+
+		test.before( 'Delete Cookies and Local Storage', function() {
+			driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		} );
+
+		test.describe( 'Can upload many media types', () => {
+
+			test.before( 'Can log in and navigate to Editor page', () => {
+				const loginFlow = new LoginFlow( driver );
+				loginFlow.loginAndStartNewPage();
+				editorPage = new EditorPage( driver );
+			} );
+
+			test.describe( 'Can upload a normal image', function() {
+				let fileDetails;
+
+				test.before( 'Create image file for upload', function() {
+					mediaHelper.createFileWithFilename( 'normal.jpg' ).then( function( details ) {
+						fileDetails = details;
+					} );
+				} );
+
+				test.it( 'Can upload an image', function() {
+					editorPage.uploadMedia( fileDetails );
+				} );
+
+				test.it( 'Can delete image', function() {
+					editorPage.deleteMedia();
+				} );
+
+				test.after( function() {
+					editorPage.dismissMediaModal();
+					if ( fileDetails ) {
+						mediaHelper.deleteFile( fileDetails ).then( function() {} );
+					}
+				} );
+
+			} );
+
+			test.describe( 'Can upload an image with reserved url chars in the filename', function() {
+				let fileDetails;
+
+				test.before( 'Create image file for upload', function() {
+					mediaHelper.createFileWithFilename( 'filewith#?#?reservedurlchars.jpg', true ).then( function( details ) {
+						fileDetails = details;
+					} );
+				} );
+
+				test.it( 'Can upload an image', function() {
+					editorPage.uploadMedia( fileDetails );
+				} );
+
+				test.it( 'Can delete image', function() {
+					editorPage.deleteMedia();
+				} );
+
+				test.after( function() {
+					editorPage.dismissMediaModal();
+					if ( fileDetails ) {
+						mediaHelper.deleteFile( fileDetails ).then( function() {} );
+					}
+				} );
+			} );
+
+			test.describe( 'Can upload an mp3', function() {
+				let fileDetails;
+
+				test.before( 'Create mp3 for upload', function() {
+					mediaHelper.createFileWithFilename( 'fake.mp3' ).then( function( details ) {
+						fileDetails = details;
+					} );
+				} );
+
+				test.it( 'Can upload an mp3', function() {
+					editorPage.uploadMedia( fileDetails );
+				} );
+
+				test.it( 'Can delete mp3', function() {
+					editorPage.deleteMedia();
+				} );
+
+				test.after( function() {
+					editorPage.dismissMediaModal();
+					if ( fileDetails ) {
+						mediaHelper.deleteFile( fileDetails ).then( function() {} );
+					}
+				} );
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
I'm adding a few cases for Editor image upload. We has some recent regressions and some e2e tests could help us catch these more quickly.

Questions:
- ~~Should I sanitize the filenames in `createFileWithFilename`, or just remind folks to use it cautiously?~~
- ~~Would you prefer that I add test cleanup to delete the uploaded files Calypso. Without them we'll eventually run out of media storage space for our test account.~~

cc @alisterscott @hoverduck @aduth 