### PR TITLE
Fully removing Followers after invites

### DIFF
--- a/lib/pages/people-page.js
+++ b/lib/pages/people-page.js
@@ -30,6 +30,52 @@ export default class PeoplePage extends BaseContainer {
 		return DriverHelper.clickWhenClickable( this.driver, By.css( '.section-nav-tabs__list a[href*=email-followers]' ) );
 	}
 
+	selectFollowers() {
+		this.ensureMobileMenuOpen();
+		return DriverHelper.clickWhenClickable( this.driver, By.css( '.section-nav-tabs__list a[href*="people/followers"]' ) );
+	}
+
+	emptyUsers() {
+		var d = webdriver.promise.defer();
+		var self = this;
+
+		this.driver.isElementPresent( By.css( '.people-list-section-header span.count' ) ).then( function( present ) {
+			if ( present ) {
+				self.driver.findElement( webdriver.By.css( '.people-list-section-header span.count' ) ).getText().then( function( numItems ) {
+					var flow = self.driver.controlFlow();
+					var promiseArray = [];
+					for ( let i = 0; i < parseInt( numItems.replace( /,/, '' ) ); i++ ) {
+						promiseArray.push( flow.execute( function() {
+							self.removeUser( self );
+						} ) );
+					}
+					webdriver.promise.all( promiseArray ).then( function() {
+						d.fulfill( true );
+					} );
+				} );
+			} else {
+				d.fulfill( true );
+			}
+		} );
+
+		return d.promise;
+	}
+
+	removeUser( self ) {
+		const removeButton = By.css( 'button.people-list-item__remove-button' );
+		const confirmRemove = By.css( '.dialog__action-buttons button.is-primary' );
+
+		let d = webdriver.promise.defer();
+
+		DriverHelper.clickWhenClickable( self.driver, removeButton ).then( function() {
+			DriverHelper.clickWhenClickable( self.driver, confirmRemove ).then( function() {
+				d.fulfill();
+			} );
+		} );
+
+		return d.promise;
+	}
+
 	ensureMobileMenuOpen() {
 		const driver = this.driver;
 		const mobileHeaderSelector = By.css( '.section-nav__mobile-header' );
@@ -52,16 +98,28 @@ export default class PeoplePage extends BaseContainer {
 				return text === `${username}\n@${username}\nREMOVE`;
 			} );
 		} ).then( function( filteredViewers ) {
-			return (filteredViewers.length === 1);
+			return ( filteredViewers.length === 1 );
 		} );
 	}
 
-	removeViewer( username ) {
+	/**
+	 * Removes the given user from the currently displayed list
+	 * @param {string} username The username to remove
+	 * @param {bool} useSince Whether to include the "SINCE" line in the pattern match (for Followers, not Viewers)
+	 * @returns {Promise} Promise from the click action
+	 */
+	removeUserByName( username, useSince ) {
 		let viewers = this.driver.findElements( By.css( 'a.people-list-item' ) );
 
 		webdriver.promise.filter( viewers, function( viewer ) {
 			return viewer.getText().then( function( text ) {
-				return text === `${username}\n@${username}\nREMOVE`;
+				let re = new RegExp( `${username}\n@${username}\nREMOVE` );
+
+				if ( useSince ) {
+					re = new RegExp( `${username}\n@${username}\nSINCE.*\nREMOVE` );
+				}
+
+				return text.match( re );
 			} );
 		} ).then( function( filteredViewers ) {
 			if ( filteredViewers.length !== 1 ) {
@@ -96,6 +154,11 @@ export default class PeoplePage extends BaseContainer {
 				return !present;
 			} );
 		}, this.explicitWaitMS, 'The search results are still loading when they should have finished.' );
+	}
+
+	cancelSearch() {
+		const cancelSelector = By.css( 'span[aria-label="Close Search"] svg' );
+		return DriverHelper.clickWhenClickable( this.driver, cancelSelector );
 	}
 
 	numberSearchResults() {

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -355,6 +355,17 @@ testDescribe( 'Invites: (' + screenSize + ')', function() {
 									this.peoplePage.numberSearchResults().then( ( numberPeopleShown ) => {
 										assert.equal( numberPeopleShown, 0, `After deletion, the number of email follower search results for '${newUserName}' was incorrect` );
 									} );
+									this.peoplePage.cancelSearch();
+								} );
+
+								test.it( 'Can remove the follower account from the site', function() {
+									this.peoplePage.selectFollowers();
+									this.peoplePage.waitForSearchResults();
+									this.peoplePage.removeUserByName( newUserName, true );
+									this.peoplePage.waitForSearchResults();
+									this.peoplePage.viewerDisplayed( newUserName ).then( ( displayed ) => {
+										assert.equal( displayed, false, `The username of '${newUserName}' was still displayed as a site viewer` );
+									} );
 								} );
 							} );
 						} );
@@ -508,7 +519,7 @@ testDescribe( 'Invites: (' + screenSize + ')', function() {
 
 								test.describe( 'As the original user, I can remove the new user added to site', function() {
 									test.it( 'Can remove the team member from the site', function() {
-										this.peoplePage.removeViewer( newUserName );
+										this.peoplePage.removeUserByName( newUserName, false );
 										this.peoplePage.waitForSearchResults();
 										this.peoplePage.viewerDisplayed( newUserName ).then( ( displayed ) => {
 											assert.equal( displayed, false, `The username of '${newUserName}' was still displayed as a site viewer` );


### PR DESCRIPTION
Previously the "Invite Follower" test was only deleting the new user from the "Email Followers" list, but left them in the main "Follower" list (since they created an account).  This caused a buildup of ~3500 followers, which was overflowing our Mailosaur account with too many daily e-mails.

With this PR we now remove both the e-mail follower and the other one (although only the latter is actually necessary, I left the direct e-mail remove in there so we still test that functionality).