### PR TITLE
Update tests to always use 'original' plan features

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -56,5 +56,5 @@
         "version": "11.103"
     }
   },
-  "knownABTestKeys": [ "multiDomainRegistrationV1", "translatorInvitation", "freeTrialsInSignup", "freeTrialNudgeOnThankYouPage", "privacyCheckbox", "domainSuggestionVendor", "guidedTours", "domainCreditsInfoNotice", "domainsWithPlansOnly", "wordadsInstantActivation", "googleVouchers", "personalPlan", "wordpressAdCredits", "verticalThemes", "signupStore", "coldStartReader", "browserNotifications", "skipPlansLinkForFree" ]
+  "knownABTestKeys": [ "multiDomainRegistrationV1", "translatorInvitation", "freeTrialsInSignup", "freeTrialNudgeOnThankYouPage", "privacyCheckbox", "domainSuggestionVendor", "guidedTours", "domainCreditsInfoNotice", "domainsWithPlansOnly", "wordadsInstantActivation", "googleVouchers", "personalPlan", "wordpressAdCredits", "verticalThemes", "signupStore", "coldStartReader", "browserNotifications", "skipPlansLinkForFree", "planFeatures" ]
 }

--- a/lib/base-container.js
+++ b/lib/base-container.js
@@ -92,8 +92,10 @@ export default class BaseContainer {
 		const browserNotificationsValue = 'disabled';
 		const skipFreePlansKey = 'skipPlansLinkForFree_20160711';
 		const skipFreePlansValue = 'showFreePlan';
+		const planFeaturesKey = 'planFeatures_20160720';
+		const planFeaturesValue = 'original';
 
-		const expectedABTestValue = `{"${privacyCheckBoxKey}":"${privacyCheckBoxValue}","${freeTrialsSignupKey }":"${freeTrialsSignupValue}","${domainsWithPlanKey}":"${domainsWithPlanValue}","${guidedToursKey}":"${guidedToursValue}","${domainCreditsKey}":"${domainCreditsValue}","${domainSuggestionVendorKey}":"${domainSuggestionVendorValue}","${googleVoucherKey}":"${googleVoucherValue}","${personalPlanKey}":"${personalPlanValue}","${signupStoreKey}":"${signupStoreValue}","${browserNotificationsKey}":"${browserNotificationsValue}","${skipFreePlansKey}":"${skipFreePlansValue}"}`;
+		const expectedABTestValue = `{"${privacyCheckBoxKey}":"${privacyCheckBoxValue}","${freeTrialsSignupKey }":"${freeTrialsSignupValue}","${domainsWithPlanKey}":"${domainsWithPlanValue}","${guidedToursKey}":"${guidedToursValue}","${domainCreditsKey}":"${domainCreditsValue}","${domainSuggestionVendorKey}":"${domainSuggestionVendorValue}","${googleVoucherKey}":"${googleVoucherValue}","${personalPlanKey}":"${personalPlanValue}","${signupStoreKey}":"${signupStoreValue}","${browserNotificationsKey}":"${browserNotificationsValue}","${skipFreePlansKey}":"${skipFreePlansValue}","${planFeaturesKey}":"${planFeaturesValue}"}`;
 
 		this.driver.executeScript( `window.localStorage.setItem('ABTests','${expectedABTestValue}');` );
 


### PR DESCRIPTION
Change introduced here:
https://github.com/Automattic/wp-calypso/pull/6935

Will update e2e tests to use new features page once AB test has been
successful