### PR TITLE
Update checking ab tests to take url

### DIFF
--- a/lib/base-container.js
+++ b/lib/base-container.js
@@ -68,7 +68,7 @@ export default class BaseContainer {
 			}
 		} );
 	}
-	setABTestControlGroupsInLocalStorage( culture = 'en', flow = 'main', personalPlanValue = 'hide' ) {
+	setABTestControlGroupsInLocalStorage( url, culture = 'en', flow = 'main' ) {
 		const overrideABTests = config.get( 'overrideABTests' );
 
 		const expectedABTestValue = overrideABTests.map( ( entry ) => {
@@ -79,23 +79,7 @@ export default class BaseContainer {
 
 		this.driver.executeScript( `window.localStorage.setItem('signupFlowName','"${flow}"');` );
 
-		this.driver.getCurrentUrl().then( ( currentUrl ) => {
-			const culturePath = `/${culture}`;
-			let newUrl = currentUrl.replace( 'upgrade/', '' ); // remove the upgrade path as this overrides local storage
-			newUrl = newUrl.replace( 'layout/survey', '' ); // remove the layout path as this indicates Headstart, which is not yet supported in these tests
-
-			if ( culture.toLowerCase() !== 'en' ) {
-				if ( !newUrl.endsWith( culturePath ) ) {
-					newUrl = newUrl + culturePath;
-				}
-			}
-
-			if ( currentUrl !== newUrl ) {
-				slackNotifier.warn( `Changing URLs for various AB tests: OLD URL: '${ currentUrl }' NEW URL: '${ newUrl }'`, { suppressDuplicateMessages: true } );
-			}
-
-			this.driver.get( newUrl );
-		} );
+		this.driver.get( url );
 
 		this.driver.executeScript( 'return window.localStorage.signupFlowName;' ).then( ( flowValue ) => {
 			assert.equal( flowValue, `"${flow}"`, 'The local storage value for flow wasn\'t set correctly' );

--- a/lib/pages/jetpack-authorize-page.js
+++ b/lib/pages/jetpack-authorize-page.js
@@ -7,7 +7,9 @@ import * as driverHelper from '../driver-helper';
 export default class JetpackAuthorizePage extends BaseContainer {
 	constructor( driver ) {
 		super( driver, by.css( '.is-section-jetpackConnect' ) );
-		this.setABTestControlGroupsInLocalStorage();
+		driver.getCurrentUrl().then( ( urlDisplayed ) => {
+			this.setABTestControlGroupsInLocalStorage( urlDisplayed );
+		} );
 	}
 
 	chooseSignIn() {

--- a/lib/pages/signup/start-page.js
+++ b/lib/pages/signup/start-page.js
@@ -24,8 +24,8 @@ export default class StartPage extends BaseContainer {
 
 		let ABTestControlFlow = flow !== '' ? flow : 'main';
 
-		super( driver, By.css( '.flow-progress-indicator' ), visit, url );
+		super( driver, By.css( '.step-header' ), visit, url );
 		this.checkForUnknownABTestKeys();
-		this.setABTestControlGroupsInLocalStorage( culture, ABTestControlFlow, personalPlanSetting );
+		this.setABTestControlGroupsInLocalStorage( url, culture, ABTestControlFlow );
 	}
 }

--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -63,8 +63,10 @@ test.describe( 'Managing Domains: (' + screenSize + ')', function() {
 		test.describe( 'Can search for and select a paid domain', function() {
 			test.it( 'Can choose add a domain', () => {
 				const domainsPage = new DomainsPage( driver );
-				domainsPage.setABTestControlGroupsInLocalStorage();
-				domainsPage.clickAddDomain();
+				driver.getCurrentUrl().then( ( urlDisplayed ) => {
+					domainsPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
+				} );
+				return domainsPage.clickAddDomain();
 			} );
 
 			test.it( 'Can see the domain search component', () => {

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -566,7 +566,7 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 	} );
 
 
-	test.describe( 'Sign up for a free site with Survey step', function() {
+	test.describe( 'Sign up for a Survey Step free site', function() {
 		this.bailSuite( true );
 
 		const blogName = dataHelper.getNewBlogName();


### PR DESCRIPTION
Currently the method `setABTestControlGroupsInLocalStorage` refreshes the page after setting AB tests, but if the URL has been changed (for example user signup in first step of signup), refreshing the page doesn't change the flow and therefore the expected flow/ab tests are not taken into account.

This PR makes `setABTestControlGroupsInLocalStorage` take the URL so it knows what URL to revisit after setting the AB test keys.

@hoverduck: just so you know about this change.