### PR TITLE
Searching for two classnames in devdocs elements now [skip ci]

### DIFF
--- a/lib/pages/devdocs-design-page.js
+++ b/lib/pages/devdocs-design-page.js
@@ -11,11 +11,15 @@ export default class DevdocsDesignPage extends BaseContainer {
 
 		super( driver, by.css( '.devdocs.main' ), visit, baseURL );
 
+		// The devdocs page is transitioning to a new standard classname
+		let oldClassName = '.design-assets__group';
+		let newClassName = '.docs__design-assets-group';
+
 		this.baseURL = baseURL;
-		this.designElementSelector = by.className( 'design-assets__group' );
-		this.designElementLinkSelector = by.css( '.design-assets__group h2 a:not(.button)' );
+		this.designElementSelector = by.css( `${oldClassName}, ${newClassName}` );
+		this.designElementLinkSelector = by.css( `${oldClassName} h2 a:not(.button), ${newClassName} h2 a:not(.button)` );
 		this.elementTitleSelector = by.css( '.header-cake__title' );
-		this.elementButtonSelector = by.css( 'div:not([style*="display:none"]):not([style*="display: none"]) > .design-assets__group h2 a.button' );
+		this.elementButtonSelector = by.css( `div:not([style*="display:none"]):not([style*="display: none"]) > ${oldClassName} h2 a.button, div:not([style*="display:none"]):not([style*="display: none"]) > ${newClassName} h2 a.button` );
 		this.allComponentsSelector = by.css( 'button.header-cake__back' );
 	}
 


### PR DESCRIPTION
The devdocs design elements are now supposed to be using `docs__design-assets-group` rather than `design-assets__group`.  This PR updates the DevdocsDesignPage object to search for either, since they're currently both in use.

See https://github.com/Automattic/wp-calypso/pull/7505#issuecomment-242927337 for context