### PR TITLE
Adds initial support for different jetpack hosts

### DIFF
--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -45,3 +45,7 @@ export function getWidgetContent() {
 function getRandomInt( min, max ) {
 	return Math.floor( Math.random() * ( max - min + 1 ) ) + min;
 }
+
+export function getJetpackHost() {
+	return process.env.JETPACKHOST || 'PRESSABLE';
+}

--- a/specs-jetpack-calypso/wp-jetpack-calypso-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-calypso-spec.js
@@ -25,7 +25,7 @@ test.before( 'Start Browser', function() {
 	driver = driverManager.startBrowser();
 } );
 
-test.describe.only( `${host} Jetpack Sites on Calypso: '${ screenSize }'`, function() {
+test.describe( `${host} Jetpack Sites on Calypso: '${ screenSize }'`, function() {
 	this.timeout( mochaTimeOut );
 	this.bailSuite( true );
 

--- a/specs-jetpack-calypso/wp-jetpack-calypso-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-calypso-spec.js
@@ -3,6 +3,7 @@ import test from 'selenium-webdriver/testing';
 
 import config from 'config';
 import * as driverManager from '../lib/driver-manager';
+import * as dataHelper from '../lib/data-helper';
 
 import PluginsPage from '../lib/pages/plugins-page';
 import PluginsBrowserPage from '../lib/pages/plugins-browser-page';
@@ -15,6 +16,7 @@ import LoginFlow from '../lib/flows/login-flow';
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
 
 var driver;
 
@@ -23,7 +25,7 @@ test.before( 'Start Browser', function() {
 	driver = driverManager.startBrowser();
 } );
 
-test.describe( `Jetpack Sites on Calypso: '${ screenSize }'`, function() {
+test.describe.only( `${host} Jetpack Sites on Calypso: '${ screenSize }'`, function() {
 	this.timeout( mochaTimeOut );
 	this.bailSuite( true );
 
@@ -32,8 +34,8 @@ test.describe( `Jetpack Sites on Calypso: '${ screenSize }'`, function() {
 	} );
 
 	test.before( 'Can log in and go to the Plugins page', function() {
-		let loginFlow = new LoginFlow( driver, 'jetpackUser' );
-		loginFlow.loginAndSelectPlugins(); //assuming that it lands on our JP site
+		let loginFlow = new LoginFlow( driver, 'jetpackUser' + host );
+		loginFlow.loginAndSelectPlugins();
 	} );
 
 	test.describe( 'Can activate Hello Dolly', function() {

--- a/specs-jetpack-calypso/wp-jetpack-post-editor-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-post-editor-spec.js
@@ -25,6 +25,7 @@ import * as slackNotifier from '../lib/slack-notifier';
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
 
 var driver;
 
@@ -33,7 +34,7 @@ test.before( 'Start Browser', function() {
 	driver = driverManager.startBrowser();
 } );
 
-test.describe( 'Jetpack Site: Editor: Posts (' + screenSize + ')', function() {
+test.describe( host + ' Jetpack Site: Editor: Posts (' + screenSize + ')', function() {
 	this.bailSuite( true );
 	this.timeout( mochaTimeOut );
 
@@ -59,7 +60,7 @@ test.describe( 'Jetpack Site: Editor: Posts (' + screenSize + ')', function() {
 			const publicizeTwitterAccount = config.has( 'publicizeTwitterAccount' ) ? config.get( 'publicizeTwitterAccount' ) : '';
 
 			test.it( 'Can log in as a Jetpack user', function() {
-				let loginFlow = new LoginFlow( driver, 'jetpackUser' );
+				let loginFlow = new LoginFlow( driver, 'jetpackUser' + host );
 				return loginFlow.loginAndStartNewPost();
 			} );
 


### PR DESCRIPTION
This adds the ability to run Jetpack e2e automated tests against different hosts like Bluehost and GoDaddy by setting the `JETPACKHOST` environment variable to the host name, like `BLUEHOST` or `GODADDY`, and adding an appropriate config value for the associated WordPress.com account, eg. `jetpackUserBLUEHOST`