### PR TITLE
Cross-browser diffs now use smaller desktop screensize

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,11 +1,9 @@
-'use strict';
-
-module.exports = function (grunt) {
+module.exports = function( grunt ) {
 	// configure tasks
-	grunt.initConfig({
+	grunt.initConfig( {
 		shell: {
 			runTests: {
-				command: function(browserSize, sauceConfig) {
+				command: function( browserSize, sauceConfig ) {
 					return './run.sh -R -c -f -l ' + sauceConfig + ' -s ' + browserSize
 				}
 			}
@@ -13,33 +11,33 @@ module.exports = function (grunt) {
 
 		concurrent: {
 			target: {
-				tasks: [  'run_mobile_osx-chrome', 'run_desktop_osx-chrome', 'run_tablet_osx-chrome',
- 					'run_mobile_osx-firefox', 'run_desktop_osx-firefox', 'run_tablet_osx-firefox',
- 					'run_mobile_osx-safari', 'run_desktop_osx-safari', 'run_tablet_osx-safari' ],
-// 					'run_desktop_win-ie11' ],
+				tasks: [ 'run_mobile_osx-chrome', 'run_desktop_osx-chrome', 'run_tablet_osx-chrome',
+					'run_mobile_osx-firefox', 'run_desktop_osx-firefox', 'run_tablet_osx-firefox',
+					'run_mobile_osx-safari', 'run_desktop_osx-safari', 'run_tablet_osx-safari',
+					'run_desktop_win-ie11' ],
 				options: {
 					limit: 3,
 					logConcurrentOutput: true
 				}
 			}
 		}
-	});
+	} );
 
 	// load tasks
-	grunt.loadNpmTasks('grunt-concurrent');
-	grunt.loadNpmTasks('grunt-shell');
+	grunt.loadNpmTasks( 'grunt-concurrent' );
+	grunt.loadNpmTasks( 'grunt-shell' );
 
 	// register tasks
-	grunt.registerTask('default', ['concurrent:target']);
+	grunt.registerTask( 'default', ['concurrent:target'] );
 
-	grunt.registerTask('run_mobile_osx-chrome', ['shell:runTests:mobile:osx-chrome']);
-	grunt.registerTask('run_desktop_osx-chrome', ['shell:runTests:desktop:osx-chrome']);
-	grunt.registerTask('run_tablet_osx-chrome', ['shell:runTests:tablet:osx-chrome']);
-	grunt.registerTask('run_mobile_osx-firefox', ['shell:runTests:mobile:osx-firefox']);
-	grunt.registerTask('run_desktop_osx-firefox', ['shell:runTests:desktop:osx-firefox']);
-	grunt.registerTask('run_tablet_osx-firefox', ['shell:runTests:tablet:osx-firefox']);
-	grunt.registerTask('run_mobile_osx-safari', ['shell:runTests:mobile:osx-safari']);
-	grunt.registerTask('run_desktop_osx-safari', ['shell:runTests:desktop:osx-safari']);
-	grunt.registerTask('run_tablet_osx-safari', ['shell:runTests:tablet:osx-safari']);
-	grunt.registerTask('run_desktop_win-ie11', ['shell:runTests:desktop:win-ie11']);
+	grunt.registerTask( 'run_mobile_osx-chrome', ['shell:runTests:mobile:osx-chrome'] );
+	grunt.registerTask( 'run_desktop_osx-chrome', ['shell:runTests:desktop-small:osx-chrome'] );
+	grunt.registerTask( 'run_tablet_osx-chrome', ['shell:runTests:tablet:osx-chrome'] );
+	grunt.registerTask( 'run_mobile_osx-firefox', ['shell:runTests:mobile:osx-firefox'] );
+	grunt.registerTask( 'run_desktop_osx-firefox', ['shell:runTests:desktop-small:osx-firefox'] );
+	grunt.registerTask( 'run_tablet_osx-firefox', ['shell:runTests:tablet:osx-firefox'] );
+	grunt.registerTask( 'run_mobile_osx-safari', ['shell:runTests:mobile:osx-safari'] );
+	grunt.registerTask( 'run_desktop_osx-safari', ['shell:runTests:desktop-small:osx-safari'] );
+	grunt.registerTask( 'run_tablet_osx-safari', ['shell:runTests:tablet:osx-safari'] );
+	grunt.registerTask( 'run_desktop_win-ie11', ['shell:runTests:desktop-small:win-ie11'] );
 };

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -30,6 +30,8 @@ export function getSizeAsObject() {
 			return { width: 1024, height: 1000};
 		case 'desktop':
 			return { width: 1440, height: 1000};
+		case 'desktop-small':
+			return { width: 1200, height: 950};
 		case 'laptop':
 			return { width: 1400, height: 790};
 		default:
@@ -182,6 +184,9 @@ export function resizeBrowser( driver, screenSize ) {
 				break;
 			case 'desktop':
 				driver.manage().window().setSize( 1440, 1000 );
+				break;
+			case 'desktop-small':
+				driver.manage().window().setSize( 1200, 950 );
 				break;
 			case 'laptop':
 				driver.manage().window().setSize( 1400, 790 );

--- a/specs-visdiff/critical/wp-devdocs-visdiff.js
+++ b/specs-visdiff/critical/wp-devdocs-visdiff.js
@@ -52,10 +52,11 @@ test.describe( 'DevDocs Visual Diff (' + screenSizeName + ')', function() {
 	test.before( function() {
 		let testName = `DevDocs Design [${screenSizeName}]`;
 		if ( crossBrowser ) {
+			let parsedScreenSize = screenSizeName.replace( /-small/, '' );
 			eyes.setHideScrollbars( true )
-			eyes.setBaselineName( `devdocs-cross-browser-${screenSizeName}` );
+			eyes.setBaselineName( `devdocs-cross-browser-${parsedScreenSize}` );
 			eyes.setMatchLevel( 'LAYOUT2' );
-			testName = `DevDocs Cross-Browser [${screenSizeName}]`;
+			testName = `DevDocs Cross-Browser [${parsedScreenSize}]`;
 		}
 
 		eyes.open( driver, 'WordPress.com', testName, screenSize );
@@ -153,7 +154,6 @@ test.describe( 'DevDocs Visual Diff (' + screenSizeName + ')', function() {
 						assert( false, message );
 					}
 				}
-
 			} );
 		} finally {
 			eyes.abortIfNotClosed();


### PR DESCRIPTION
SauceLabs doesn't provide a high enough resolution display for Windows VMs to match the screenshots we're comparing for the other browsers.  So now all cross-browser desktop tests will run with a smaller resolution (1200x950).  This PR also enables IE11 in those tests.