### PR TITLE
Added LinkedIn ads domains to /etc/hosts on CI to avoid timeouts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,9 @@
 machine:
   node:
     version: 6.9.4
+  hosts:
+    linkedin.com: 127.0.0.1
+    snap.licdn.com: 127.0.0.1
 
 general:
   artifacts:


### PR DESCRIPTION
The logged-out homepage of WordPress.com is loading an ad tracker from LinkedIn that's frequently timing out the tests.  This PR stubs out the address to the LinkedIn domains so it doesn't affect us.