### PR TITLE
Add a pauseBetweenKeysMS parameter to setWhenSettable to allow pauses between key inputs

### DIFF
--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -178,16 +178,23 @@ export function waitForFieldClearableMobile( driver, selector ) {
 	return driver.wait( d.promise, explicitWaitMS, `Timed out waiting for element with ${selector.using} of '${selector.value}' to be clearable` );
 }
 
-export function setWhenSettable( driver, selector, value, { secureValue = false } = {} ) {
+export function setWhenSettable( driver, selector, value, { secureValue = false, pauseBetweenKeysMS = 0 } = {} ) {
 	const logValue = secureValue === true ? '*********' : value;
 	let self = this;
 	return driver.wait( function() {
 		return driver.findElement( selector ).then( function( element ) {
 			self.waitForFieldClearable( driver, selector );
-			return element.sendKeys( value ).then( function() {
-				return element.getAttribute( 'value' ).then( ( actualValue ) => {
-					return actualValue === value;
-				} );
+			if ( pauseBetweenKeysMS === 0 ) {
+				element.sendKeys( value );
+			} else {
+				for ( let i = 0; i < value.length; i++ ) {
+					driver.sleep( pauseBetweenKeysMS ).then( () => {
+						element.sendKeys( value[i] );
+					} );
+				}
+			}
+			return element.getAttribute( 'value' ).then( ( actualValue ) => {
+				return actualValue === value;
 			}, function() {
 				return false;
 			} );

--- a/lib/pages/plugins-browser-page.js
+++ b/lib/pages/plugins-browser-page.js
@@ -11,7 +11,7 @@ export default class PluginsBrowserPage extends BaseContainer {
 	}
 
 	searchForPlugin( searchTerm ) {
-		return driverHelper.setWhenSettable( this.driver, by.css( '.plugins-browser__main-header input[type="search"]' ), searchTerm );
+		return driverHelper.setWhenSettable( this.driver, by.css( '.plugins-browser__main-header input[type="search"]' ), searchTerm, { pauseBetweenKeysMS: 100 } );
 	}
 
 	pluginTitledShown( pluginTitle, searchTerm ) {
@@ -21,7 +21,7 @@ export default class PluginsBrowserPage extends BaseContainer {
 			if ( shown === true ) {
 				return shown;
 			}
-			SlackNotifier.warn( 'The Jetpack Plugins Browser results were not showing expected result, so refreshing and trying again' );
+			SlackNotifier.warn( 'The Jetpack Plugins Browser results were not showing the expected result, so trying again' );
 			driverHelper.clickWhenClickable( self.driver, by.css( '.search__close-icon' ) );
 			self.searchForPlugin( searchTerm );
 			return driverHelper.isEventuallyPresentAndDisplayed( self.driver, selector );


### PR DESCRIPTION
This fixes an issue on the Jetpack plugins results where asynchronous
searches sometimes show no results because the input is too fast - it
now waits 100ms in between key strokes and seems to solve this timing
issue