### PR TITLE
Added option to make custom UA dynamically selectable [skip ci]

### DIFF
--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -49,7 +49,7 @@ export function getProxyType() {
 	}
 }
 
-export function startBrowser() {
+export function startBrowser( useCustomUA = true ) {
 	if ( global.__BROWSER__ ) {
 		return global.__BROWSER__;
 	}
@@ -91,7 +91,9 @@ export function startBrowser() {
 				options = new chrome.Options();
 				options.setProxy( this.getProxyType() );
 				options.addArguments( '--no-sandbox' );
-				options.addArguments( 'user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36' );
+				if ( useCustomUA ) {
+					options.addArguments( 'user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36' );
+				}
 				builder = new webdriver.Builder();
 				builder.setChromeOptions( options );
 				global.__BROWSER__ = driver = builder.forBrowser( 'chrome' ).setLoggingPrefs( pref ).build();
@@ -103,7 +105,9 @@ export function startBrowser() {
 				profile.setPreference( 'browser.startup.homepage_override.mstone', 'ignore' );
 				profile.setPreference( 'browser.startup.homepage', 'about:blank' );
 				profile.setPreference( 'startup.homepage_welcome_url.additional', 'about:blank' );
-				profile.setPreference( 'general.useragent.override', 'Mozilla/5.0 (wp-e2e-tests) Gecko/20100101 Firefox/46.0' );
+				if ( useCustomUA ) {
+					profile.setPreference( 'general.useragent.override', 'Mozilla/5.0 (wp-e2e-tests) Gecko/20100101 Firefox/46.0' );
+				}
 				options = new firefox.Options().setProfile( profile );
 				options.setProxy( this.getProxyType() );
 				builder = new webdriver.Builder();

--- a/specs-visdiff/critical/wp-devdocs-visdiff.js
+++ b/specs-visdiff/critical/wp-devdocs-visdiff.js
@@ -33,7 +33,7 @@ if ( batchName !== '' ) {
 
 test.before( function() {
 	this.timeout( startBrowserTimeoutMS );
-	driver = driverManager.startBrowser();
+	driver = driverManager.startBrowser( false ); // Start browser with default UA string
 	screenSize = driverManager.getSizeAsObject();
 } );
 


### PR DESCRIPTION
The custom UA string confused Applitools into believing it was looking at a new baseline of images because it couldn't detect the OS being used.  We could have just accepted this as the new defacto baseline, but to keep things clean I instead fixed it so the startBrowser() function takes an argument to disable to custom UA string.

Note that it only works for the visdiff tests because they are run by a separate mocha process spawning its own browser.  It would not work for an individual spec file in a large batch of them, since they share the webdriver/browser instance.

If more flexibility is needed, this argument could be expanded to provide a custom UA at runtime