### PR TITLE
Update the posts list page to not wait for images

### DIFF
--- a/lib/pages/posts-page.js
+++ b/lib/pages/posts-page.js
@@ -10,7 +10,7 @@ export default class PostsPage extends BaseContainer {
 
 	waitForPosts() {
 		const driver = this.driver;
-		const resultsLoadingSelector = By.css( '.posts__list .is-placeholder' );
+		const resultsLoadingSelector = By.css( '.posts__list .is-placeholder:not(.post-image)' );
 		driver.wait( function() {
 			return driver.isElementPresent( resultsLoadingSelector ).then( function( present ) {
 				return ! present;


### PR DESCRIPTION
Caters for changes introduced here: https://github.com/Automattic/wp-calypso/pull/9284