### PR TITLE
Added ThemeDetailPage object, updated theme switch spec

### DIFF
--- a/lib/pages/theme-detail-page.js
+++ b/lib/pages/theme-detail-page.js
@@ -1,0 +1,30 @@
+var webdriver = require( 'selenium-webdriver' );
+var config = require( 'config' );
+var until = webdriver.until;
+var by = webdriver.By;
+var driverHelper = require( '../driver-helper.js' );
+
+function ThemeDetailPage( driver ) {
+	this.driver = driver;
+	this.explicitWaitMS = config.get( 'explicitWaitMS' );
+
+	var pickDesignSelector = webdriver.By.css( 'button.themes__sheet-primary-button' );
+	this.pickDesignSelector = pickDesignSelector;
+
+	var liveDemoSelector = webdriver.By.css( 'a.themes__sheet-preview-link' );
+	this.liveDemoSelector = liveDemoSelector;
+
+	var mainSheetSelector = webdriver.By.css( '.themes__sheet.main' );
+
+	this.driver.wait( until.elementsLocated( mainSheetSelector ), this.explicitWaitMS, 'Theme details page not displayed.' );
+}
+
+ThemeDetailPage.prototype.pickDesign = function() {
+	return driverHelper.clickWhenClickable( this.driver, this.pickDesignSelector );
+};
+
+ThemeDetailPage.prototype.openLiveDemo = function() {
+	return driverHelper.clickWhenClickable( this.driver, this.liveDemoSelector );
+};
+
+module.exports = ThemeDetailPage;

--- a/specs/wp-theme-switch-spec.js
+++ b/specs/wp-theme-switch-spec.js
@@ -8,6 +8,7 @@ import LoginFlow from '../lib/flows/login-flow.js';
 
 import ThemesPage from '../lib/pages/themes-page.js';
 import ThemePreviewPage from '../lib/pages/theme-preview-page.js';
+import ThemeDetailPage from '../lib/pages/theme-detail-page.js';
 import CustomizerPage from '../lib/pages/customizer-page.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
@@ -38,6 +39,11 @@ test.describe( 'Themes: (' + screenSize + ')', function() {
 				this.themesPage.searchFor( 'Twenty F' );
 				this.themesPage.waitForThemeStartingWith( 'Twenty F' );
 				return this.themesPage.selectNewThemeStartingWith( 'Twenty F' );
+			} );
+
+			test.it( 'Can see theme Details page, open Preview/Live Demo', function() {
+				this.themeDetailPage = new ThemeDetailPage( driver );
+				return this.themeDetailPage.openLiveDemo();
 			} );
 
 			test.it( 'Can preview, customize and save theme', function() {


### PR DESCRIPTION
The default action when clicking on a theme card on the /design page has changed.  This PR adds an extra step to the theme switch spec to go through the new page.