### PR TITLE
Remove the mobile editor config switch

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -14,7 +14,6 @@
   "checkForConsoleErrors": false,
   "reportWarningsToSlack": false,
   "neverSaveScreenshots": false,
-  "useNewMobileEditor": true,
   "useNewMailosaur": true,
   "sauceConfigurations": {
     "osx-chrome": {

--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -11,24 +11,15 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.post-editor__sidebar' ) );
 		this.publicizeMessageSelector = By.css( 'div.editor-sharing__message-input textarea' );
-		if ( config.get( 'useNewMobileEditor' ) === true ) {
-			if ( driverManager.currentScreenSize() === 'mobile' ) {
-				this.publishButtonSelector = By.css( '.editor-mobile-navigation .editor-publish-button' );
-			} else {
-				this.publishButtonSelector = By.css( '.editor-ground-control__publish-combo .editor-publish-button' )
-			}
+		if ( driverManager.currentScreenSize() === 'mobile' ) {
+			this.publishButtonSelector = By.css( '.editor-mobile-navigation .editor-publish-button' );
 		} else {
-			this.publishButtonSelector = By.css( '.editor-ground-control__publish-button' )
+			this.publishButtonSelector = By.css( '.editor-ground-control__publish-combo .editor-publish-button' )
 		}
 		this.switchToComponentOnMobileIfNecessary();
 	}
 	switchToComponentOnMobileIfNecessary() {
-		let actionButtonsSelector;
-		if ( config.get( 'useNewMobileEditor' ) === true ) {
-			actionButtonsSelector = By.css( '.editor-mobile-navigation__tabs .gridicons-cog.editor-mobile-navigation__icon' );
-		} else {
-			actionButtonsSelector = By.css( 'button.editor-mobile-navigation__toggle' );
-		}
+		const actionButtonsSelector = By.css( '.editor-mobile-navigation__tabs .gridicons-cog.editor-mobile-navigation__icon' );
 		const postStatusSelector = By.css( '.editor-ground-control__status' );
 		this.driver.findElement( postStatusSelector ).isDisplayed().then( ( postStatusDisplayed ) => {
 			if ( postStatusDisplayed === false ) {

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -26,25 +26,16 @@ export default class EditorPage extends BaseContainer {
 		this.editorFrameName = by.css( '.mce-edit-area iframe' );
 		this.saveSelector = by.css( 'button.editor-ground-control__save' );
 
-		if ( config.get( 'useNewMobileEditor' ) === true ) {
-			const writeButtonSelector = by.css( '.editor-mobile-navigation__tabs .gridicons-pencil.editor-mobile-navigation__icon' );
-			driver.findElement( writeButtonSelector ).isDisplayed().then( function( writeButtonDisplayed ) {
-				if ( writeButtonDisplayed === true ) {
-					driver.findElement( writeButtonSelector ).getAttribute( 'class' ).then( ( c ) => {
-						if ( c.indexOf( 'is-selected' ) < 0 ) {
-							driverHelper.clickWhenClickable( driver, writeButtonSelector );
-						}
-					} );
-				}
-			} );
-		} else {
-			const writeButtonSelector = by.css( 'button.editor-sidebar__toggle-sidebar' );
-			driver.findElement( writeButtonSelector ).isDisplayed().then( function( writeButtonDisplayed ) {
-				if ( writeButtonDisplayed === true ) {
-					driverHelper.clickIfPresent( driver, writeButtonSelector, 3 );
-				}
-			} );
-		}
+		const writeButtonSelector = by.css( '.editor-mobile-navigation__tabs .gridicons-pencil.editor-mobile-navigation__icon' );
+		driver.findElement( writeButtonSelector ).isDisplayed().then( function( writeButtonDisplayed ) {
+			if ( writeButtonDisplayed === true ) {
+				driver.findElement( writeButtonSelector ).getAttribute( 'class' ).then( ( c ) => {
+					if ( c.indexOf( 'is-selected' ) < 0 ) {
+						driverHelper.clickWhenClickable( driver, writeButtonSelector );
+					}
+				} );
+			}
+		} );
 
 		this.waitForPage();
 		this.ensureEditorShown();

--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -162,7 +162,7 @@ test.describe( 'Editor: Pages (' + screenSize + ')', function() {
 			} );
 
 			test.it( 'Can set visibility to private', function() {
-				if ( config.get( 'useNewMobileEditor' ) === true && screenSize === 'mobile' ) {
+				if ( screenSize === 'mobile' ) {
 					const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 					postEditorSidebarComponent.setVisibilityToPrivate();
 				} else {
@@ -223,7 +223,7 @@ test.describe( 'Editor: Pages (' + screenSize + ')', function() {
 			test.it( 'Can enter page title and content and set to password protected', function() {
 				this.editorPage = new EditorPage( driver );
 				this.editorPage.enterTitle( pageTitle );
-				if ( config.get( 'useNewMobileEditor' ) === true && screenSize === 'mobile' ) {
+				if ( screenSize === 'mobile' ) {
 					this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 					this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
 				} else {

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -36,7 +36,7 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 	this.bailSuite( true );
 	this.timeout( mochaTimeOut );
 
-	test.describe( 'Public Posts:', function() {
+	test.describe.only( 'Public Posts:', function() {
 		let fileDetails;
 
 		test.before( 'Delete Cookies and Local Storage', function() {
@@ -276,7 +276,7 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 				} );
 
 				test.it( 'Can set visibility to private which immediately publishes it', function() {
-					if ( config.get( 'useNewMobileEditor' ) === true &&  screenSize === 'mobile' ) {
+					if ( screenSize === 'mobile' ) {
 						const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 						postEditorSidebarComponent.setVisibilityToPrivate();
 					} else {
@@ -355,7 +355,7 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 			test.it( 'Can enter post title and content and set to password protected', function() {
 				this.editorPage = new EditorPage( driver );
 				this.editorPage.enterTitle( blogPostTitle );
-				if ( config.get( 'useNewMobileEditor' ) === true && screenSize === 'mobile' ) {
+				if ( screenSize === 'mobile' ) {
 					this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 					this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
 				} else {
@@ -669,7 +669,7 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 			} );
 
 			test.it( 'Can trash the new post', function() {
-				if ( config.get( 'useNewMobileEditor' ) === true && screenSize === 'mobile' ) {
+				if ( screenSize === 'mobile' ) {
 					const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 					postEditorSidebarComponent.trashPost();
 				} else {

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -36,7 +36,7 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 	this.bailSuite( true );
 	this.timeout( mochaTimeOut );
 
-	test.describe.only( 'Public Posts:', function() {
+	test.describe( 'Public Posts:', function() {
 		let fileDetails;
 
 		test.before( 'Delete Cookies and Local Storage', function() {


### PR DESCRIPTION
Since we’re all in on the new mobile editor redesign now we can safely
remove the feature toggle and all the conditional code