### PR TITLE
Added publish step before trashing post

### DIFF
--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -648,6 +648,12 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 				editorPage.enterContent( blogPostQuote );
 			} );
 
+			// Shouldn't need to publish first, but putting in temporarily to workaround Trac bug #7753
+			test.it( 'Can publish post', function() {
+				let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+				postEditorSidebarComponent.publishPost();
+			} );
+
 			test.it( 'Can trash the new post', function() {
 				const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 				postEditorSidebarComponent.ensureSaved();


### PR DESCRIPTION
The "Trash Post" spec will now publish before deleting the post, as deleting a draft is taking 15-25 seconds instead of the 3-5 it takes to delete a published one.  We should revert this if/when it's fixed on the backend. 

Ref 7753-wpcom