### PR TITLE
Restore the Site Title validation on newly created sites.

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -178,7 +178,7 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 
 										test.it( 'Can see the correct blog title displayed', function() {
 											return this.viewBlogPage.title().then( ( title ) => {
-												return assert( title.match( blogName ), 'The expected blog title is not displaying correctly' );
+												return assert.equal( title, 'Site Title', 'The expected blog title is not displaying correctly' );
 											} );
 										} );
 


### PR DESCRIPTION
The Site Title change wasn't intentional and the tests were right to fail :) I restored the functionality as it was before, so we can catch my mishaps again in the future.

cc @hoverduck 