### PR TITLE
Add support for Site Title step in signup

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -65,6 +65,6 @@
 	[ "signupStoreBenchmarking_20160927", "pressable" ],
 	[ "signupThemeUpload_20160928", "hideThemeUpload" ],
 	[ "signupSurveyStep_20161005", "surveyStepV1" ],
-	[ "siteTitleStep_20160928", "hideSiteTitleStep" ]
+	[ "siteTitleStep_20160928", "showSiteTitleStep" ]
   ]
 }

--- a/config/default.json
+++ b/config/default.json
@@ -56,7 +56,7 @@
         "version": "11.103"
     }
   },
-  "knownABTestKeys": [ "multiDomainRegistrationV1", "signupStore", "signupStoreBenchmarking",  "coldStartReader", "browserNotifications", "domainSuggestionPopover", "paidNuxStreamlined", "plansDescriptions", "domainSuggestionClickableRow", "verticalScreenshots", "signupThemeUpload", "signupSurveyStep" ],
+  "knownABTestKeys": [ "multiDomainRegistrationV1", "signupStore", "signupStoreBenchmarking",  "coldStartReader", "browserNotifications", "domainSuggestionPopover", "paidNuxStreamlined", "plansDescriptions", "domainSuggestionClickableRow", "verticalScreenshots", "signupThemeUpload", "signupSurveyStep", "siteTitleStep" ],
   "overrideABTests": [
 	[ "signupStore_20160927", "designTypeWithStore" ],
 	[ "browserNotifications_20160628", "disabled" ],
@@ -64,6 +64,7 @@
 	[ "domainSuggestionClickableRow_20160802", "clickableButton"],
 	[ "signupStoreBenchmarking_20160927", "pressable" ],
 	[ "signupThemeUpload_20160928", "hideThemeUpload" ],
-	[ "signupSurveyStep_20161005", "surveyStepV1" ]
+	[ "signupSurveyStep_20161005", "surveyStepV1" ],
+	[ "siteTitleStep_20160928", "hideSiteTitleStep" ]
   ]
 }

--- a/lib/pages/signup/site-title-page.js
+++ b/lib/pages/signup/site-title-page.js
@@ -1,0 +1,15 @@
+import { By } from 'selenium-webdriver';
+import BaseContainer from '../../base-container';
+import * as driverHelper from '../../driver-helper';
+
+export default class SiteTitlePage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.signup-site-title' ) );
+		this.titleInput = By.className( 'signup-site-title__input' );
+		this.continueButton = By.className( 'signup-site-title__button' );
+	}
+	setSiteTitle( title ) {
+		driverHelper.setWhenSettable( this.driver, this.titleInput, title );
+		return driverHelper.clickWhenClickable( this.driver, this.continueButton );
+	}
+}

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1,7 +1,6 @@
 import test from 'selenium-webdriver/testing';
 import config from 'config';
 import assert from 'assert';
-import * as ccGenerator from 'creditcard-generator';
 
 import * as driverManager from '../lib/driver-manager.js';
 import * as dataHelper from '../lib/data-helper.js';
@@ -12,6 +11,7 @@ import StartPage from '../lib/pages/signup/start-page.js';
 import StartPremiumPage from '../lib/pages/signup/start-premium-page.js';
 import StartBusinessPage from '../lib/pages/signup/start-business-page.js';
 import SurveyPage from '../lib/pages/signup/survey-page.js';
+import SiteTitlePage from '../lib/pages/signup/site-title-page.js';
 import DesignTypeChoicePage from '../lib/pages/signup/design-type-choice-page.js';
 import PickAPlanPage from '../lib/pages/signup/pick-a-plan-page.js';
 import CreateYourAccountPage from '../lib/pages/signup/create-your-account-page.js';
