### PR TITLE
Added extra check for new mobile layout for private/trash buttons

### DIFF
--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -162,7 +162,7 @@ test.describe( 'Editor: Pages (' + screenSize + ')', function() {
 			} );
 
 			test.it( 'Can set visibility to private', function() {
-				if ( config.get( 'useNewMobileEditor' ) === true ) {
+				if ( config.get( 'useNewMobileEditor' ) === true && screenSize === 'mobile' ) {
 					const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 					postEditorSidebarComponent.setVisibilityToPrivate();
 				} else {
@@ -223,7 +223,7 @@ test.describe( 'Editor: Pages (' + screenSize + ')', function() {
 			test.it( 'Can enter page title and content and set to password protected', function() {
 				this.editorPage = new EditorPage( driver );
 				this.editorPage.enterTitle( pageTitle );
-				if ( config.get( 'useNewMobileEditor' ) === true ) {
+				if ( config.get( 'useNewMobileEditor' ) === true && screenSize === 'mobile' ) {
 					this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 					this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
 				} else {

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -276,7 +276,7 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 				} );
 
 				test.it( 'Can set visibility to private which immediately publishes it', function() {
-					if ( config.get( 'useNewMobileEditor' ) === true ) {
+					if ( config.get( 'useNewMobileEditor' ) === true &&  screenSize === 'mobile' ) {
 						const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 						postEditorSidebarComponent.setVisibilityToPrivate();
 					} else {
@@ -355,7 +355,7 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 			test.it( 'Can enter post title and content and set to password protected', function() {
 				this.editorPage = new EditorPage( driver );
 				this.editorPage.enterTitle( blogPostTitle );
-				if ( config.get( 'useNewMobileEditor' ) === true ) {
+				if ( config.get( 'useNewMobileEditor' ) === true && screenSize === 'mobile' ) {
 					this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 					this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
 				} else {
@@ -669,7 +669,7 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 			} );
 
 			test.it( 'Can trash the new post', function() {
-				if ( config.get( 'useNewMobileEditor' ) === true ) {
+				if ( config.get( 'useNewMobileEditor' ) === true && screenSize === 'mobile' ) {
 					const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 					postEditorSidebarComponent.trashPost();
 				} else {


### PR DESCRIPTION
With the new mobile editor the Private/Trash/Password buttons were relocated...but only on the mobile layout.  The desktop layout leaves them where they were.  This PR adds a check to only look in the sidebar if the screenSize is mobile.