### PR TITLE
Add workaround for wp-calypso/7874 devdocs/blocks crash

### DIFF
--- a/lib/pages/devdocs-design-page.js
+++ b/lib/pages/devdocs-design-page.js
@@ -61,8 +61,11 @@ export default class DevdocsDesignPage extends BaseContainer {
 
 	openAppComponents() {
 		var url = this.baseURL + '/blocks';
+		const driver = this.driver;
 
-		return this.driver.get( url );
+		return driver.get( url ).then( function() {
+			return driver.navigate().refresh();
+		} );
 	}
 
 	getAllDesignElements() {

--- a/lib/pages/devdocs-design-page.js
+++ b/lib/pages/devdocs-design-page.js
@@ -63,7 +63,7 @@ export default class DevdocsDesignPage extends BaseContainer {
 		var url = this.baseURL + '/blocks';
 		const driver = this.driver;
 
-		return driver.get( url ).then( function() {
+		return driver.get( url ).then( function() { // Refresh page to work around https://github.com/Automattic/wp-calypso/issues/7874
 			return driver.navigate().refresh();
 		} );
 	}

--- a/run.sh
+++ b/run.sh
@@ -129,7 +129,7 @@ if [ $PARALLEL == 1 ]; then
       NC="--NODE_CONFIG='{$NODE_CONFIG_ARG}'"
       CMD="env BROWSERSIZE=mobile $MOCHA $NC $GREP $REPORTER specs/ $AFTER"
 
-      echo $CMD
+      eval $CMD
       RETURN+=$?
   fi
   if [ $CIRCLE_NODE_INDEX == $DESKTOP ]; then
@@ -137,7 +137,7 @@ if [ $PARALLEL == 1 ]; then
       NC="--NODE_CONFIG='{$NODE_CONFIG_ARG}'"
       CMD="env BROWSERSIZE=desktop $MOCHA $NC $GREP $REPORTER specs/ $AFTER"
 
-      echo $CMD
+      eval $CMD
       RETURN+=$?
   fi
   if [ $CIRCLE_NODE_INDEX == $TABLET ] && [ "$CIRCLE_BRANCH" == "master" ]; then # only run tablet screensize on master branch
@@ -145,7 +145,7 @@ if [ $PARALLEL == 1 ]; then
       NC="--NODE_CONFIG='{$NODE_CONFIG_ARG}'"
       CMD="env BROWSERSIZE=tablet $MOCHA $NC $GREP $REPORTER specs/ $AFTER"
 
-      echo $CMD
+      eval $CMD
       RETURN+=$?
   fi
   if [ $CIRCLE_NODE_INDEX == $VISUAL ] && [ $VISDIFF == 1 ]; then
@@ -156,11 +156,11 @@ if [ $PARALLEL == 1 ]; then
       CMD2="env BROWSERSIZE=desktop $MOCHA $NC $GREP $REPORTER specs-visdiff/critical/ $AFTER"
       CMD3="env BROWSERSIZE=tablet $MOCHA $NC $GREP $REPORTER specs-visdiff/critical/ $AFTER"
 
-      echo $CMD1
+      eval $CMD1
       RETURN+=$?
       eval $CMD2
       RETURN+=$?
-      echo $CMD3
+      eval $CMD3
       RETURN+=$?
   fi
 else # Not a parallel run, just queue up the tests in sequence
@@ -173,7 +173,7 @@ else # Not a parallel run, just queue up the tests in sequence
         if [ "$target" != "" ]; then
           CMD="env BROWSERSIZE=$size $MOCHA $NC $GREP $REPORTER $target $AFTER"
 
-          echo $CMD
+          eval $CMD
           RETURN+=$?
         fi
       done

--- a/run.sh
+++ b/run.sh
@@ -129,7 +129,7 @@ if [ $PARALLEL == 1 ]; then
       NC="--NODE_CONFIG='{$NODE_CONFIG_ARG}'"
       CMD="env BROWSERSIZE=mobile $MOCHA $NC $GREP $REPORTER specs/ $AFTER"
 
-      eval $CMD
+      echo $CMD
       RETURN+=$?
   fi
   if [ $CIRCLE_NODE_INDEX == $DESKTOP ]; then
@@ -137,7 +137,7 @@ if [ $PARALLEL == 1 ]; then
       NC="--NODE_CONFIG='{$NODE_CONFIG_ARG}'"
       CMD="env BROWSERSIZE=desktop $MOCHA $NC $GREP $REPORTER specs/ $AFTER"
 
-      eval $CMD
+      echo $CMD
       RETURN+=$?
   fi
   if [ $CIRCLE_NODE_INDEX == $TABLET ] && [ "$CIRCLE_BRANCH" == "master" ]; then # only run tablet screensize on master branch
@@ -145,7 +145,7 @@ if [ $PARALLEL == 1 ]; then
       NC="--NODE_CONFIG='{$NODE_CONFIG_ARG}'"
       CMD="env BROWSERSIZE=tablet $MOCHA $NC $GREP $REPORTER specs/ $AFTER"
 
-      eval $CMD
+      echo $CMD
       RETURN+=$?
   fi
   if [ $CIRCLE_NODE_INDEX == $VISUAL ] && [ $VISDIFF == 1 ]; then
@@ -156,11 +156,11 @@ if [ $PARALLEL == 1 ]; then
       CMD2="env BROWSERSIZE=desktop $MOCHA $NC $GREP $REPORTER specs-visdiff/critical/ $AFTER"
       CMD3="env BROWSERSIZE=tablet $MOCHA $NC $GREP $REPORTER specs-visdiff/critical/ $AFTER"
 
-      eval $CMD1
+      echo $CMD1
       RETURN+=$?
       eval $CMD2
       RETURN+=$?
-      eval $CMD3
+      echo $CMD3
       RETURN+=$?
   fi
 else # Not a parallel run, just queue up the tests in sequence
@@ -173,7 +173,7 @@ else # Not a parallel run, just queue up the tests in sequence
         if [ "$target" != "" ]; then
           CMD="env BROWSERSIZE=$size $MOCHA $NC $GREP $REPORTER $target $AFTER"
 
-          eval $CMD
+          echo $CMD
           RETURN+=$?
         fi
       done


### PR DESCRIPTION
This fixes the issue where the /devdocs/blocks page was crashing on loading the Plan Thank You component without Calypso already loaded.