### PR TITLE
Updated themes-page to use new theme filter buttons [skip ci]

### DIFF
--- a/lib/pages/themes-page.js
+++ b/lib/pages/themes-page.js
@@ -5,24 +5,14 @@ import * as driverHelper from '../driver-helper.js';
 export default class ThemesPage extends BaseContainer {
 	constructor( driver ) {
 		super( driver, by.css( '.theme__active-focus' ) );
+		this.allThemesSelector = by.css( 'a.item-index-0' );
+		this.freeThemesSelector = by.css( 'a.item-index-1' );
+		this.premiumThemesSelector = by.css( 'a.item-index-2' );
 	}
 
 	showOnlyFreeThemes() {
 		const self = this;
-		return self.driver.getCurrentUrl().then( ( url ) => {
-			if ( url.indexOf( '/design/free' ) > -1 ) {
-				return true;
-			}
-			if ( url.indexOf( '/design/premium' ) > -1 ) {
-				const newUrl = url.replace( '/design/premium', '/design/free' );
-				return self.driver.get( newUrl );
-			}
-			if ( url.indexOf( '/design' ) > -1 ) {
-				const newUrl = url.replace( '/design', '/design/free' );
-				return self.driver.get( newUrl );
-			}
-			throw new Error( `Could not determine the themes URL to show only free themes. Current URL is '${url}'` );
-		} );
+		return driverHelper.clickWhenClickable( this.driver, this.freeThemesSelector, this.explicitWaitMS );
 	}
 
 	selectNewTheme() {


### PR DESCRIPTION
This change is for https://github.com/Automattic/wp-calypso/pull/7214, and closes #152 
