### PR TITLE
Removed grabLogs() from Slack reporter

### DIFF
--- a/lib/reporter/lib/spec-xunit-slack-reporter.js
+++ b/lib/reporter/lib/spec-xunit-slack-reporter.js
@@ -24,17 +24,6 @@ var reportName = reportDir + '/xunit_' + new Date().getTime().toString() + '.xml
 
 exports = module.exports = SpecXUnitSlack;
 
-function grabLogs( test ) {
-	var driver = global.__BROWSER__;
-	var shortTestFileName = test.title.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
-
-	driver.manage().logs().get( 'browser' ).then( function( logs ) {
-		if ( logs.length > 0 ) {
-			fs.writeFile( reportDir + '/' + process.env.BROWSERSIZE + '_' + shortTestFileName + '.json', JSON.stringify( logs ) );
-		}
-	} );
-}
-
 /**
  * Initialize a new `SpecXUnitSlack` test reporter.
  *
@@ -46,16 +35,11 @@ function SpecXUnitSlack( runner ) {
 	XUnit.call( this, runner, { reporterOptions: { output: reportName } } );
 
 	if ( config.has( 'slackHook' ) && process.env.CIRCLE_BRANCH === 'master' ) {
-		runner.on( 'pass', function( test ) {
-			grabLogs( test );
-		} );
-
 		// Slack notification
 		runner.on( 'fail', function( test, err ) {
 			var slackClient = slack( config.get( 'slackHook' ) );
 
 			var fieldsObj = { Error: err.message };
-			grabLogs( test );
 			if ( process.env.DEPLOY_USER ) {
 				fieldsObj['Git Diff'] = '<https://github.com/Automattic/wp-calypso/compare/' + process.env.PROD_REVISION + '...' + process.env.TO_DEPLOY_REVISION + '|Compare Commits>';
 				fieldsObj.Author = process.env.DEPLOY_USER;


### PR DESCRIPTION
The alternative solution in lib/after.js is preferable, and this one was breaking the IE11 tests on Sauce Labs (since they don't recognize the `logs` call, which I'll troubleshoot later)