### PR TITLE
Add waitUntilThemesLoaded() to solve race condition on themes page

### DIFF
--- a/lib/pages/themes-page.js
+++ b/lib/pages/themes-page.js
@@ -34,6 +34,16 @@ export default class ThemesPage extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 
+	waitUntilThemesLoaded() {
+		const selector = by.css( '.themes-list .is-placeholder' );
+		const self = this;
+		return self.driver.wait( function() {
+			return self.driver.isElementPresent( selector ).then( function( present ) {
+				return !present;
+			} );
+		}, this.explicitWaitMS, 'The themes are still loading after waiting for them' );
+	}
+
 	waitForThemeStartingWith( phrase ) {
 		const selector = by.xpath( `//h2[text()[contains(.,'${ phrase }')]]/../../../../div[not(contains(concat(' ', @class, ' '), ' is-active '))]` );
 		return this.driver.wait( until.elementLocated( selector ), this.explicitWaitMS, 'Could not locate theme beginning with: ' + phrase );

--- a/specs/wp-theme-multisite-spec.js
+++ b/specs/wp-theme-multisite-spec.js
@@ -108,14 +108,14 @@ test.describe( 'Themes: All sites (' + screenSize + ')', function() {
 						test.it( 'and select all sites', function() {
 							const sideBarComponent = new SidebarComponent( this.driver );
 							sideBarComponent.selectSiteSwitcher();
-							return sideBarComponent.selectAllSites();							
+							return sideBarComponent.selectAllSites();
 						} );
-						
+
 						test.it( 'can search for free themes', function() {
 							themesPage = new ThemesPage( this.driver );
 							themesPage.showOnlyFreeThemes();
 							themesPage.searchFor( this.themeSearchName );
-
+							themesPage.waitUntilThemesLoaded();
 							themesPage.waitForThemeStartingWith( this.expectedTheme );
 						} );
 
@@ -178,6 +178,7 @@ test.describe( 'Themes: All sites (' + screenSize + ')', function() {
 			this.themesPage.showOnlyFreeThemes();
 			this.themesPage.searchFor( this.themeSearchName );
 
+			this.themesPage.waitUntilThemesLoaded();
 			this.themesPage.waitForThemeStartingWith( this.expectedTheme );
 
 			this.themesPage.getFirstThemeName().then( ( name ) => {

--- a/specs/wp-theme-switch-spec.js
+++ b/specs/wp-theme-switch-spec.js
@@ -38,6 +38,7 @@ test.describe( 'Themes: (' + screenSize + ')', function() {
 				this.themesPage = new ThemesPage( driver );
 				this.themesPage.showOnlyFreeThemes();
 				this.themesPage.searchFor( 'Twenty F' );
+				this.themesPage.waitUntilThemesLoaded();
 				this.themesPage.waitForThemeStartingWith( 'Twenty F' );
 				return this.themesPage.selectNewThemeStartingWith( 'Twenty F' );
 			} );


### PR DESCRIPTION
It seems like there’s a race condition on the themes page if you select
the theme really really quickly then it doesn’t work. So this PR
introduces a wait until all the placeholders are no longer present
before continuing.