### PR TITLE
Updated plugin search to not refresh but clear search and try again

### DIFF
--- a/lib/pages/plugins-browser-page.js
+++ b/lib/pages/plugins-browser-page.js
@@ -14,17 +14,17 @@ export default class PluginsBrowserPage extends BaseContainer {
 		return driverHelper.setWhenSettable( this.driver, by.css( '.plugins-browser__main-header input[type="search"]' ), searchTerm );
 	}
 
-	pluginTitledShown( pluginTitle ) {
+	pluginTitledShown( pluginTitle, searchTerm ) {
 		const self = this;
 		const selector = by.xpath( `//div[@class="plugins-browser-item__title"][text()="${pluginTitle}"]` );
 		return driverHelper.isEventuallyPresentAndDisplayed( self.driver, selector ).then( ( shown ) => {
 			if ( shown === true ) {
 				return shown;
-			} else {
-				SlackNotifier.warn( 'The Jetpack Plugins Browser results were not showing expected result, so refreshing and trying again' );
-				self.driver.navigate().refresh();
-				return driverHelper.isEventuallyPresentAndDisplayed( self.driver, selector );
 			}
+			SlackNotifier.warn( 'The Jetpack Plugins Browser results were not showing expected result, so refreshing and trying again' );
+			driverHelper.clickWhenClickable( self.driver, by.css( '.search__close-icon' ) );
+			self.searchForPlugin( searchTerm );
+			return driverHelper.isEventuallyPresentAndDisplayed( self.driver, selector );
 		} );
 	}
 }

--- a/specs/wp-jetpack-calypso-spec.js
+++ b/specs/wp-jetpack-calypso-spec.js
@@ -76,7 +76,7 @@ test.describe( `Jetpack Sites on Calypso: '${ screenSize }'`, function() {
 			this.sidebarComponent.selectAddPlugin();
 			this.pluginsBrowserPage = new PluginsBrowserPage( driver );
 			this.pluginsBrowserPage.searchForPlugin( pluginVendor );
-			this.pluginsBrowserPage.pluginTitledShown( pluginTitle ).then( ( pluginDisplayed ) => {
+			this.pluginsBrowserPage.pluginTitledShown( pluginTitle, pluginVendor ).then( ( pluginDisplayed ) => {
 				assert( pluginDisplayed, `The plugin titled ${pluginTitle} was not displayed` );
 			} );
 		} );


### PR DESCRIPTION
The refresh looks like it means the results don’t load - raised here:
https://github.com/Automattic/wp-calypso/issues/10074