### PR TITLE
Set user agent to 'wp-e2e-tests' in Chrome and Firefox

### DIFF
--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -91,7 +91,7 @@ export function startBrowser() {
 				options = new chrome.Options();
 				options.setProxy( this.getProxyType() );
 				options.addArguments( '--no-sandbox' );
-				options.addArguments( 'user-agent=wp-e2e-tests' );
+				options.addArguments( 'user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36' );
 				builder = new webdriver.Builder();
 				builder.setChromeOptions( options );
 				global.__BROWSER__ = driver = builder.forBrowser( 'chrome' ).setLoggingPrefs( pref ).build();
@@ -103,7 +103,7 @@ export function startBrowser() {
 				profile.setPreference( 'browser.startup.homepage_override.mstone', 'ignore' );
 				profile.setPreference( 'browser.startup.homepage', 'about:blank' );
 				profile.setPreference( 'startup.homepage_welcome_url.additional', 'about:blank' );
-				profile.setPreference( 'general.useragent.override', 'Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36' );
+				profile.setPreference( 'general.useragent.override', 'Mozilla/5.0 (wp-e2e-tests) Gecko/20100101 Firefox/46.0' );
 				options = new firefox.Options().setProfile( profile );
 				options.setProxy( this.getProxyType() );
 				builder = new webdriver.Builder();

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -103,7 +103,7 @@ export function startBrowser() {
 				profile.setPreference( 'browser.startup.homepage_override.mstone', 'ignore' );
 				profile.setPreference( 'browser.startup.homepage', 'about:blank' );
 				profile.setPreference( 'startup.homepage_welcome_url.additional', 'about:blank' );
-				profile.setPreference( 'general.useragent.override', 'wp-e2e-tests' );
+				profile.setPreference( 'general.useragent.override', 'Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36' );
 				options = new firefox.Options().setProfile( profile );
 				options.setProxy( this.getProxyType() );
 				builder = new webdriver.Builder();

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -91,6 +91,7 @@ export function startBrowser() {
 				options = new chrome.Options();
 				options.setProxy( this.getProxyType() );
 				options.addArguments( '--no-sandbox' );
+				options.addArguments( 'user-agent=wp-e2e-tests' );
 				builder = new webdriver.Builder();
 				builder.setChromeOptions( options );
 				global.__BROWSER__ = driver = builder.forBrowser( 'chrome' ).setLoggingPrefs( pref ).build();
@@ -102,6 +103,7 @@ export function startBrowser() {
 				profile.setPreference( 'browser.startup.homepage_override.mstone', 'ignore' );
 				profile.setPreference( 'browser.startup.homepage', 'about:blank' );
 				profile.setPreference( 'startup.homepage_welcome_url.additional', 'about:blank' );
+				profile.setPreference( 'general.useragent.override', 'wp-e2e-tests' );
 				options = new firefox.Options().setProfile( profile );
 				options.setProxy( this.getProxyType() );
 				builder = new webdriver.Builder();

--- a/specs/wp-log-in-out-spec.js
+++ b/specs/wp-log-in-out-spec.js
@@ -80,7 +80,7 @@ test.describe( 'User Agent: (' + screenSize + ')', function() {
 	test.it( 'Can see the correct user agent set', function() {
 		this.wpHomePage = new WPHomePage( driver, { visit: true } );
 		driver.executeScript( 'return navigator.userAgent;' ).then( ( userAgent ) => {
-			assert.equal( userAgent, 'Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36' );
+			assert( userAgent.match( 'wp-e2e-tests' ), `User Agent does not contain 'wp-e2e-tests'.  [${userAgent}]` );
 		} );
 	} );
 } );

--- a/specs/wp-log-in-out-spec.js
+++ b/specs/wp-log-in-out-spec.js
@@ -80,7 +80,7 @@ test.describe( 'User Agent: (' + screenSize + ')', function() {
 	test.it( 'Can see the correct user agent set', function() {
 		this.wpHomePage = new WPHomePage( driver, { visit: true } );
 		driver.executeScript( 'return navigator.userAgent;' ).then( ( userAgent ) => {
-			assert.equal( userAgent, 'wp-e2e-tests' );
+			assert.equal( userAgent, 'Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36' );
 		} );
 	} );
 } );

--- a/specs/wp-log-in-out-spec.js
+++ b/specs/wp-log-in-out-spec.js
@@ -4,8 +4,9 @@ import test from 'selenium-webdriver/testing';
 import config from 'config';
 import * as driverManager from '../lib/driver-manager.js';
 
-import ReaderPage from '../lib/pages/reader-page.js';
-import ProfilePage from '../lib/pages/profile-page.js';
+import ReaderPage from '../lib/pages/reader-page';
+import ProfilePage from '../lib/pages/profile-page';
+import WPHomePage from '../lib/pages/wp-home-page';
 
 import NavbarComponent from '../lib/components/navbar-component.js';
 
@@ -64,6 +65,22 @@ test.describe( 'Authentication: (' + screenSize + ')', function() {
 					assert.equal( url, 'https://wordpress.com', 'The home page url was incorrect after signing out' );
 				} );
 			} );
+		} );
+	} );
+} );
+
+test.describe( 'User Agent: (' + screenSize + ')', function() {
+	this.timeout( mochaTimeOut );
+	this.bailSuite( true );
+
+	test.before( 'Delete Cookies and Local Storage', function() {
+		driverManager.clearCookiesAndDeleteLocalStorage( driver );
+	} );
+
+	test.it( 'Can see the correct user agent set', function() {
+		this.wpHomePage = new WPHomePage( driver, { visit: true } );
+		driver.executeScript( 'return navigator.userAgent;' ).then( ( userAgent ) => {
+			assert.equal( userAgent, 'wp-e2e-tests' );
 		} );
 	} );
 } );


### PR DESCRIPTION
@hoverduck: can you please 👀  this? I could test Chrome locally, but Firefox wouldn't start and I went into a rabbit-hole of updating the [Marionette driver](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver) which I thought could break our CI systems where we use Firefox (Applitools?)

Also, I believe we run some NUX tests against IE11 in Saucelabs, I don't believe it's possible to override the user-agent for IE