### PR TITLE
Update/make e2e tests more deterministic

### DIFF
--- a/lib/base-container.js
+++ b/lib/base-container.js
@@ -1,4 +1,3 @@
-import webdriver from 'selenium-webdriver';
 import config from 'config';
 import assert from 'assert';
 
@@ -7,7 +6,6 @@ import * as driverHelper from './driver-helper';
 import * as mediaHelper from './media-helper';
 import * as slackNotifier from './slack-notifier';
 
-const until = webdriver.until;
 
 export default class BaseContainer {
 	constructor( driver, expectedElementSelector, visit = false, url = null ) {
@@ -38,11 +36,11 @@ export default class BaseContainer {
 	}
 
 	waitForPage() {
-		this.driver.wait( until.elementLocated( this.expectedElementSelector ), this.explicitWaitMS, 'Could not locate the ' + this.expectedElementSelector.value + ' element. Check that is is displayed.' );
+		return driverHelper.waitTillPresentAndDisplayed( this.driver, this.expectedElementSelector, this.explicitWaitMS );
 	}
 
 	displayed() {
-		return this.driver.isElementPresent( this.expectedElementSelector );
+		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, this.expectedElementSelector, this.explicitWaitMS );
 	}
 
 	title() {

--- a/lib/pages/signup/signup-processing-page.js
+++ b/lib/pages/signup/signup-processing-page.js
@@ -48,6 +48,11 @@ export default class SignupProcessingPage extends BaseContainer {
 			return self.driver.isElementPresent( self.expectedElementSelector ).then( ( present ) => {
 				return !present;
 			} );
-		}, this.explicitWaitMS * 2, 'The Signup Processing Page is still present when it should have automatically disappeared' );
+		}, this.explicitWaitMS * 2 ).then( () => {
+			return true;
+		}, () => {
+			slackNotifier.warn( 'The Signup Processing Page is still present when it should have automatically disappeared, trying a refresh' );
+			return self.driver.navigate().refresh();
+		} );
 	}
 }

--- a/lib/pages/signup/signup-processing-page.js
+++ b/lib/pages/signup/signup-processing-page.js
@@ -18,7 +18,12 @@ export default class SignupProcessingPage extends BaseContainer {
 			return self.driver.findElement( self.continueButtonSelector ).getAttribute( 'disabled' ).then( ( d ) => {
 				return d !== 'true';
 			} );
-		}, this.explicitWaitMS * 2, 'The continue button on the sign up processing page is still disabled after waiting for it to become enabled' );
+		}, this.explicitWaitMS * 2 ).then( () => {
+			return true;
+		}, () => {
+			slackNotifier.warn( 'The continue button on the sign up processing page is still disabled after waiting for it to become enabled, refreshing the page to see whether this fixes the issue' );
+			return self.driver.navigate().refresh();
+		} );
 	}
 
 	continueAlong() {


### PR DESCRIPTION
I noticed quite a few tests failing on the base page method waitForPage() with errors coming back from Chrome like `TimeoutError: timeout: cannot determine loading status`
We weren't handling any errors like this during a wait which could cause more failures.
We do handle these in driverHelper methods, which are now called from the base page class.