### PR TITLE
Override Sauce Labs /etc/hosts file to prevent loading external images

### DIFF
--- a/fix-saucelabs-etc-hosts.bat
+++ b/fix-saucelabs-etc-hosts.bat
@@ -1,0 +1,4 @@
+@echo off
+echo. >> C:\Windows\System32\drivers\etc\hosts
+echo 127.0.0.1 lorempixel.com >> C:\Windows\System32\drivers\etc\hosts
+echo 127.0.0.1 placekitten.com >> C:\Windows\System32\drivers\etc\hosts

--- a/fix-saucelabs-etc-hosts.sh
+++ b/fix-saucelabs-etc-hosts.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "127.0.0.1 lorempixel.com" >> /etc/hosts
+echo "127.0.0.1 placekitten.com" >> /etc/hosts

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -71,9 +71,9 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 		caps.maxDuration = 2700; // 45 minutes
 
 		if ( caps.platform.match( /Windows/ ) ) {
-			caps.prerun = { executable: 'https://raw.githubusercontent.com/Automattic/wp-e2e-tests/fix/visdiff-saucelabs-etc-hosts/fix-saucelabs-etc-hosts.bat' };
+			caps.prerun = { executable: 'https://raw.githubusercontent.com/Automattic/wp-e2e-tests/master/fix-saucelabs-etc-hosts.bat' };
 		} else {
-			caps.prerun = { executable: 'https://raw.githubusercontent.com/Automattic/wp-e2e-tests/fix/visdiff-saucelabs-etc-hosts/fix-saucelabs-etc-hosts.sh' };
+			caps.prerun = { executable: 'https://raw.githubusercontent.com/Automattic/wp-e2e-tests/master/fix-saucelabs-etc-hosts.sh' };
 		}
 		if ( process.env.CIRCLE_BUILD_NUM ) {
 			caps.name += ' - CircleCI Build #' + process.env.CIRCLE_BUILD_NUM;

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -69,7 +69,12 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 		caps.accessKey = config.get( 'sauceAccessKey' );
 		caps.name = caps.browserName + ' - [' + screenSize + ']';
 		caps.maxDuration = 2700; // 45 minutes
-		caps.prerun = { executable: 'https://raw.githubusercontent.com/Automattic/wp-e2e-tests/fix/visdiff-saucelabs-etc-hosts/fix-saucelabs-etc-hosts.sh' };
+
+		if ( caps.platform.match( /Windows/ ) ) {
+			caps.prerun = { executable: 'https://raw.githubusercontent.com/Automattic/wp-e2e-tests/fix/visdiff-saucelabs-etc-hosts/fix-saucelabs-etc-hosts.bat' };
+		} else {
+			caps.prerun = { executable: 'https://raw.githubusercontent.com/Automattic/wp-e2e-tests/fix/visdiff-saucelabs-etc-hosts/fix-saucelabs-etc-hosts.sh' };
+		}
 		if ( process.env.CIRCLE_BUILD_NUM ) {
 			caps.name += ' - CircleCI Build #' + process.env.CIRCLE_BUILD_NUM;
 		}

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -69,6 +69,7 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 		caps.accessKey = config.get( 'sauceAccessKey' );
 		caps.name = caps.browserName + ' - [' + screenSize + ']';
 		caps.maxDuration = 2700; // 45 minutes
+		caps.prerun = { executable: 'https://raw.githubusercontent.com/Automattic/wp-e2e-tests/fix/visdiff-saucelabs-etc-hosts/fix-saucelabs-etc-hosts.sh' };
 		if ( process.env.CIRCLE_BUILD_NUM ) {
 			caps.name += ' - CircleCI Build #' + process.env.CIRCLE_BUILD_NUM;
 		}


### PR DESCRIPTION
Several components in devdocs load random filler images from lorempixel.com and placekitten.com.  In addition to the images themselves being random and throwing off the visdiff, they were causing frequent performance problems in running the tests while waiting for those resources to load.  This PR stubs out those URLs via the hosts file so the components show up with consistent blank images.