### PR TITLE
Fixed JETPACKHOST variable setting, bug with option ordering

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -99,7 +99,7 @@ while getopts ":Rpb:s:givwl:cm:fhjH:" opt; do
       TARGET="specs-jetpack-calypso/"
       ;;
     H)
-      JETPACKHOST=$OPTARG
+      export JETPACKHOST=$OPTARG
       ;;
     f)
       NODE_CONFIG_ARGS+=("\"failVisdiffs\":\"true\"")
@@ -120,6 +120,7 @@ while getopts ":Rpb:s:givwl:cm:fhjH:" opt; do
   esac
 
   TARGETS+=("$TARGET")
+  unset TARGET
 done
 
 # Skip any tests in the given variable


### PR DESCRIPTION
The envvar needed to be `export`ed to get picked up by mocha.  I also uncovered a bug that would lead to the tests being run multiple times, so that's fixed here as well.