### PR TITLE
Fix/run sh support dot only

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,6 @@ general:
     - "logs"
   branches:
     ignore:
-      - /.*[j,J]etpack.*/ # ignore branches with jetpack in their name for Circle - these are run in a separate build
       - /.*[v,V]isdiff.*/ # ignore branches with visdiff in their name for Circle - these are run in a separate build
       - /.*i[o,O][s,S].*/ # ignore branches with iOS in their name for Circle - these are run in a separate build
 

--- a/run-wrapper.sh
+++ b/run-wrapper.sh
@@ -7,9 +7,6 @@ if [ "$CIRCLE_NODE_INDEX" == "0" ]; then
   if [ "$SKIP_TEST_REGEX" != "" ]; then
     babel-node --presets es2015 lib/slack-ping-cli.js "Attention! Tests are being skipped with pattern [$SKIP_TEST_REGEX]"
   fi
-  if [ "$RUN_VISDIFF" != "true" ]; then
-    babel-node --presets es2015 lib/slack-ping-cli.js "Attention! Visual Diff tests are currently disabled!"
-  fi
 fi
 
 if [ "$NODE_ENV_OVERRIDE" != "" ]; then
@@ -20,6 +17,8 @@ export TESTARGS="-R -p"
 
 if [ "$RUN_SPECIFIED" == "true" ]; then
   TESTARGS=$RUN_ARGS
+elif [[ "$CIRCLE_BRANCH" =~ .*[Jj]etpack.*|.*[Jj][Pp].* ]]; then
+  TESTARGS="-R -j" # Execute Jetpack tests
 elif [ "$CIRCLE_BRANCH" == "master" ]; then
   TESTARGS="-R -p" # Parallel execution, implies -g -s mobile,desktop
 fi

--- a/run.sh
+++ b/run.sh
@@ -41,7 +41,7 @@ if [ $# -eq 0 ]; then
   usage
 fi
 
-while getopts ":Rpb:s:givwl:cm:fh" opt; do
+while getopts ":Rpb:s:givwl:cm:fhj" opt; do
   case $opt in
     R)
       REPORTER="-R spec-xunit-slack-reporter"
@@ -90,6 +90,11 @@ while getopts ":Rpb:s:givwl:cm:fh" opt; do
 	eval $CMD
       fi
       exit $?
+      ;;
+    j)
+      MOCHA+=" --compilers js:babel-register"
+      SCREENSIZES="desktop,mobile"
+      TARGET="specs-jetpack-calypso/"
       ;;
     f)
       NODE_CONFIG_ARGS+=("\"failVisdiffs\":\"true\"")

--- a/run.sh
+++ b/run.sh
@@ -113,7 +113,10 @@ while getopts ":Rpb:s:givwl:cm:fh" opt; do
 done
 
 # Skip any tests in the given variable
-GREP="-i -g '$SKIP_TEST_REGEX'"
+GREP=""
+if [ "$SKIP_TEST_REGEX" != "" ]; then
+	GREP="-i -g '$SKIP_TEST_REGEX'"
+fi
 
 # Combine any NODE_CONFIG entries into a single object
 NODE_CONFIG_ARG="$(joinStr , ${NODE_CONFIG_ARGS[*]})"


### PR DESCRIPTION
This PR fixes the issue where using `run.sh` would fail to recognize the `.only` flag on a test.  This was because it would pass the `-i` option to mocha, which inverted the selection (as intended when using the SKIP_TEST_REGEX envvar).  So now that parameter is only used if the SKIP_TEST_REGEX variable is actually set.

It also adds the capability to run the Jetpack tests from the main CI repo as opposed to just the https://github.com/Automattic/wp-e2e-tests-jetpack repo if the word `Jetpack` or `jp` is in the branch name