### PR TITLE
Add support for Clickable Domain Rows

### DIFF
--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -45,7 +45,7 @@ export default class FindADomainComponent extends BaseContainer {
 		} );
 	}
 	selectDotComAddress( dotComAddress ) {
-		const selector = By.css( `button[data-e2e-domain="${ dotComAddress }"]` );
+		const selector = By.css( `[data-e2e-domain="${ dotComAddress }"]` );
 		this.driver.wait( until.elementLocated( selector ), this.explicitWaitMS, 'Could not locate the select button for the paid address: ' + dotComAddress );
 		const element = this.driver.findElement( selector );
 		this.driver.wait( until.elementIsEnabled( element ), this.explicitWaitMS, 'The paid address button for ' + dotComAddress + ' does not appear to be enabled to click' );


### PR DESCRIPTION
This should (hopefully) fix the E2E tests for the new clickable rows interface we're adding as part of the following PR: https://github.com/Automattic/wp-calypso/pull/7239

![](https://cloud.githubusercontent.com/assets/418473/17499412/b3a3baf0-5da3-11e6-9b7a-3af6b36af6e5.png)