### PR TITLE
Fixes deactivate/activate selectors when updates are available

### DIFF
--- a/lib/pages/wp-admin/wp-admin-plugins-page.js
+++ b/lib/pages/wp-admin/wp-admin-plugins-page.js
@@ -16,7 +16,7 @@ export default class WPAdminPluginsPage extends BaseContainer {
 
 	deactivateJetpack() {
 		const self = this;
-		const deactivateSelector = by.css( 'tr[data-slug="jetpack-by-wordpress-com"] .deactivate' );
+		const deactivateSelector = by.css( 'tr[data-slug="jetpack-by-wordpress-com"] .deactivate,tr[data-slug="jetpack"] .deactivate' );
 		const deactivatedMessageDismissSelector = by.css( '#message button' );
 		return this.driver.isElementPresent( deactivateSelector ).then( ( located ) => {
 			if ( located === true ) {
@@ -28,7 +28,7 @@ export default class WPAdminPluginsPage extends BaseContainer {
 
 	activateJetpack() {
 		const self = this;
-		const activateSelector = by.css( 'tr[data-slug="jetpack-by-wordpress-com"] .activate' );
+		const activateSelector = by.css( 'tr[data-slug="jetpack-by-wordpress-com"] .activate,tr[data-slug="jetpack"] .activate' );
 		const activatedMessageDismissSelector = by.css( '#message button' );
 		return this.driver.isElementPresent( activateSelector ).then( ( located ) => {
 			if ( located === true ) {


### PR DESCRIPTION
The data slugs change when the jetpack plugin has available updates -
so this makes it work for either