### PR TITLE
Added report generator for querying recent CI failures [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "grunt-cli": "^0.1.13",
     "appium": "1.5.3",
     "wd": "^0.4.0",
-    "wd-bridge": "^0.0.2"
+    "wd-bridge": "^0.0.2",
+    "xml2json-command": "^0.0.3"
   },
   "devDependencies": {
     "eslint": "<2.3.0",

--- a/report.sh
+++ b/report.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# CircleCI Reports
+# Assuming the $CIRCLE_TOKEN envvar is populated, this will retrieve all of the xunit report files from the last 30 failed runs and print the errors
+# to the screen.  The idea is that this will give you a nice easy way to skim all the recent results to see if the same jobs have been failing repeatedly.
+
+which jq > /dev/null 2>&1
+RC=$?
+if [ $RC != 0 ];then
+  echo "Please install jq"
+  exit 1
+fi
+
+red='\E[31;40m'
+reset='\e[0m'
+
+#0) Keep all artifacts in a reports subdirectory
+mkdir -p reports
+cd reports
+
+#1) Get list of recent deploy-triggered builds (failures only), building a subdir for each
+curl https://circleci.com/api/v1.1/project/github/Automattic/wp-e2e-tests?circle-token=$CIRCLE_TOKEN\&filter=failed 2>/dev/null | jq '.[] | select( .build_parameters.DEPLOY_USER != null ) | select( .build_parameters.DEPLOY_USER != "" ) | .build_num' | xargs mkdir -p
+
+#2) Retrieve xunit artifacts for each failed build, skipping any directories that already have files
+for BUILD_NUM in $(ls); do
+  cd $BUILD_NUM
+  if [ "$(ls)" == "" ]; then
+    curl https://circleci.com/api/v1.1/project/github/Automattic/wp-e2e-tests/$BUILD_NUM/artifacts?circle-token=$CIRCLE_TOKEN 2>/dev/null | jq '.[] | select( .path | contains( "xml" ) ) | .url' | xargs wget
+  fi
+  cd ..
+done
+
+#3) For each build, parse out the failed test names and errors
+for BUILD_NUM in $(ls); do
+  cd $BUILD_NUM
+  echo $BUILD_NUM
+
+  # Print timestamp of the first file
+  head -1 $(ls | head -1) | sed 's/^.*timestamp="//' | sed 's/".*$//'
+    
+  # Loop through the files that have a failure recorded
+  for file in $(grep -l failures=\"[^0]\" *); do
+    # Convert the XML to JSON
+    json=$(xml2json < $file)
+    failures=$(echo $json | jq -M '.testsuite.testcase | map( select( .failure ) | { classname: .classname, name: .name, failure: .failure."$cd" } )')
+    numFailures=$(echo $failures | jq '. | length')
+    i=0
+    while [ $i -lt $numFailures ]; do
+      failure=$(echo $failures | jq -M --arg index $i '.[$index | tonumber]')
+	# TODO - Truncate string with ellipsis
+      echo "	$(echo $failure | jq -M '.classname')"
+      echo "		$(echo $failure | jq -M '.name')"
+      printf "		$red %s $reset\n" "$(echo $failure | jq -C '.failure' | grep -o 'Error:.*\\n' | sed 's/\\n.*$//')"
+
+      i=$[$i+1]
+    done
+  done
+
+  cd ..
+done


### PR DESCRIPTION
The `report.sh` shell script queries CircleCI using the $CIRCLE_TOKEN envvar and pulls down the 30 most recent failures, then parses out only the ones that were triggered by a wp-calypso deploy.  Then it retrieves the XUnit report files and parses them, printing out the failing tests with their error  messages.  This makes it a little easier to skim through and see if the same test has been repeatedly failing, especially overnight or the weekend.

In the future I'd like to expand it to run autonomously and send a report via Slack, possibly integrating some smarts to look for patterns in repeated failures.

It also needs to be expanded to look at the non-deploy runs, specifically the IE NUX and cross-browser visdiffs.