### PR TITLE
Add debug flag to visdiffs

### DIFF
--- a/lib/pages/devdocs-page.js
+++ b/lib/pages/devdocs-page.js
@@ -48,7 +48,7 @@ export default class DevdocsPage extends BaseContainer {
 			let promiseArray = [];
 			for ( const a of anchors ) {
 				promiseArray.push( a.getAttribute( 'href' ).then( function( href ) {
-					hrefs.push( href );
+					hrefs.push( href + '?debug=true' );
 				} ) );
 			}
 

--- a/lib/pages/devdocs-page.js
+++ b/lib/pages/devdocs-page.js
@@ -8,7 +8,7 @@ const by = webdriver.By;
 
 export default class DevdocsPage extends BaseContainer {
 	constructor( driver, visit ) {
-		const baseURL = 'https://wpcalypso.wordpress.com/devdocs?debug=true';
+		const baseURL = 'https://wpcalypso.wordpress.com/devdocs';
 		//const baseURL = 'http://calypso.localhost:3000/devdocs';
 
 		super( driver, by.css( '.devdocs.main' ), visit, baseURL );
@@ -21,19 +21,19 @@ export default class DevdocsPage extends BaseContainer {
 	}
 
 	openUIComponents() {
-		var url = this.baseURL + '/design';
+		var url = this.baseURL + '/design?debug=true';
 
 		return this.driver.get( url );
 	}
 
 	openTypography() {
-		var url = this.baseURL + '/design/typography';
+		var url = this.baseURL + '/design/typography?debug=true';
 
 		return this.driver.get( url );
 	}
 
 	openAppComponents() {
-		var url = this.baseURL + '/blocks';
+		var url = this.baseURL + '/blocks?debug=true';
 
 		return this.driver.get( url ).then( function() {}, function() {
 			slackWarn( `[${global.browserName}][${currentScreenSize()}] - Driver claims to have failed to get /devdocs/blocks.  Moving on anyway.` );

--- a/lib/pages/devdocs-page.js
+++ b/lib/pages/devdocs-page.js
@@ -8,7 +8,7 @@ const by = webdriver.By;
 
 export default class DevdocsPage extends BaseContainer {
 	constructor( driver, visit ) {
-		const baseURL = 'https://wpcalypso.wordpress.com/devdocs';
+		const baseURL = 'https://wpcalypso.wordpress.com/devdocs?debug=true';
 		//const baseURL = 'http://calypso.localhost:3000/devdocs';
 
 		super( driver, by.css( '.devdocs.main' ), visit, baseURL );


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/issues/11079 documents an issue with the new JS minimization (uglify) on Calypso that's causing the titles on a few components do behave strangely.  This PR adds the `?debug=true` flag to prevent minimization.