### PR TITLE
New ensureMobileMenuOpen() procedure, added to login flow

### DIFF
--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -342,12 +342,12 @@ export function scrollToFindElement( driver, selector, { maxSwipes = 2 } = {} ) 
 export function ensureMobileMenuOpen( driver ) {
 	const self = this;
 	const mobileHeaderSelector = by.css( '.section-nav__mobile-header' );
+	const openSidebarSelector = by.css( 'header.current-section svg.gridicons-chevron-left' );
 	driver.findElement( mobileHeaderSelector ).isDisplayed().then( ( mobileDisplayed ) => {
 		if ( mobileDisplayed ) {
-			driver.findElement( by.css( '.section-nav.has-pinned-items' ) ).getAttribute( 'class' ).then( ( classNames ) => {
-				if ( classNames.includes( 'is-open' ) === false ) {
-					self.clickWhenClickable( driver, mobileHeaderSelector );
-				}
+			// If .focus-sidebar is found, do nothing.  Otherwise click the < icon
+			driver.findElement( by.css( '.focus-sidebar' ) ).then( () => {}, () => {
+				self.clickWhenClickable( driver, openSidebarSelector );
 			} );
 		}
 	} );

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -7,6 +7,8 @@ import config from 'config';
 import SidebarComponent from '../components/sidebar-component.js';
 import NavbarComponent from '../components/navbar-component.js';
 
+import * as DriverHelper from '../driver-helper.js';
+
 export default class LoginFlow {
 	constructor( driver, account ) {
 		this.driver = driver;
@@ -69,6 +71,7 @@ export default class LoginFlow {
 		this.loginAndSelectMySite();
 
 		let sidebarComponent = new SidebarComponent( this.driver );
+		DriverHelper.ensureMobileMenuOpen( this.driver );
 		return sidebarComponent.selectAddNewPage();
 	}
 
@@ -76,6 +79,7 @@ export default class LoginFlow {
 		this.loginAndSelectMySite();
 
 		let sideBarComponent = new SidebarComponent( this.driver );
+		DriverHelper.ensureMobileMenuOpen( this.driver );
 		return sideBarComponent.selectDomains();
 	}
 
@@ -83,6 +87,7 @@ export default class LoginFlow {
 		this.loginAndSelectMySite();
 
 		let sideBarComponent = new SidebarComponent( this.driver );
+		DriverHelper.ensureMobileMenuOpen( this.driver );
 		return sideBarComponent.selectPeople();
 	}
 
@@ -90,6 +95,7 @@ export default class LoginFlow {
 		this.loginAndSelectMySite();
 
 		let sideBarComponent = new SidebarComponent( this.driver );
+		DriverHelper.ensureMobileMenuOpen( this.driver );
 		sideBarComponent.selectAddPerson();
 	}
 
@@ -110,6 +116,7 @@ export default class LoginFlow {
 		this.loginAndSelectMySite();
 
 		const sideBarComponent = new SidebarComponent( this.driver );
+		DriverHelper.ensureMobileMenuOpen( this.driver );
 		sideBarComponent.selectSiteSwitcher();
 		return sideBarComponent.selectAllSites();
 	}
@@ -118,6 +125,7 @@ export default class LoginFlow {
 		this.loginAndSelectMySite();
 
 		let sideBarComponent = new SidebarComponent( this.driver );
+		DriverHelper.ensureMobileMenuOpen( this.driver );
 		return sideBarComponent.selectThemes();
 	}
 
@@ -125,6 +133,7 @@ export default class LoginFlow {
 		this.loginAndSelectMySite();
 
 		let sideBarComponent = new SidebarComponent( this.driver );
+		DriverHelper.ensureMobileMenuOpen( this.driver );
 		return sideBarComponent.selectPlugins();
 	}
 


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/10505 changed the default behavior for when the My Site link is clicked on mobile, dumping the user immediately into Stats instead of on the sidebar.  This PR adds a call to ensureMobileMenuOpen to all login flows that required the sidebar to be open.

And for reasons I'm not clear on, the existing method for ensureMobileMenuOpen stopped working, and I had to find an alternate way.
