### PR TITLE
Add a contact form e2e test

### DIFF
--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -60,15 +60,8 @@ export default class EditorPage extends BaseContainer {
 	}
 
 	_chooseInsertMediaOption() {
-		const self = this;
-		return self.driver.isElementPresent( by.css( '.mce-wpcom-insert-menu' ) ).then( ( menuPresent ) => {
-			if ( menuPresent === true ) {
-				driverHelper.clickWhenClickable( self.driver, by.css( '.mce-wpcom-insert-menu button.mce-open' ) );
-				driverHelper.clickWhenClickable( self.driver, by.css( '.gridicons-add-image' ) );
-			} else {
-				driverHelper.clickWhenClickable( self.driver, by.css( '.mce-media' ) );
-			}
-		} );
+		driverHelper.clickWhenClickable( this.driver, by.css( '.mce-wpcom-insert-menu button.mce-open' ) );
+		return driverHelper.clickWhenClickable( this.driver, by.css( '.mce-menu .gridicons-add-image' ) );
 	}
 
 	uploadMedia( fileDetails ) {
@@ -82,6 +75,12 @@ export default class EditorPage extends BaseContainer {
 		self.driver.wait( elementIsNotPresent( '.media-library__list-item.is-transient' ), this.explicitWaitMS, 'Transient media is still present' );
 		self.driver.wait( elementIsNotPresent( '.media-library .notice.is-error' ), 500, 'Upload error message is present' );
 		return self.driver.wait( until.elementLocated( by.css( '.media-library__list-item.is-selected' ) ), this.explicitWaitMS, 'Could not locate the newly uploaded item.' );
+	}
+
+	insertContactForm() {
+		driverHelper.clickWhenClickable( this.driver, by.css( '.mce-wpcom-insert-menu button.mce-open' ) );
+		driverHelper.clickWhenClickable( this.driver, by.css( '.mce-menu .gridicons-mention' ) );
+		return driverHelper.clickWhenClickable( this.driver, by.css( '.editor-contact-form-modal button.is-primary' ) );
 	}
 
 	enterPostImage( fileDetails ) {
@@ -138,6 +137,12 @@ export default class EditorPage extends BaseContainer {
 	errorDisplayed() {
 		this.driver.sleep( 1000 );
 		return this.driver.isElementPresent( by.css( '.notice.is-error' ) );
+	}
+
+	ensureContactFormDisplayedInPost() {
+		this.driver.wait( until.ableToSwitchToFrame( this.editorFrameName ), this.explicitWaitMS, 'Could not locate the editor iFrame.' );
+		driverHelper.waitTillPresentAndDisplayed( this.driver, by.css( '.wpview-type-contact-form' ) );
+		this.driver.switchTo().defaultContent();
 	}
 
 	setVisibilityToPrivate() {

--- a/lib/pages/view-post-page.js
+++ b/lib/pages/view-post-page.js
@@ -34,6 +34,10 @@ export default class ViewPostPage extends BaseContainer {
 		return this.driver.findElement( By.css( 'a[rel=tag]' ) ).getText();
 	};
 
+	contactFormDisplayed() {
+		return this.driver.isElementPresent( By.css( '.contact-form' ) );
+	}
+
 	isPasswordProtected() {
 		return this.driver.isElementPresent( By.css( 'form.post-password-form' ) );
 	};

--- a/specs-jetpack-calypso/wp-jetpack-post-editor-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-post-editor-spec.js
@@ -776,4 +776,49 @@ test.describe( 'Jetpack Site: Editor: Posts (' + screenSize + ')', function() {
 			} );
 		} );
 	} );
+
+	test.describe( 'Insert a contact form:', function() {
+		this.bailSuite( true );
+
+		test.it( 'Delete Cookies and Local Storage', function() {
+			driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		} );
+
+		test.describe( 'Publish a New Post', function() {
+			const originalBlogPostTitle = 'Contact Us: ' + dataHelper.randomPhrase();
+
+			test.it( 'Can log in', function() {
+				this.loginFlow = new LoginFlow( driver, 'jetpackUser' );
+				return this.loginFlow.loginAndStartNewPost();
+			} );
+
+			test.it( 'Can insert the contact form', function() {
+				this.editorPage = new EditorPage( driver );
+				this.editorPage.enterTitle( originalBlogPostTitle );
+				this.editorPage.insertContactForm( );
+
+				return this.editorPage.errorDisplayed().then( ( errorShown ) => {
+					return assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
+				} );
+			} );
+
+			test.it( 'Can see the contact form inserted into the visual editor', function() {
+				this.editorPage = new EditorPage( driver );
+				return this.editorPage.ensureContactFormDisplayedInPost();
+			} );
+
+			test.it( 'Can publish and view content', function() {
+				let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+				postEditorSidebarComponent.ensureSaved();
+				postEditorSidebarComponent.publishAndViewContent();
+				this.viewPostPage = new ViewPostPage( driver );
+			} );
+
+			test.it( 'Can see the contact form in our published post', function() {
+				this.viewPostPage.contactFormDisplayed().then( function( displayed ) {
+					assert.equal( displayed, true, 'The published post does not contain the contact form' );
+				} );
+			} );
+		} );
+	} );
 } );

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -778,4 +778,49 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 			} );
 		} );
 	} );
+
+	test.describe( 'Insert a contact form:', function() {
+		this.bailSuite( true );
+
+		test.it( 'Delete Cookies and Local Storage', function() {
+			driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		} );
+
+		test.describe( 'Publish a New Post', function() {
+			const originalBlogPostTitle = 'Contact Us: ' + dataHelper.randomPhrase();
+
+			test.it( 'Can log in', function() {
+				this.loginFlow = new LoginFlow( driver );
+				return this.loginFlow.loginAndStartNewPost();
+			} );
+
+			test.it( 'Can insert the contact form', function() {
+				this.editorPage = new EditorPage( driver );
+				this.editorPage.enterTitle( originalBlogPostTitle );
+				this.editorPage.insertContactForm( );
+
+				return this.editorPage.errorDisplayed().then( ( errorShown ) => {
+					return assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
+				} );
+			} );
+
+			test.it( 'Can see the contact form inserted into the visual editor', function() {
+				this.editorPage = new EditorPage( driver );
+				return this.editorPage.ensureContactFormDisplayedInPost();
+;			} );
+
+			test.it( 'Can publish and view content', function() {
+				let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+				postEditorSidebarComponent.ensureSaved();
+				postEditorSidebarComponent.publishAndViewContent();
+				this.viewPostPage = new ViewPostPage( driver );
+			} );
+
+			test.it( 'Can see the contact form in our published post', function() {
+				this.viewPostPage.contactFormDisplayed().then( function( displayed ) {
+					assert.equal( displayed, true, 'The published post does not contain the contact form' );
+				} );
+			} );
+		} );
+	} );
 } );

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -807,7 +807,7 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 			test.it( 'Can see the contact form inserted into the visual editor', function() {
 				this.editorPage = new EditorPage( driver );
 				return this.editorPage.ensureContactFormDisplayedInPost();
-;			} );
+			} );
 
 			test.it( 'Can publish and view content', function() {
 				let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );


### PR DESCRIPTION
This adds an e2e test for inserting a contact form into a post.

This is adding missing coverage for this bug: https://github.com/Automattic/wp-calypso/issues/11025