### PR TITLE
Try higher timeouts for live branches

### DIFF
--- a/config/live-branches.json
+++ b/config/live-branches.json
@@ -1,0 +1,9 @@
+{
+  "calypsoBaseURL": "https://calypso.live",
+  "explicitWaitMS": 40000,
+  "mochaTimeoutMS": 320000,
+  "mochaVisDiffTimeoutMS": 640000,
+  "mochaDevDocsTimeoutMS": 750000,
+  "browser": "chrome",
+  "saveAllScreenshots": true
+}

--- a/lib/base-container.js
+++ b/lib/base-container.js
@@ -12,6 +12,7 @@ export default class BaseContainer {
 	constructor( driver, expectedElementSelector, visit = false, url = null ) {
 		this.screenSize = driverManager.currentScreenSize().toUpperCase();
 		this.explicitWaitMS = config.get( 'explicitWaitMS' );
+console.log( `explicitWaitMS = ${this.explicitWaitMS}` );
 		this.driver = driver;
 		this.expectedElementSelector = expectedElementSelector;
 		this.url = url;

--- a/lib/base-container.js
+++ b/lib/base-container.js
@@ -12,7 +12,6 @@ export default class BaseContainer {
 	constructor( driver, expectedElementSelector, visit = false, url = null ) {
 		this.screenSize = driverManager.currentScreenSize().toUpperCase();
 		this.explicitWaitMS = config.get( 'explicitWaitMS' );
-console.log( `explicitWaitMS = ${this.explicitWaitMS}` );
 		this.driver = driver;
 		this.expectedElementSelector = expectedElementSelector;
 		this.url = url;

--- a/run-wrapper.sh
+++ b/run-wrapper.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ "$NODE_ENV_OVERRIDE" != "" ]; then
+  NODE_ENV=$NODE_ENV_OVERRIDE
+fi
+
 export TESTARGS="-R -p"
 
 if [ "$RUN_SPECIFIED" == "true" ]; then

--- a/trigger-circle-ci-live-branch.sh
+++ b/trigger-circle-ci-live-branch.sh
@@ -14,6 +14,7 @@ post_data=$(cat <<EOF
     "RUN_SPECIFIED": "true",
     "RUN_ARGS": "${_run_args}",
     "liveBranches": "true",
+    "NODE_ENV": "live-branches",
     "branchName": "${_calypso_branch}"
   }
 }

--- a/trigger-circle-ci-live-branch.sh
+++ b/trigger-circle-ci-live-branch.sh
@@ -14,7 +14,7 @@ post_data=$(cat <<EOF
     "RUN_SPECIFIED": "true",
     "RUN_ARGS": "${_run_args}",
     "liveBranches": "true",
-    "NODE_ENV": "live-branches",
+    "NODE_ENV_OVERRIDE": "live-branches",
     "branchName": "${_calypso_branch}"
   }
 }


### PR DESCRIPTION
@alisterscott with this I've enabled a build_parameter to override the NODE_ENV variable to 'live-branches' to give the tests a higher timeout value.  I ran it against https://calypso.live?branch=master and it ran fine (a couple of failures on the themes test, but nothing unique to this).

You did most of the test runs while getting the live branch code working on our end...do you think most of the failures you were seeing would be solved by higher timeouts like this, or is there a more fundamental stability issue on the calypso.live backend?