### PR TITLE
Add default variation for the noSurveyStep ABtest

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -67,6 +67,7 @@
 	[ "signupSurveyStep_20161005", "surveyStepV1" ],
 	[ "siteTitleStep_20160928", "hideSiteTitleStep" ],
 	[ "gSuiteOnSignup_20161025", "original" ],
-	[ "jetpackConnectPlansFirst_20161024", "showPlansAfterAuth" ]
+	[ "jetpackConnectPlansFirst_20161024", "showPlansAfterAuth" ],
+	[ "noSurveyStep_20161202", "showSurveyStep" ]
   ]
 }


### PR DESCRIPTION
This PR adds the default variation for the Automattic/wp-calypso#9789 PR, which will test the signup flows with and without the `survey` step.

While we're testing, we want to leave the tests to run with the default value.