### PR TITLE
Add screenshot when editor page fails to initially load

### DIFF
--- a/lib/base-container.js
+++ b/lib/base-container.js
@@ -22,7 +22,9 @@ export default class BaseContainer {
 	}
 
 	takeScreenShot( screenName = '' ) {
+		console.log( 'taking screenshot in base 1' );
 		if ( config.get( 'saveAllScreenshots' ) === true ) {
+			console.log( 'taking screenshot in base 2' );
 			const prefix = ( screenName !== '' ) ? `BaseContainer-${this.screenSize}-` : `${screenName}-${this.screenSize}-`;
 			try {
 				return this.driver.takeScreenshot().then( ( data ) => {

--- a/lib/base-container.js
+++ b/lib/base-container.js
@@ -22,10 +22,8 @@ export default class BaseContainer {
 	}
 
 	takeScreenShot( screenName = '' ) {
-		console.log( 'taking screenshot in base 1' );
 		if ( config.get( 'saveAllScreenshots' ) === true ) {
-			console.log( 'taking screenshot in base 2' );
-			const prefix = ( screenName !== '' ) ? `BaseContainer-${this.screenSize}-` : `${screenName}-${this.screenSize}-`;
+			const prefix = ( screenName === '' ) ? `BaseContainer-${this.screenSize}-` : `${screenName}-${this.screenSize}-`;
 			try {
 				return this.driver.takeScreenshot().then( ( data ) => {
 					mediaHelper.writeScreenshot( data, prefix );

--- a/lib/base-container.js
+++ b/lib/base-container.js
@@ -21,9 +21,9 @@ export default class BaseContainer {
 		this.checkForUnknownABTestKeys();
 	}
 
-	takeScreenShot() {
+	takeScreenShot( screenName = '' ) {
 		if ( config.get( 'saveAllScreenshots' ) === true ) {
-			const prefix = `BASE-CONTAINER-${this.screenSize}`;
+			const prefix = ( screenName !== '' ) ? `BaseContainer-${this.screenSize}-` : `${screenName}-${this.screenSize}-`;
 			try {
 				return this.driver.takeScreenshot().then( ( data ) => {
 					mediaHelper.writeScreenshot( data, prefix );

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -52,6 +52,7 @@ export default class EditorPage extends BaseContainer {
 	}
 	ensureEditorShown() {
 		const driver = this.driver;
+		const self = this;
 		driver.wait( until.elementLocated( this.editorFrameName ), this.explicitWaitMS * 2 ).then( function() { }, function( error ) {
 			const message = `Found issue on editor iFrame: '${error}' for '${driverManager.currentScreenSize()}' browser - Refreshing the browser to see if this works.`;
 			console.log( message );
@@ -63,7 +64,7 @@ export default class EditorPage extends BaseContainer {
 					username: 'WebDriverJS'
 				} );
 			}
-			this.takeScreenShot( 'EditorPageFailed' );
+			self.takeScreenShot( 'EditorPageFailed' );
 			return driver.navigate().refresh();
 		} );
 	}

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -64,7 +64,6 @@ export default class EditorPage extends BaseContainer {
 					username: 'WebDriverJS'
 				} );
 			}
-			console.log( 'taking screenshot of editor page' );
 			self.takeScreenShot( 'EditorPageFailed' );
 			return driver.navigate().refresh();
 		} );

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -64,6 +64,7 @@ export default class EditorPage extends BaseContainer {
 					username: 'WebDriverJS'
 				} );
 			}
+			console.log( 'taking screenshot of editor page' );
 			self.takeScreenShot( 'EditorPageFailed' );
 			return driver.navigate().refresh();
 		} );

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -4,6 +4,7 @@ import slack from 'slack-notify';
 import config from 'config';
 
 import * as driverHelper from '../driver-helper.js';
+import * as driverManager from '../driver-manager.js';
 import { currentScreenSize } from '../driver-manager.js';
 
 const by = webdriver.By;
@@ -52,7 +53,7 @@ export default class EditorPage extends BaseContainer {
 	ensureEditorShown() {
 		const driver = this.driver;
 		driver.wait( until.elementLocated( this.editorFrameName ), this.explicitWaitMS * 2 ).then( function() { }, function( error ) {
-			const message = `Found issue on editor iFrame: '${error}' - Refreshing the browser to see if this works.`;
+			const message = `Found issue on editor iFrame: '${error}' for '${driverManager.currentScreenSize()}' browser - Refreshing the browser to see if this works.`;
 			console.log( message );
 			if ( config.has( 'slackHook' ) ) {
 				let slackClient = slack( config.get( 'slackHook' ) );
@@ -62,6 +63,7 @@ export default class EditorPage extends BaseContainer {
 					username: 'WebDriverJS'
 				} );
 			}
+			this.takeScreenShot( 'EditorPageFailed' );
 			return driver.navigate().refresh();
 		} );
 	}

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -24,7 +24,7 @@ const elementIsNotPresent = function( cssSelector ) {
 export default class EditorPage extends BaseContainer {
 	constructor( driver ) {
 		super( driver, by.css( '.post-editor' ) );
-		this.editorFrameName = by.css( '#tinymce-1_ifr' );
+		this.editorFrameName = by.css( '.mce-edit-area iframe' );
 		this.saveSelector = by.css( 'button.editor-ground-control__save' );
 
 		if ( config.get( 'useNewMobileEditor' ) === true ) {


### PR DESCRIPTION
This is because this `Found issue on editor iFrame: 'Error: Waiting for element to be located By.cssSelector("#tinymce-1_ifr")` is happening a lot.
I have realized the editor id changes between page loads, so I've updated it to handle this. 