### PR TITLE
Removed check to use mobile.twitter.com

### DIFF
--- a/lib/pages/twitter-feed-page.js
+++ b/lib/pages/twitter-feed-page.js
@@ -8,13 +8,9 @@ const screenSize = driverManager.currentScreenSize();
 export default class TwitterFeedPage extends BaseContainer {
 	constructor( driver, twitterAccount, visit = false ) {
 		let url, expectedElementSelector;
-		if ( screenSize === 'mobile' ) {
-			url = `https://mobile.twitter.com/${twitterAccount}`;
-			expectedElementSelector = by.css( '.Timeline,#react-root' );
-		} else {
-			url = `https://twitter.com/${twitterAccount}`;
-			expectedElementSelector = by.css( '#timeline' );
-		}
+		url = `https://twitter.com/${twitterAccount}`;
+		expectedElementSelector = by.css( '#timeline' );
+
 		super( driver, expectedElementSelector, visit, url );
 	}
 


### PR DESCRIPTION
The mobile version of Twitter's website is throwing API rate limit errors when accessed from the CI servers.  We're not actually doing any visual validation of the Twitter site, just verifying that the tweet showed up, so there's no need to actually check that.  This PR just removes that check and loads twitter.com for everything.