@@ -51,6 +51,7 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 
 	test.describe( 'Sign up for a free site', function() {
 		this.bailSuite( true );
+		let stepNum = 1;
 
 		const blogName = dataHelper.getNewBlogName();
 		let newBlogAddress = '';
@@ -63,7 +64,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 			return driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		test.describe( 'Step One: Survey', function() {
+		test.describe( `Step ${stepNum}: Survey`, function() {
+			stepNum++;
+
 			test.it( 'When we visit the start URL we see the survey page', function() {
 				this.startPage = new StartPage( driver, { visit: true } );
 				this.surveyPage = new SurveyPage( driver );
@@ -76,7 +79,24 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 				this.surveyPage.selectFirstSurveyOptions();
 			} );
 
-			test.describe( 'Step Two: Design Type Choice', function() {
+			test.describe( `Step ${stepNum}: Site Title`, function() {
+				stepNum++;
+
+				test.it( 'Can see the site title page', function() {
+					this.siteTitlePage = new SiteTitlePage( driver );
+					return this.siteTitlePage.displayed().then( ( displayed ) => {
+						return assert.equal( displayed, true, 'The site title page is not displayed' );
+					} );
+				} );
+
+				test.it( 'Can set the site title', function() {
+					return this.siteTitlePage.setSiteTitle( blogName );
+				} );
+			} );
+
+			test.describe( `Step ${stepNum}: Design Type Choice`, function() {
+				stepNum++;
+
 				test.it( 'Can see the design type choice page', function() {
 					this.designTypeChoicePage = new DesignTypeChoicePage( driver );
 					return this.designTypeChoicePage.displayed().then( ( displayed ) => {
@@ -88,7 +108,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 					this.designTypeChoicePage.selectFirstDesignType();
 				} );
 
-				test.describe( 'Step Three: Themes', function() {
+				test.describe( `Step ${stepNum}: Themes`, function() {
+					stepNum++;
+
 					test.it( 'Can see the choose a theme page', function() {
 						this.chooseAThemePage = new ChooseAThemePage( driver );
 						return this.chooseAThemePage.displayed().then( ( displayed ) => {
@@ -100,7 +122,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 						this.chooseAThemePage.selectFirstTheme();
 					} );
 
-					test.describe( 'Step Four: Domains', function() {
+					test.describe( `Step ${stepNum}: Domains`, function() {
+						stepNum++;
+
 						test.it( 'Can then see the domains page ', function() {
 							this.findADomainComponent = new FindADomainComponent( driver );
 							return this.findADomainComponent.displayed().then( ( displayed ) => {
@@ -118,7 +142,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 							return this.findADomainComponent.selectFreeAddress();
 						} );
 
-						test.describe( 'Step Five: Plans', function() {
+						test.describe( `Step ${stepNum}: Plans`, function() {
+							stepNum++;
+
 							test.it( 'Can then see the plans page', function() {
 								this.pickAPlanPage = new PickAPlanPage( driver );
 								return this.pickAPlanPage.displayed().then( ( displayed ) => {
@@ -130,7 +156,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 								return this.pickAPlanPage.selectFreePlan();
 							} );
 
-							test.describe( 'Step Six: Account', function() {
+							test.describe( `Step ${stepNum}: Account`, function() {
+								stepNum++;
+
 								test.it( 'Can then see the account page', function() {
 									this.createYourAccountPage = new CreateYourAccountPage( driver );
 									return this.createYourAccountPage.displayed().then( ( displayed ) => {
@@ -142,7 +170,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 									return this.createYourAccountPage.enterAccountDetailsAndSubmit( emailAddress, blogName, password );
 								} );
 
-								test.describe( 'Step Seven: Sign Up Processing', function() {
+								test.describe( `Step ${stepNum}: Sign Up Processing`, function() {
+									stepNum++;
+
 									test.it( 'Can then see the sign up processing page', function() {
 										this.signupProcessingPage = new SignupProcessingPage( driver );
 										return this.signupProcessingPage.displayed().then( ( displayed ) => {
@@ -158,7 +188,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 										this.signupProcessingPage.continueAlong();
 									} );
 
-									test.describe( 'Step Eight: View Site/Trampoline', function() {
+									test.describe( `Step ${stepNum}: View Site/Trampoline`, function() {
+										stepNum++;
+
 										test.it( 'We are on the view blog page, can see trampoline, our URL and title', function() {
 											return this.viewBlogPage = new ViewBlogPage( driver );
 										} );
@@ -178,11 +210,13 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 
 										test.it( 'Can see the correct blog title displayed', function() {
 											return this.viewBlogPage.title().then( ( title ) => {
-												return assert.equal( title, 'Site Title', 'The expected blog title is not displaying correctly' );
+												return assert.equal( title, blogName, 'The expected blog title is not displaying correctly' );
 											} );
 										} );
 
-										test.describe( 'Step Nine: Can activate my account from an email', function() {
+										test.describe( `Step ${stepNum}: Can activate my account from an email`, function() {
+											stepNum++;
+
 											test.before( function() {
 												return this.emailClient = new EmailClient( signupInboxId );
 											} );
@@ -205,6 +239,7 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 
 	test.describe( 'Sign up for a site on a premium paid plan through main flow', function() {
 		this.bailSuite( true );
+		let stepNum = 1;
 
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
@@ -228,7 +263,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 			this.WPHomePage.setSandboxModeForPayments( sandboxCookieValue );
 		} );
 
-		test.describe( 'Step One: Survey', function() {
+		test.describe( `Step One: Survey`, function() {
+			stepNum++;
+
 			test.it( 'When we visit the start URL we see the survey page', function() {
 				this.startPage = new StartPage( driver, { visit: true } );
 				this.surveyPage = new SurveyPage( driver );
@@ -241,7 +278,24 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 				this.surveyPage.selectFirstSurveyOptions();
 			} );
 
-			test.describe( 'Step Two: Design Type Choice', function() {
+			test.describe( `Step ${stepNum}: Site Title`, function() {
+				stepNum++;
+
+				test.it( 'Can see the site title page', function() {
+					this.siteTitlePage = new SiteTitlePage( driver );
+					return this.siteTitlePage.displayed().then( ( displayed ) => {
+						return assert.equal( displayed, true, 'The site title page is not displayed' );
+					} );
+				} );
+
+				test.it( 'Can set the site title', function() {
+					return this.siteTitlePage.setSiteTitle( blogName );
+				} );
+			} );
+
+			test.describe( `Step ${stepNum}: Design Type Choice`, function() {
+				stepNum++;
+
 				test.it( 'Can see the design type choice page', function() {
 					this.designTypeChoicePage = new DesignTypeChoicePage( driver );
 					return this.designTypeChoicePage.displayed().then( ( displayed ) => {
@@ -253,7 +307,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 					this.designTypeChoicePage.selectFirstDesignType();
 				} );
 
-				test.describe( 'Step Three: Themes', function() {
+				test.describe( `Step ${stepNum}: Themes`, function() {
+					stepNum++;
+
 					test.it( 'Can see the choose a theme page as the starting page', function() {
 						this.chooseAThemePage = new ChooseAThemePage( driver );
 						return this.chooseAThemePage.displayed().then( ( displayed ) => {
@@ -265,7 +321,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 						return this.chooseAThemePage.selectFirstTheme();
 					} );
 
-					test.describe( 'Step Four: Domains', function() {
+					test.describe( `Step ${stepNum}: Domains`, function() {
+						stepNum++;
+
 						test.it( 'Can then see the domains page ', function() {
 							this.findADomainComponent = new FindADomainComponent( driver );
 							return this.findADomainComponent.displayed().then( ( displayed ) => {
@@ -282,7 +340,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 							return this.findADomainComponent.selectFreeAddress();
 						} );
 
-						test.describe( 'Step Five: Plans', function() {
+						test.describe( `Step ${stepNum}: Plans`, function() {
+							stepNum++;
+
 							test.it( 'Can then see the plans page', function() {
 								this.pickAPlanPage = new PickAPlanPage( driver );
 								return this.pickAPlanPage.displayed().then( ( displayed ) => {
@@ -294,7 +354,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 								return this.pickAPlanPage.selectPremiumPlan();
 							} );
 
-							test.describe( 'Step Six: Account', function() {
+							test.describe( `Step ${stepNum}: Account`, function() {
+								stepNum++;
+
 								test.it( 'Can then enter account details', function() {
 									this.createYourAccountPage = new CreateYourAccountPage( driver );
 									this.createYourAccountPage.displayed().then( ( displayed ) => {
@@ -303,7 +365,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 									return this.createYourAccountPage.enterAccountDetailsAndSubmit( emailAddress, blogName, password );
 								} );
 
-								test.describe( 'Step Seven: Processing', function() {
+								test.describe( `Step ${stepNum}: Processing`, function() {
+									stepNum++;
+
 									test.it( 'Can then see the sign up processing page', function() {
 										this.signupProcessingPage = new SignupProcessingPage( driver );
 										return this.signupProcessingPage.displayed().then( ( displayed ) => {
@@ -315,7 +379,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 										this.signupProcessingPage.waitToDisappear();
 									} );
 
-									test.describe( 'Step Eight: Secure Payment Page', function() {
+									test.describe( `Step ${stepNum}: Secure Payment Page`, function() {
+										stepNum++;
+
 										test.it( 'Can then see the secure payment page', function() {
 											this.securePaymentComponent = new SecurePaymentComponent( driver );
 											return this.securePaymentComponent.displayed().then( ( displayed ) => {
@@ -329,7 +395,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 											return this.securePaymentComponent.waitForPageToDisappear();
 										} );
 
-										test.describe( 'Step Nine: Checkout Thank You Page', function() {
+										test.describe( `Step ${stepNum}: Checkout Thank You Page`, function() {
+											stepNum++;
+
 											test.it( 'Can see the secure check out thank you page', function() {
 												this.CheckOutThankyouPage = new CheckOutThankyouPage( driver );
 												return this.CheckOutThankyouPage.displayed().then( ( displayed ) => {
@@ -349,6 +417,7 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 
 	test.describe( 'Sign up for a site on a premium paid plan coming in via /create as premium flow', function() {
 		this.bailSuite( true );
+		let stepNum = 1;
 
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
@@ -372,7 +441,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 			this.WPHomePage.setSandboxModeForPayments( sandboxCookieValue );
 		} );
 
-		test.describe( 'Step One: Survey', function() {
+		test.describe( `Step ${stepNum}: Survey`, function() {
+			stepNum++;
+
 			test.it( 'When we visit the /start/premium URL we see the survey page', function() {
 				this.startPage = new StartPremiumPage( driver, { visit: true } );
 				this.surveyPage = new SurveyPage( driver );
@@ -385,7 +456,24 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 				this.surveyPage.selectFirstSurveyOptions();
 			} );
 
-			test.describe( 'Step Two: Design Type Choice', function() {
+			test.xdescribe( `Step ${stepNum}: Site Title`, function() {
+				stepNum++;
+
+				test.it( 'Can see the site title page', function() {
+					this.siteTitlePage = new SiteTitlePage( driver );
+					return this.siteTitlePage.displayed().then( ( displayed ) => {
+						return assert.equal( displayed, true, 'The site title page is not displayed' );
+					} );
+				} );
+
+				test.it( 'Can set the site title', function() {
+					return this.siteTitlePage.setSiteTitle( blogName );
+				} );
+			} );
+
+			test.describe( `Step ${stepNum}: Design Type Choice`, function() {
+				stepNum++;
+
 				test.it( 'Can see the design type choice page', function() {
 					this.designTypeChoicePage = new DesignTypeChoicePage( driver );
 					return this.designTypeChoicePage.displayed().then( ( displayed ) => {
@@ -397,7 +485,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 					this.designTypeChoicePage.selectFirstDesignType();
 				} );
 
-				test.describe( 'Step Three: Themes', function() {
+				test.describe( `Step ${stepNum}: Themes`, function() {
+					stepNum++;
+
 					test.it( 'Can see the choose a theme page as the starting page', function() {
 						this.chooseAThemePage = new ChooseAThemePage( driver );
 						return this.chooseAThemePage.displayed().then( ( displayed ) => {
@@ -409,7 +499,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 						return this.chooseAThemePage.selectFirstTheme();
 					} );
 
-					test.describe( 'Step Four: Domains', function() {
+					test.describe( `Step ${stepNum}: Domains`, function() {
+						stepNum++;
+
 						test.it( 'Can then see the domains page ', function() {
 							this.findADomainComponent = new FindADomainComponent( driver );
 							return this.findADomainComponent.displayed().then( ( displayed ) => {
@@ -426,7 +518,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 							return this.findADomainComponent.selectFreeAddress();
 						} );
 
-						test.describe( 'Step Five: Account', function() {
+						test.describe( `Step ${stepNum}: Account`, function() {
+							stepNum++;
+
 							test.it( 'Can then enter account details', function() {
 								this.createYourAccountPage = new CreateYourAccountPage( driver );
 								this.createYourAccountPage.displayed().then( ( displayed ) => {
@@ -435,7 +529,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 								return this.createYourAccountPage.enterAccountDetailsAndSubmit( emailAddress, blogName, password );
 							} );
 
-							test.describe( 'Step Six: Processing', function() {
+							test.describe( `Step ${stepNum}: Processing`, function() {
+								stepNum++;
+
 								test.it( 'Can then see the sign up processing page', function() {
 									this.signupProcessingPage = new SignupProcessingPage( driver );
 									return this.signupProcessingPage.displayed().then( ( displayed ) => {
@@ -455,7 +551,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 									this.signupProcessingPage.continueAlong();
 								} );
 
-								test.describe( 'Step Seven: Secure Payment Page', function() {
+								test.describe( `Step ${stepNum}: Secure Payment Page`, function() {
+									stepNum++;
+
 									test.it( 'Can then see the secure payment page', function() {
 										this.securePaymentComponent = new SecurePaymentComponent( driver );
 										return this.securePaymentComponent.displayed().then( ( displayed ) => {
@@ -469,7 +567,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 										return this.securePaymentComponent.waitForPageToDisappear();
 									} );
 
-									test.describe( 'Step Eight: Checkout Thank You Page', function() {
+									test.describe( `Step ${stepNum}: Checkout Thank You Page`, function() {
+										stepNum++;
+
 										test.it( 'Can see the secure check out thank you page', function() {
 											this.CheckOutThankyouPage = new CheckOutThankyouPage( driver );
 											return this.CheckOutThankyouPage.displayed().then( ( displayed ) => {
@@ -488,6 +588,7 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 
 	test.describe( 'Partially sign up for a site on a business paid plan w/ domain name coming in via /create as business flow', function() {
 		this.bailSuite( true );
+		let stepNum = 1;
 
 		const siteName = dataHelper.getNewBlogName();
 		const emailName = new Date().getTime().toString();
@@ -519,7 +620,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 			this.WPHomePage.setSandboxModeForPayments( sandboxCookieValue );
 		} );
 
-		test.describe( 'Step One: Survey', function() {
+		test.describe( `Step ${stepNum}: Survey`, function() {
+			stepNum++;
+
 			test.it( 'When we visit the /start/business URL we see the survey page', function() {
 				this.startPage = new StartBusinessPage( driver, { visit: true } );
 				this.surveyPage = new SurveyPage( driver );
@@ -532,7 +635,24 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 				this.surveyPage.selectFirstSurveyOptions();
 			} );
 
-			test.describe( 'Step Two: Design Type Choice', function() {
+			test.xdescribe( `Step ${stepNum}: Site Title`, function() {
+				stepNum++;
+
+				test.it( 'Can see the site title page', function() {
+					this.siteTitlePage = new SiteTitlePage( driver );
+					return this.siteTitlePage.displayed().then( ( displayed ) => {
+						return assert.equal( displayed, true, 'The site title page is not displayed' );
+					} );
+				} );
+
+				test.it( 'Can set the site title', function() {
+					return this.siteTitlePage.setSiteTitle( siteName );
+				} );
+			} );
+
+			test.describe( `Step ${stepNum}: Design Type Choice`, function() {
+				stepNum++;
+
 				test.it( 'Can see the design type choice page', function() {
 					this.designTypeChoicePage = new DesignTypeChoicePage( driver );
 					return this.designTypeChoicePage.displayed().then( ( displayed ) => {
@@ -544,7 +664,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 					this.designTypeChoicePage.selectFirstDesignType();
 				} );
 
-				test.describe( 'Step Three: Themes', function() {
+				test.describe( `Step ${stepNum}: Themes`, function() {
+					stepNum++;
+
 					test.it( 'Can see the choose a theme page as the starting page', function() {
 						this.chooseAThemePage = new ChooseAThemePage( driver );
 						return this.chooseAThemePage.displayed().then( ( displayed ) => {
@@ -556,7 +678,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 						return this.chooseAThemePage.selectFirstTheme();
 					} );
 
-					test.describe( 'Step Four: Domains', function() {
+					test.describe( `Step ${stepNum}: Domains`, function() {
+						stepNum++;
+
 						test.it( 'Can then see the domains page ', function() {
 							this.findADomainComponent = new FindADomainComponent( driver );
 							return this.findADomainComponent.displayed().then( ( displayed ) => {
@@ -570,7 +694,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 							return this.findADomainComponent.declineGoogleApps();
 						} );
 
-						test.describe( 'Step Five: Account', function() {
+						test.describe( `Step ${stepNum}: Account`, function() {
+							stepNum++;
+
 							test.it( 'Can then enter account details', function() {
 								this.createYourAccountPage = new CreateYourAccountPage( driver );
 								this.createYourAccountPage.displayed().then( ( displayed ) => {
@@ -579,7 +705,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 								return this.createYourAccountPage.enterAccountDetailsAndSubmit( emailAddress, siteName, password );
 							} );
 
-							test.describe( 'Step Six: Processing', function() {
+							test.describe( `Step ${stepNum}: Processing`, function() {
+								stepNum++;
+
 								test.it( 'Can then see the sign up processing page', function() {
 									this.signupProcessingPage = new SignupProcessingPage( driver );
 									return this.signupProcessingPage.displayed().then( ( displayed ) => {
@@ -591,7 +719,9 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 									this.signupProcessingPage.waitToDisappear();
 								} );
 
-								test.describe( 'Step Seven: Secure Payment Page', function() {
+								test.describe( `Step ${stepNum}: Secure Payment Page`, function() {
+									stepNum++;
+
 									test.it( 'Can see checkout page', () => {
 										this.checkOutPage = new CheckOutPage( driver );
 										this.checkOutPage.displayed().then( ( displayed ) => {


### PR DESCRIPTION
Forces the AB test key siteTitleStep to showSiteTitleStep, which adds a new step to the signup flow, and then sets the site title to the blog's name.

This PR also dynamically numbers the steps in the spec file, so we can add/remove/move steps without editing each describe block further down the line.
