### PR TITLE
Add Slack ping for skipped tests

### DIFF
--- a/lib/slack-ping-cli.js
+++ b/lib/slack-ping-cli.js
@@ -1,0 +1,7 @@
+import * as slackNotifier from './slack-notifier';
+
+if ( process.argv.length !== 3 ) {
+	console.log( `Usage: babel-node --presets es2015 ${process.argv[1]}` );
+} else {
+	slackNotifier.warn( process.argv[2] );
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "eslint": "<2.3.0",
+    "babel-cli": "^6.10.1",
     "babel-eslint": "^5.0.0-beta6",
     "babel-plugin-add-module-exports": "^0.1.2",
     "babel-plugin-syntax-export-extensions": "^6.3.13",

--- a/run-wrapper.sh
+++ b/run-wrapper.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Notify Slack if any tests are being skipped
+if [ "$SKIP_TEST_REGEX" != "" ]; then
+  babel-node --presets es2015 lib/slack-ping-cli.js "Attention! Tests are being skipped with pattern $SKIP_TEST_REGEX"
+fi
+if [ "$RUN_VISDIFF" != "true" ]; then
+  babel-node --presets es2015 lib/slack-ping-cli.js "Attention! Visual Diff tests are currently disabled!"
+fi
+
 if [ "$NODE_ENV_OVERRIDE" != "" ]; then
   NODE_ENV=$NODE_ENV_OVERRIDE
 fi

--- a/run-wrapper.sh
+++ b/run-wrapper.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
-# Notify Slack if any tests are being skipped
-if [ "$SKIP_TEST_REGEX" != "" ]; then
-  babel-node --presets es2015 lib/slack-ping-cli.js "Attention! Tests are being skipped with pattern [$SKIP_TEST_REGEX]"
-fi
-if [ "$RUN_VISDIFF" != "true" ]; then
-  babel-node --presets es2015 lib/slack-ping-cli.js "Attention! Visual Diff tests are currently disabled!"
+# Notify Slack if any tests are being skipped -- Only runs on Node 0 so you just get one ping
+# -- Note that since this is called before run.sh the BROWSERSIZE variable is not yet set and 
+#    it will always say "screen size 'desktop'"
+if [ "$CIRCLE_NODE_INDEX" == "0" ]; then
+  if [ "$SKIP_TEST_REGEX" != "" ]; then
+    babel-node --presets es2015 lib/slack-ping-cli.js "Attention! Tests are being skipped with pattern [$SKIP_TEST_REGEX]"
+  fi
+  if [ "$RUN_VISDIFF" != "true" ]; then
+    babel-node --presets es2015 lib/slack-ping-cli.js "Attention! Visual Diff tests are currently disabled!"
+  fi
 fi
 
 if [ "$NODE_ENV_OVERRIDE" != "" ]; then

--- a/run-wrapper.sh
+++ b/run-wrapper.sh
@@ -2,7 +2,7 @@
 
 # Notify Slack if any tests are being skipped
 if [ "$SKIP_TEST_REGEX" != "" ]; then
-  babel-node --presets es2015 lib/slack-ping-cli.js "Attention! Tests are being skipped with pattern $SKIP_TEST_REGEX"
+  babel-node --presets es2015 lib/slack-ping-cli.js "Attention! Tests are being skipped with pattern [$SKIP_TEST_REGEX]"
 fi
 if [ "$RUN_VISDIFF" != "true" ]; then
   babel-node --presets es2015 lib/slack-ping-cli.js "Attention! Visual Diff tests are currently disabled!"


### PR DESCRIPTION
@alisterscott 👀 if you don't mind.  I'm open to alternate implementations if you've got another idea.

This will alert us if any tests are being skipped so nothing slips through the cracks.