### PR TITLE
Allow Eyes to resize window rather than doing it explicitly for visdiffs

### DIFF
--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -53,7 +53,7 @@ export function getProxyType() {
 	}
 }
 
-export function startBrowser( useCustomUA = true ) {
+export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true } = {} ) {
 	if ( global.__BROWSER__ ) {
 		return global.__BROWSER__;
 	}
@@ -125,7 +125,11 @@ export function startBrowser( useCustomUA = true ) {
 	}
 	driver.manage().timeouts().implicitlyWait( webDriverImplicitTimeOutMS );
 	driver.manage().timeouts().pageLoadTimeout( webDriverPageLoadTimeOutMS );
-	this.resizeBrowser( driver, screenSize );
+
+	if ( resizeBrowserWindow ) {
+		this.resizeBrowser( driver, screenSize );
+	}
+
 	return driver;
 }
 

--- a/specs-visdiff/critical/wp-devdocs-visdiff.js
+++ b/specs-visdiff/critical/wp-devdocs-visdiff.js
@@ -41,7 +41,7 @@ if ( batchName !== '' ) {
 
 test.before( function() {
 	this.timeout( startBrowserTimeoutMS );
-	driver = driverManager.startBrowser( false ); // Start browser with default UA string
+	driver = driverManager.startBrowser( { useCustomUA: false, resizeBrowserWindow: false } ); // Start browser with default UA string and do not resize (rely on Eyes to do that)
 	screenSize = driverManager.getSizeAsObject();
 } );
 
@@ -129,11 +129,7 @@ test.describe( 'DevDocs Visual Diff (' + screenSizeName + ')', function() {
 			devdocsDesignPage.hideMasterbar().then( function() {
 				devdocsDesignPage.hideEnvironmentBadge().then( function() {
 					slackNotifier.warn( 'The Blocks page is currently being ignored, pending wp-calypso/7257 resolution' );
-					if ( screenSizeName === 'desktop-small' ) {
-						console.log( 'Skipping Blocks screenshot entirely for cross-browser desktop' );
-					} else {
-						driverHelper.eyesScreenshot( driver, eyes, 'DevDocs Design (Blocks)', by.id( 'primary' ) );
-					}
+					driverHelper.eyesScreenshot( driver, eyes, 'DevDocs Design (Blocks)', by.id( 'primary' ) );
 				} );
 			} );
 		} );


### PR DESCRIPTION
There's a bug in the eyes.selenium package that's crashing Firefox in the cross-browser visdiffs on the `/devdocs/blocks` page at the 1200x950 screen resolution.  But it works fine if I just allow Eyes to set the screensize itself, rather than set it explicitly when starting the browser.  So this PR just adds a control flag to driver-manager.js to skip the resize function call if needed.