### PR TITLE
Temporarily disable all sites theme test since this is broken

### DIFF
--- a/specs/wp-theme-multisite-spec.js
+++ b/specs/wp-theme-multisite-spec.js
@@ -25,7 +25,7 @@ test.before( function() {
 	this.driver = driverManager.startBrowser();
 } );
 
-test.describe( 'Themes: All sites (' + screenSize + ')', function() {
+test.xdescribe( 'Themes: All sites (' + screenSize + ')', function() {
 
 	test.describe( 'Preview a theme', function() {
 		this.bailSuite( true );


### PR DESCRIPTION
See issue: https://github.com/Automattic/wp-calypso/issues/5804