### PR TITLE
Plans: update page helpers

### DIFF
--- a/lib/pages/signup/pick-a-plan-page.js
+++ b/lib/pages/signup/pick-a-plan-page.js
@@ -3,7 +3,9 @@ import { By, until } from 'selenium-webdriver';
 import BaseContainer from '../../base-container.js';
 
 import * as driverHelper from '../../driver-helper.js';
-import * as driverManager from '../../driver-manager.js';
+import { currentScreenSize } from '../../driver-manager.js';
+
+const screenSize = currentScreenSize();
 
 export default class PickAPlanPage extends BaseContainer {
 	constructor( driver ) {
@@ -13,15 +15,19 @@ export default class PickAPlanPage extends BaseContainer {
 		const freePlanHeaderSelector = By.css( '.free_plan .plan-header__title' );
 		const freePlanButtonSelector = By.css( '.free_plan button' );
 		driverHelper.clickWhenClickable( this.driver, freePlanHeaderSelector, this.explicitWaitMS );
-		this.waitForPlanButton( freePlanButtonSelector );
-		return driverHelper.clickWhenClickable( this.driver, freePlanButtonSelector, this.explicitWaitMS );
+		if ( screenSize === 'mobile' ) {
+			this.waitForPlanButton( freePlanButtonSelector );
+			return driverHelper.clickWhenClickable( this.driver, freePlanButtonSelector, this.explicitWaitMS );
+		}
 	}
 	selectPremiumPlan() {
 		const premiumPlanHeaderSelector = By.css( 'div.value_bundle .plan-header__title' );
 		const premiumPlanButtonSelector = By.css( 'div.value_bundle button' );
 		driverHelper.clickWhenClickable( this.driver, premiumPlanHeaderSelector, this.explicitWaitMS );
-		this.waitForPlanButton( premiumPlanButtonSelector );
-		return driverHelper.clickWhenClickable( this.driver, premiumPlanButtonSelector, this.explicitWaitMS );
+		if ( screenSize === 'mobile' ) {
+			this.waitForPlanButton( premiumPlanButtonSelector );
+			return driverHelper.clickWhenClickable( this.driver, premiumPlanButtonSelector, this.explicitWaitMS );
+		}
 	}
 	compare() {
 		return driverHelper.clickWhenClickable( this.driver, By.css( 'a.plans-step__compare-plans-link' ), this.explicitWaitMS );


### PR DESCRIPTION
After fixing issue https://github.com/Automattic/wp-calypso/issues/4486, in desktop view we now select a plan immediately if we click in the following areas
![ddd5f55e-f827-11e5-8081-fcf7cf89beb5](https://cloud.githubusercontent.com/assets/1270189/15868703/d6fefc80-2c9d-11e6-9598-dc774f9d025d.png)

This PR updates the helpers to only wait for the plan button when we detect that we are in mobile view. This had been previously timing out tests.
<img width="586" alt="screen shot 2016-06-07 at 10 53 16 am" src="https://cloud.githubusercontent.com/assets/1270189/15868773/1f201fd0-2c9e-11e6-993e-d7faed903ea7.png">

cc @alisterscott @hoverduck 

