### PR TITLE
Reworked actions on the Customizer page to hopefully avoid timing races

### DIFF
--- a/lib/pages/customizer-page.js
+++ b/lib/pages/customizer-page.js
@@ -30,7 +30,7 @@ export default class CustomizerPage extends BaseContainer {
 
 	waitForCustomizer() {
 		const self = this;
-		self.driver.wait( until.elementLocated( this.metaiFrameElementSelector ), this.explicitWaitMS * 2 ).then( function() { }, function(error ) {
+		self.driver.wait( until.elementLocated( this.metaiFrameElementSelector ), this.explicitWaitMS * 2 ).then( function() { }, function( error ) {
 			const message = `Found issue on customizer page: '${error}' - Clicking try again button now.`;
 			slackNotifier.warn( message );
 			self.driver.wait( function() {
@@ -46,102 +46,124 @@ export default class CustomizerPage extends BaseContainer {
 	}
 
 	saveNewTheme() {
-		this._ensureMetaViewOnMobile();
-		this._switchToMetaiFrame();
-		this.driver.sleep( this.shortSleepMS ).then( () => {
-			return driverHelper.clickWhenClickable( this.driver, this.saveSelector );
+		const self = this;
+		self._ensureMetaViewOnMobile();
+		self._switchToMetaiFrame();
+		return self.driver.sleep( self.shortSleepMS ).then( () => {
+			return driverHelper.clickWhenClickable( self.driver, self.saveSelector ).then( () => {
+				return self._switchToDefaultContent();
+			} );
 		} );
-		return this._switchToDefaultContent();
 	}
 
 	close() {
-		this._ensureMetaViewOnMobile();
-		this._switchToMetaiFrame();
-		this.driver.sleep( this.shortSleepMS ).then( () => {
-			return driverHelper.clickWhenClickable( this.driver, by.css( '.customize-controls-close' ) );
+		const self = this;
+		self._ensureMetaViewOnMobile();
+		self._switchToMetaiFrame();
+		return self.driver.sleep( self.shortSleepMS ).then( () => {
+			return driverHelper.clickWhenClickable( self.driver, by.css( '.customize-controls-close' ) ).then( () => {
+				return self._switchToDefaultContent();
+			} );
 		} );
-		return this._switchToDefaultContent();
 	}
 
 	closeOpenSection() {
-		this._ensureMetaViewOnMobile();
-		this._switchToMetaiFrame();
-		this.driver.sleep( this.shortSleepMS ).then( () => {
-			return driverHelper.clickWhenClickable( this.driver, this.backSelector );
+		const self = this;
+		self._ensureMetaViewOnMobile();
+		self._switchToMetaiFrame();
+		return self.driver.sleep( self.shortSleepMS ).then( () => {
+			return driverHelper.clickWhenClickable( self.driver, self.backSelector ).then( () => {
+				return self._switchToDefaultContent();
+			} );
 		} );
-		return this._switchToDefaultContent();
 	}
 
 	closeOpenPanel() {
-		this._ensureMetaViewOnMobile();
-		this._switchToMetaiFrame();
-		this.driver.sleep( this.shortSleepMS ).then( () => {
-			return driverHelper.clickWhenClickable( this.driver, by.css( '.customize-panel-back[tabindex=\'0\']' ) );
+		const self = this;
+		self._ensureMetaViewOnMobile();
+		self._switchToMetaiFrame();
+		return self.driver.sleep( self.shortSleepMS ).then( () => {
+			return driverHelper.clickWhenClickable( self.driver, by.css( '.customize-panel-back[tabindex=\'0\']' ) ).then( () => {
+				return self._switchToDefaultContent();
+			} );
 		} );
-		return this._switchToDefaultContent();
 	}
 
 	expandSiteIdentity() {
-		this._ensureMetaViewOnMobile();
-		this._switchToMetaiFrame();
-		this.driver.sleep( this.shortSleepMS ).then( () => {
-			return driverHelper.clickWhenClickable( this.driver, by.css( 'li#accordion-section-title_tagline' ) );
+		const self = this;
+		self._ensureMetaViewOnMobile();
+		self._switchToMetaiFrame();
+		return self.driver.sleep( self.shortSleepMS ).then( () => {
+			return driverHelper.clickWhenClickable( self.driver, by.css( 'li#accordion-section-title_tagline' ) ).then( () => {
+				return self._switchToDefaultContent();
+			} );
 		} );
-		return this._switchToDefaultContent();
 	}
 
 	expandColorsAndBackgrounds() {
-		this._ensureMetaViewOnMobile();
-		this._switchToMetaiFrame();
-		this.driver.sleep( this.shortSleepMS ).then( () => {
-			return driverHelper.clickWhenClickable( this.driver, by.css( 'li#accordion-section-colors_manager_tool' ) );
+		const self = this;
+		self._ensureMetaViewOnMobile();
+		self._switchToMetaiFrame();
+		return self.driver.sleep( self.shortSleepMS ).then( () => {
+			return driverHelper.clickWhenClickable( self.driver, by.css( 'li#accordion-section-colors_manager_tool' ) ).then( () => {
+				return self._switchToDefaultContent();
+			} );
 		} );
-		return this._switchToDefaultContent();
 	}
 
 	expandFonts() {
-		this._ensureMetaViewOnMobile();
-		this._switchToMetaiFrame();
-		this.driver.sleep( this.shortSleepMS ).then( () => {
-			return driverHelper.clickWhenClickable( this.driver, by.css( 'li#accordion-section-jetpack_fonts' ) );
+		const self = this;
+		self._ensureMetaViewOnMobile();
+		self._switchToMetaiFrame();
+		return self.driver.sleep( self.shortSleepMS ).then( () => {
+			return driverHelper.clickWhenClickable( self.driver, by.css( 'li#accordion-section-jetpack_fonts' ) ).then( () => {
+				return self._switchToDefaultContent();
+			} );
 		} );
-		return this._switchToDefaultContent();
 	}
 
 	expandMenus() {
-		this._ensureMetaViewOnMobile();
-		this._switchToMetaiFrame();
-		this.driver.sleep( this.shortSleepMS ).then( () => {
-			return driverHelper.clickWhenClickable( this.driver, by.css( 'li#accordion-panel-nav_menus' ) );
+		const self = this;
+		self._ensureMetaViewOnMobile();
+		self._switchToMetaiFrame();
+		return self.driver.sleep( self.shortSleepMS ).then( () => {
+			return driverHelper.clickWhenClickable( self.driver, by.css( 'li#accordion-panel-nav_menus' ) ).then( () => {
+				return self._switchToDefaultContent();
+			} );
 		} );
-		return this._switchToDefaultContent();
 	}
 
 	expandWidgets() {
-		this._ensureMetaViewOnMobile();
-		this._switchToMetaiFrame();
-		this.driver.sleep( this.shortSleepMS ).then( () => {
-			driverHelper.clickWhenClickable( this.driver, by.css( 'li#accordion-panel-widgets' ) );
+		const self = this;
+		self._ensureMetaViewOnMobile();
+		self._switchToMetaiFrame();
+		return self.driver.sleep( self.shortSleepMS ).then( () => {
+			return driverHelper.clickWhenClickable( self.driver, by.css( 'li#accordion-panel-widgets' ) ).then( () => {
+				return self._switchToDefaultContent();
+			} );
 		} );
-		return this._switchToDefaultContent();
 	}
 
 	expandStaticFrontPage() {
-		this._ensureMetaViewOnMobile();
-		this._switchToMetaiFrame();
-		this.driver.sleep( this.shortSleepMS ).then( () => {
-			driverHelper.clickWhenClickable( this.driver, by.css( 'li#accordion-section-static_front_page' ) );
+		const self = this;
+		self._ensureMetaViewOnMobile();
+		self._switchToMetaiFrame();
+		return self.driver.sleep( self.shortSleepMS ).then( () => {
+			return driverHelper.clickWhenClickable( self.driver, by.css( 'li#accordion-section-static_front_page' ) ).then( () => {
+				return self._switchToDefaultContent();
+			} );
 		} );
-		return this._switchToDefaultContent();
 	}
 
 	expandHeaderImage() {
-		this._ensureMetaViewOnMobile();
-		this._switchToMetaiFrame();
-		this.driver.sleep( this.shortSleepMS ).then( () => {
-			return driverHelper.clickWhenClickable( this.driver, by.css( 'li#accordion-section-header_image' ) );
+		const self = this;
+		self._ensureMetaViewOnMobile();
+		self._switchToMetaiFrame();
+		return self.driver.sleep( self.shortSleepMS ).then( () => {
+			return driverHelper.clickWhenClickable( self.driver, by.css( 'li#accordion-section-header_image' ) ).then( () => {
+				return self._switchToDefaultContent();
+			} );
 		} );
-		return this._switchToDefaultContent();
 	}
 
 	chooseFirstHeadingsFont() {
@@ -259,7 +281,7 @@ export default class CustomizerPage extends BaseContainer {
 		this._switchToMetaiFrame();
 		present = this.driver.wait( until.elementLocated( this.siteTitleSelector ), this.explicitWaitMS ).then( () => {
 			return true;
-		}, ( err ) => {
+		}, () => {
 			return false;
 		} );
 		this._switchToDefaultContent();


### PR DESCRIPTION
Most of the actions in the Customizer page have a short sleep statement to allow for iFrame switching.  This PR just moves the action after that switch into a `.then()` block to ensure the switch is done before moving on.