### PR TITLE
Fix signup test after PR #9309

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -56,12 +56,11 @@
         "version": "11.103"
     }
   },
-  "knownABTestKeys": [ "multiDomainRegistrationV1", "signupStore", "signupStoreBenchmarking",  "coldStartReader", "browserNotifications", "domainSuggestionPopover", "paidNuxStreamlined", "plansDescriptions", "domainSuggestionClickableRow", "verticalScreenshots", "signupThemeUpload", "signupSurveyStep", "siteTitleStep", "gSuiteOnSignup", "paidNuxThankYouPage", "jetpackConnectPlansFirst", "domainDotBlogSubdomain" ],
+  "knownABTestKeys": [ "multiDomainRegistrationV1", "signupStore", "signupStoreBenchmarking",  "coldStartReader", "browserNotifications", "domainSuggestionPopover", "paidNuxStreamlined", "plansDescriptions", "verticalScreenshots", "signupThemeUpload", "signupSurveyStep", "siteTitleStep", "gSuiteOnSignup", "paidNuxThankYouPage", "jetpackConnectPlansFirst", "domainDotBlogSubdomain" ],
   "overrideABTests": [
 	[ "signupStore_20160927", "designTypeWithStore" ],
 	[ "browserNotifications_20160628", "disabled" ],
 	[ "domainSuggestionPopover_20160809", "hidePopover" ],
-	[ "domainSuggestionClickableRow_20160802", "clickableButton"],
 	[ "signupStoreBenchmarking_20160927", "pressable" ],
 	[ "signupThemeUpload_20160928", "hideThemeUpload" ],
 	[ "signupSurveyStep_20161005", "surveyStepV1" ],

--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -52,7 +52,7 @@ export default class FindADomainComponent extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, selector, this.explicitWaitMS );
 	}
 	selectFreeAddress() {
-		const freeAddressSelector = By.css( '.domain-suggestion__action button.is-primary' );
+		const freeAddressSelector = By.css( '.domain-suggestion.is-clickable' );
 		return driverHelper.clickWhenClickable( this.driver, freeAddressSelector, this.explicitWaitMS );
 	}
 	selectMapOwnDomain() {


### PR DESCRIPTION
This PR fixes E2E tests after removing the A/B test on https://github.com/Automattic/wp-calypso/pull/9309