### PR TITLE
After a failed test, check for the existence of the 'navigate away' dialog and get rid of it

### DIFF
--- a/lib/after.js
+++ b/lib/after.js
@@ -62,6 +62,19 @@ test.afterEach( 'Take Screenshot', function() {
 	}
 } );
 
+test.afterEach( '', function() {
+	this.timeout( afterHookTimeoutMS );
+	const driver = global.__BROWSER__;
+
+	if ( this.currentTest.state === 'failed' ) {
+		driver.get( 'data:,' );
+
+		driver.switchTo().alert().then( function( alert ) {
+			alert.accept();
+		}, function( error ) { } );
+	}
+} );
+
 test.afterEach( 'Capture Logs on Failure', function() {
 	this.timeout( afterHookTimeoutMS );
 	const driver = global.__BROWSER__;


### PR DESCRIPTION
This stops subsequent tests failing with:

`unexpected alert open`

<img width="821" alt="unexpected alert" src="https://cloud.githubusercontent.com/assets/128826/15954800/a29ff614-2f1e-11e6-9c96-b1a6bade517a.png">

