### PR TITLE
Remove feature toggle 'useNewMailosaur'

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -15,7 +15,6 @@
   "reportWarningsToSlack": false,
   "neverSaveScreenshots": false,
   "useNewMobileEditor": true,
-  "useNewMailosaur": true,
   "sauceConfigurations": {
     "osx-chrome": {
         "browserName": "chrome",

--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -14,7 +14,7 @@ export function randomPhrase() {
 }
 
 export function getEmailAddress( prefix, inboxId ) {
-	const domain = ( config.get( 'useNewMailosaur' ) === true ) ? 'mailosaur.io' : 'mailosaur.in';
+	const domain = 'mailosaur.io';
 	const globalEmailPrefix = config.has( 'emailPrefix' ) ? config.get( 'emailPrefix' ) : '';
 	return `${globalEmailPrefix}${prefix}.${inboxId}@${domain}`;
 }

--- a/lib/email-client.js
+++ b/lib/email-client.js
@@ -6,7 +6,7 @@ const emailWaitMS = config.get( 'emailWaitMS' );
 export default class EmailClient {
 	constructor( mailboxId ) {
 		const apiKey = config.get( 'mailosaurAPIKey' );
-		const Mailosaur = ( config.get( 'useNewMailosaur' ) === true ) ? require( 'mailosaur' )( apiKey, 'https://www.mailosaur.com/api/' ) : require( 'mailosaur' )( apiKey );
+		const Mailosaur = require( 'mailosaur' )( apiKey, 'https://www.mailosaur.com/api/' );
 		this.mailbox = new Mailosaur.Mailbox( mailboxId );
 	}
 


### PR DESCRIPTION
Since we’re all in on the new Mailosaur API now we can remove this
feature toggle that allowed us to switch back to the old one