### PR TITLE
Added option to make visdiffs fail test instead of just alert [skip ci]

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,7 @@ module.exports = function (grunt) {
 		shell: {
 			runTests: {
 				command: function(browserSize, sauceConfig) {
-					return './run.sh -R -c -l ' + sauceConfig + ' -s ' + browserSize
+					return './run.sh -R -c -f -l ' + sauceConfig + ' -s ' + browserSize
 				}
 			}
 		},

--- a/run.sh
+++ b/run.sh
@@ -29,6 +29,7 @@ usage () {
 -l [config]	  - Execute the critical visdiff tests via Sauce Labs with the given configuration
 -c		  - Exit with status code 0 regardless of test results
 -d		  - Execute the cross-browser visual-diff tests via grunt (overrides all other arguments)
+-f		  - Tell visdiffs to fail the tests rather than just send an alert
 -i		  - Execute i18n tests in the specs-i18n/ directory, not compatible with -g flag
 -v [all/critical] - Execute the visdiff tests in specs-visdiff[/critical].  Must specify either 'all' or 'critical'.  Only accessible in combination with -p flag
 -h		  - This help listing
@@ -40,7 +41,7 @@ if [ $# -eq 0 ]; then
   usage
 fi
 
-while getopts ":Rpb:s:giv:wl:cdh" opt; do
+while getopts ":Rpb:s:giv:wl:cdfh" opt; do
   case $opt in
     R)
       REPORTER="-R spec-xunit-slack-reporter"
@@ -75,7 +76,7 @@ while getopts ":Rpb:s:giv:wl:cdh" opt; do
       TARGET="specs/*wp-signup-spec.js" # wildcard needed to account for random filename ordering
       ;;
     l)
-      NODE_CONFIG_ARGS+="\"sauce\":\"true\",\"sauceConfig\":\"$OPTARG\",\"crossBrowser\":\"true\""
+      NODE_CONFIG_ARGS+=("\"sauce\":\"true\",\"sauceConfig\":\"$OPTARG\",\"crossBrowser\":\"true\"")
       TARGET="specs-visdiff/critical/"
       ;;
     v)
@@ -86,6 +87,9 @@ while getopts ":Rpb:s:giv:wl:cdh" opt; do
         grunt
       fi
       exit $?
+      ;;
+    f)
+      NODE_CONFIG_ARGS+=("\"failVisdiffs\":\"true\"")
       ;;
     h)
       usage

--- a/specs-visdiff/critical/wp-devdocs-visdiff.js
+++ b/specs-visdiff/critical/wp-devdocs-visdiff.js
@@ -1,4 +1,5 @@
 import test from 'selenium-webdriver/testing';
+import assert from 'assert';
 import config from 'config';
 import * as driverManager from '../../lib/driver-manager.js';
 import * as driverHelper from '../../lib/driver-helper.js';
@@ -148,7 +149,11 @@ test.describe( 'DevDocs Visual Diff (' + screenSizeName + ')', function() {
 
 				if ( message !== '' ) {
 					slackNotifier.warn( message );
+					if ( config.has( 'failVisdiffs' ) && config.get( 'failVisdiffs' ) ) {
+						assert( false, message );
+					}
 				}
+
 			} );
 		} finally {
 			eyes.abortIfNotClosed();


### PR DESCRIPTION
`run.sh` now has a `-f` option which adds a failing assert() call to the visdiffs in case of miscompares.  Necessary to get proper status out of cross-browser visdiffs, and will also be used if/when we implement multiple repos for different test groups.