### PR TITLE
Added dot to country code in domain registrar details

### DIFF
--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -44,7 +44,7 @@ test.describe( 'Managing Domains: (' + screenSize + ')', function() {
 		const expectedDomainName = blogName + '.com';
 		const firstName = 'End to End';
 		const lastName = 'Testing';
-		const phoneNumber = '+0422888888';
+		const phoneNumber = '+04.22888888';
 		const countryCode = 'AU';
 		const address = '888 Queen Street';
 		const city = 'Brisbane';

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -497,7 +497,7 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 		const testCardPostCode = '4000';
 		const firstName = 'End to End';
 		const lastName = 'Testing';
-		const phoneNumber = '+0422888888';
+		const phoneNumber = '+04.22888888';
 		const countryCode = 'AU';
 		const address = '888 Queen Street';
 		const city = 'Brisbane';


### PR DESCRIPTION
Backend change now requires domain registrar phone numbers to have a dot after the country code

r147303-wpcom