### PR TITLE
Removed sleep statements from ThemesPage [skip ci]

### DIFF
--- a/lib/pages/themes-page.js
+++ b/lib/pages/themes-page.js
@@ -16,19 +16,16 @@ export default class ThemesPage extends BaseContainer {
 		const mobileSelector = by.className( 'section-nav__mobile-header' );
 		const mobileFreeSelector = by.xpath( `//span[text()='Free']/..` );
 
-		// Need to sleep to allow all themes to load before clicking the dropdown, or it closes itself
-		driver.sleep( 5000 ).then( function() {
-			driver.isElementPresent( desktopSelector ).then( function( present ) {
-				if ( present ) {
-					driverHelper.clickWhenClickable( driver, desktopSelector, explicitWaitMS );
-					driverHelper.clickWhenClickable( driver, desktopFreeSelector, explicitWaitMS );
-				} else {
-					driverHelper.clickWhenClickable( driver, mobileSelector, explicitWaitMS );
-					driverHelper.clickWhenClickable( driver, mobileFreeSelector, explicitWaitMS );
-				}
-			} );
-			d.fulfill( true );
+		driver.isElementPresent( desktopSelector ).then( function( present ) {
+			if ( present ) {
+				driverHelper.clickWhenClickable( driver, desktopSelector, explicitWaitMS );
+				driverHelper.clickWhenClickable( driver, desktopFreeSelector, explicitWaitMS );
+			} else {
+				driverHelper.clickWhenClickable( driver, mobileSelector, explicitWaitMS );
+				driverHelper.clickWhenClickable( driver, mobileFreeSelector, explicitWaitMS );
+			}
 		} );
+		d.fulfill( true );
 
 		return d.promise;
 	}
@@ -48,10 +45,7 @@ export default class ThemesPage extends BaseContainer {
 	}
 
 	clickNewThemeMoreButton() {
-		const self = this;
-		return self.driver.sleep( 5000 ).then( function() {
-			return driverHelper.clickWhenClickable( self.driver, by.css( '.is-actionable:not(.is-active) button' ) );
-		} );
+		return driverHelper.clickWhenClickable( this.driver, by.css( '.is-actionable:not(.is-active) button' ) );
 	}
 
 	clickNewThemeActivateButton() {
@@ -59,13 +53,10 @@ export default class ThemesPage extends BaseContainer {
 	}
 
 	getFirstThemeName() {
-		const self = this;
 		const selector = by.css( '.is-actionable:not(.is-active) h2' );
 
-		return self.driver.sleep( 2000 ).then( function() {
-			self.driver.wait( until.elementLocated( selector ), self.explicitWaitMS, 'Could not locate the first theme element' );
-			return self.driver.findElement( selector ).getText();
-		} );
+		this.driver.wait( until.elementLocated( selector ), this.explicitWaitMS, 'Could not locate the first theme element' );
+		return this.driver.findElement( selector ).getText();
 	}
 
 	getActiveThemeName() {


### PR DESCRIPTION
The sleeps are no longer necessary, thanks to this fix - https://github.com/Automattic/wp-calypso/pull/6435