### PR TITLE
Drop mocha git submodule, use package json instead

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "mocha"]
-	path = mocha
-	url = git@github.com:hoverduck/mocha.git

--- a/README.md
+++ b/README.md
@@ -13,12 +13,6 @@ Automated end-to-end acceptance tests for the [wp-calypso](https://github.com/Au
 brew install node-js chromedriver
 ```
 
-#### Setup Mocha
-```
-git submodule init
-git submodule update
-```
-
 #### Install dependencies
 ```
 npm install
@@ -32,7 +26,7 @@ npm install ./spec-xunit-slack-reporter-0.0.1.tgz
 
 #### To run an individual spec
 
-`./mocha/bin/mocha specs/wp-log-in-out-spec.js lib/after.js`
+`./node_modules/mocha/bin/mocha specs/wp-log-in-out-spec.js lib/after.js`
 
 Note: you can also change the spec _temporarily_ the use the <code>.only</code> syntax so it is the only spec that runs (making sure this isn't committed)
 

--- a/circle.yml
+++ b/circle.yml
@@ -7,11 +7,6 @@ general:
     - "screenshots"
     - "logs"
 
-checkout:
-  post:
-    - git submodule sync
-    - git submodule update --init
-
 dependencies:
   pre:
     - npm pack lib/reporter

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "fs-extra": "0.22.1",
     "junit-viewer": "4.9.6",
     "mailosaur": "^3.0.0",
+    "mocha": "hoverduck/mocha#4127778",
     "node-slack-upload": "1.0.4",
     "random-qoutes-generator": "0.0.1",
     "sanitize-filename": "1.6.0",

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-MOCHA=./mocha/bin/mocha
+MOCHA=./node_modules/mocha/bin/mocha
 REPORTER=""
 PARALLEL=0
 JOBS=0


### PR DESCRIPTION
I screwed up the rebase on #24, so this is the simplified version of the same change.

Now we're still pulling mocha from my personal fork to enable the bailSuite() functionality I added, but it's done via package.json and npm instead of a git submodule.  This reduces the setup complexity to get the project running locally.