### PR TITLE
Added error handling and debug support for Applitools / Sauce Labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ A full list of config values are:
 | Name | Description | Example | Required | Store in file? |
 | ---- | ----------- | ------- | -------- | ------------------- |
 | slackToken | This is a token for uploading files/screenshots to Slack (https://api.slack.com/tokens -- requires Slack login) | xxxx-##########-##########-###########-XXXXXXXXXX | No | **NO** |
+| EYESDEBUG | If this is set, no connection is opened to Applitools, only local screenshots are taken | 1 | No | **NO** |
+| SAUCEDEBUG | If this is set, on test failure a breakpoint will be set in SauceLabs, enabling you to continue interacting with the browser for troubleshooting | 1 | No | **NO** |
 
 #### CircleCI Environment Variables
 These environment variables are intended for use inside CircleCI, to control which tests are being run

--- a/lib/after.js
+++ b/lib/after.js
@@ -15,8 +15,8 @@ var allPassed = true; // For SauceLabs status
 test.afterEach( 'Sauce Breakpoint', function() {
 	const driver = global.__BROWSER__;
 
-	if ( this.currentTest.state === 'failed' && config.has( 'sauce' ) && config.get( 'sauce' ) ) {
-		driver.execute( 'sauce: break' );
+	if ( process.env.SAUCEDEBUG && this.currentTest.state === 'failed' && config.has( 'sauce' ) && config.get( 'sauce' ) ) {
+		driver.executeScript( 'sauce: break' );
 	}
 } );
 
@@ -117,7 +117,7 @@ test.afterEach( 'Check for console errors', function() {
 test.afterEach( 'Update Sauce Job Status locally', function() {
 	const driver = global.__BROWSER__;
 
-	if ( config.has( 'sauce' ) && config.get( 'sauce' ) ) {
+	if ( false && config.has( 'sauce' ) && config.get( 'sauce' ) ) {
 		driver.allPassed = driver.allPassed && this.currentTest.state === 'passed'
 	}
 } );

--- a/lib/after.js
+++ b/lib/after.js
@@ -12,6 +12,14 @@ import * as driverHelper from './driver-helper';
 const afterHookTimeoutMS = config.get( 'afterHookTimeoutMS' );
 var allPassed = true; // For SauceLabs status
 
+test.afterEach( 'Sauce Breakpoint', function() {
+	const driver = global.__BROWSER__;
+
+	if ( this.currentTest.state === 'failed' && config.has( 'sauce' ) && config.get( 'sauce' ) ) {
+		driver.execute( 'sauce: break' );
+	}
+} );
+
 test.afterEach( 'Take Screenshot', function() {
 	this.timeout( afterHookTimeoutMS );
 	allPassed = allPassed && this.currentTest.state === 'passed';

--- a/lib/after.js
+++ b/lib/after.js
@@ -117,7 +117,7 @@ test.afterEach( 'Check for console errors', function() {
 test.afterEach( 'Update Sauce Job Status locally', function() {
 	const driver = global.__BROWSER__;
 
-	if ( false && config.has( 'sauce' ) && config.get( 'sauce' ) ) {
+	if ( config.has( 'sauce' ) && config.get( 'sauce' ) ) {
 		driver.allPassed = driver.allPassed && this.currentTest.state === 'passed'
 	}
 } );

--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -3,6 +3,7 @@ import config from 'config';
 import * as driverManager from './driver-manager.js';
 import {forEach} from 'lodash';
 import * as SlackNotifier from './slack-notifier.js';
+import * as mediaHelper from './media-helper';
 
 const explicitWaitMS = config.get( 'explicitWaitMS' );
 const by = webdriver.By;
@@ -250,6 +251,12 @@ export function checkForConsoleErrors( driver ) {
 export function eyesScreenshot( driver, eyes, pageName, selector ) {
 	let browserName = global.browserName || 'chrome';
 	console.log( `eyesScreenshot - ${pageName} - [${browserName}][${driverManager.currentScreenSize()}]` );
+
+	if ( process.env.EYESDEBUG ) {
+		return driver.takeScreenshot().then( ( data ) => {
+			mediaHelper.writeScreenshot( data, `EYES-${pageName}-${driverManager.currentScreenSize()}` );
+		} );
+	}
 
 	// Remove focus to avoid blinking cursors in input fields
 	// -- Works in Firefox, but not Chrome, at least on OSX I believe due to a

--- a/lib/pages/devdocs-page.js
+++ b/lib/pages/devdocs-page.js
@@ -35,7 +35,9 @@ export default class DevdocsPage extends BaseContainer {
 	openAppComponents() {
 		var url = this.baseURL + '/blocks';
 
-		return this.driver.get( url );
+		return this.driver.get( url ).then( function() {}, function() {
+			slackWarn( `[${global.browserName}][${currentScreenSize()}] - Driver claims to have failed to get /devdocs/blocks.  Moving on anyway.` );
+		} );
 	}
 
 	getAllDesignElementLinks() {

--- a/lib/pages/devdocs-page.js
+++ b/lib/pages/devdocs-page.js
@@ -1,5 +1,7 @@
 import webdriver from 'selenium-webdriver';
-import * as driverHelper from '../driver-helper.js'
+import { eyesScreenshot } from '../driver-helper.js'
+import { warn as slackWarn } from '../slack-notifier';
+import { currentScreenSize } from '../driver-manager';
 import BaseContainer from '../base-container.js';
 
 const by = webdriver.By;
@@ -102,6 +104,8 @@ export default class DevdocsPage extends BaseContainer {
 					let titleSplit = href.split( '/' );
 					title = titleSplit[ titleSplit.length - 1 ];
 					return driver.get( href );
+				} ).then( function() {}, function() {
+					slackWarn( `[${global.browserName}][${currentScreenSize()}] - Driver claims to have failed to get ${title}.  Moving on anyway.` );
 				} );
 				// Hide the masterbar for clean CSS stitching
 				flow.execute( function() {
@@ -113,7 +117,7 @@ export default class DevdocsPage extends BaseContainer {
 				} );
 				// Take the screenshot
 				flow.execute( function() {
-					return driverHelper.eyesScreenshot( driver, eyes, title, by.id( 'primary' ) );
+					return eyesScreenshot( driver, eyes, title, by.id( 'primary' ) );
 				} );
 				// Check for Compact button
 				flow.execute( function() {
@@ -123,12 +127,12 @@ export default class DevdocsPage extends BaseContainer {
 								// Some browsers need a more precise click on the mobile width to avoid overlapping elements
 								if ( global.browserName.toLowerCase() === 'chrome' || global.browserName.toLowerCase() === 'firefox' ) {
 									return driver.actions().mouseMove( button, {x: 3, y: 3} ).click().perform().then( function() {
-										return driverHelper.eyesScreenshot( driver, eyes, title + ' (Compact)', by.id( 'primary' ) );
+										return eyesScreenshot( driver, eyes, title + ' (Compact)', by.id( 'primary' ) );
 									} );
 								}
 
 								return button.click().then( function() {
-									return driverHelper.eyesScreenshot( driver, eyes, title + ' (Compact)', by.id( 'primary' ) );
+									return eyesScreenshot( driver, eyes, title + ' (Compact)', by.id( 'primary' ) );
 								} );
 							} );
 						}

--- a/specs-visdiff/wp-devdocs-visdiff.js
+++ b/specs-visdiff/wp-devdocs-visdiff.js
@@ -45,7 +45,10 @@ test.describe( `DevDocs Visual Diff (${screenSizeName})`, function() {
 			eyes.setBatch( batchName, `wp-e2e-tests-visdiff-${global.browserName}-${process.env.CIRCLE_BUILD_NUM}` );
 		}
 
-		eyes.open( driver, 'WordPress.com', testName, screenSize );
+		if ( ! process.env.EYESDEBUG ) {
+			eyes.open( driver, 'WordPress.com', testName, screenSize );
+		}
+
 		let loginFlow = new LoginFlow( driver );
 		loginFlow.login();
 
@@ -98,7 +101,9 @@ test.describe( `DevDocs Visual Diff (${screenSizeName})`, function() {
 				}
 			} );
 		} finally {
-			eyes.abortIfNotClosed();
+			if ( ! process.env.EYESDEBUG ) {
+				eyes.abortIfNotClosed();
+			}
 		}
 	} );
 } );


### PR DESCRIPTION
Running the visdiff tests against IE11 in Sauce Labs it frequently crashes when loading the https://wpcalypso.wordpress.com/devdocs/blocks page, or one of the components therein.  The page actually loads fine, but Webdriver seems to never get the message that it's done so it times out.

This PR just adds an error handling function that sends a Slack warning when that happens, and moves on.  It doesn't change the processing of the test in any way.

It also adds support for environment variables:

`EYESDEBUG` - If this is set it doesn't open a connection to Applitools, and only screenshots locally
`SAUCEDEBUG` - On test failure it sets a breakpoint in SauceLabs so it doesn't close the connection, enabling you to continue manually interacting with the browser to diagnose the problem.