### PR TITLE
Signup: Add AB default variation for new Verticals test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -56,13 +56,14 @@
         "version": "11.103"
     }
   },
-  "knownABTestKeys": [ "multiDomainRegistrationV1", "signupStore", "signupStoreBenchmarking",  "coldStartReader", "browserNotifications", "domainSuggestionPopover", "paidNuxStreamlined", "plansDescriptions", "domainSuggestionClickableRow", "verticalScreenshots", "signupThemeUpload" ],
+  "knownABTestKeys": [ "multiDomainRegistrationV1", "signupStore", "signupStoreBenchmarking",  "coldStartReader", "browserNotifications", "domainSuggestionPopover", "paidNuxStreamlined", "plansDescriptions", "domainSuggestionClickableRow", "verticalScreenshots", "signupThemeUpload", "signupSurveyStep" ],
   "overrideABTests": [
 	[ "signupStore_20160927", "designTypeWithStore" ],
 	[ "browserNotifications_20160628", "disabled" ],
 	[ "domainSuggestionPopover_20160809", "hidePopover" ],
 	[ "domainSuggestionClickableRow_20160802", "clickableButton"],
 	[ "signupStoreBenchmarking_20160927", "pressable" ],
-	[ "signupThemeUpload_20160928", "hideThemeUpload" ]
+	[ "signupThemeUpload_20160928", "hideThemeUpload" ],
+	[ "signupSurveyStep_20161005", "surveyStepV1" ]
   ]
 }


### PR DESCRIPTION
The new design for the Verticals step is hidden behind an AB test - automattic/wp-calypso#7700

I added the default variation and the test to `knownABTestKeys`.

I would love for someone to check this before merging.