### PR TITLE
Removed the /type level from the themes filter URL

### DIFF
--- a/lib/pages/themes-page.js
+++ b/lib/pages/themes-page.js
@@ -10,19 +10,15 @@ export default class ThemesPage extends BaseContainer {
 	showOnlyFreeThemes() {
 		const self = this;
 		return self.driver.getCurrentUrl().then( ( url ) => {
-			if ( url.indexOf( '/design/type/free' ) > -1 ) {
+			if ( url.indexOf( '/design/free' ) > -1 ) {
 				return true;
 			}
-			if ( url.indexOf( '/design/type/all' ) > -1 ) {
-				const newUrl = url.replace( '/design/type/all', '/design/type/free' );
-				return self.driver.get( newUrl );
-			}
-			if ( url.indexOf( '/design/type/premium' ) > -1 ) {
-				const newUrl = url.replace( '/design/type/premium', '/design/type/free' );
+			if ( url.indexOf( '/design/premium' ) > -1 ) {
+				const newUrl = url.replace( '/design/premium', '/design/free' );
 				return self.driver.get( newUrl );
 			}
 			if ( url.indexOf( '/design' ) > -1 ) {
-				const newUrl = url.replace( '/design', '/design/type/free' );
+				const newUrl = url.replace( '/design', '/design/free' );
 				return self.driver.get( newUrl );
 			}
 			throw new Error( `Could not determine the themes URL to show only free themes. Current URL is '${url}'` );


### PR DESCRIPTION
The URL for filtering the themes list changed from `/design/type/free` to just `/design/free` - https://github.com/Automattic/wp-calypso/pull/6886