### PR TITLE
Updated README and config examples

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -11,9 +11,9 @@
   "browser": "chrome",
   "proxy": "direct",
   "saveAllScreenshots": false,
+  "neverSaveScreenshots": false,
   "checkForConsoleErrors": false,
   "reportWarningsToSlack": false,
-  "neverSaveScreenshots": false,
   "sauceConfigurations": {
     "osx-chrome": {
         "browserName": "chrome",

--- a/config/local.example.json
+++ b/config/local.example.json
@@ -14,11 +14,11 @@
 	* Remove this comment :)
 */
 {
-	"calypsoBaseURL": "https://wpcalypso.wordpress.com",
 	"highlightElements": true,
 	"testSiteForInvites": "example.wordpress.com",
+	"testSiteForNotifications": "example.wordpress.com",
 	"privateSiteForInvites": "example.wordpress.com",
-	"passwordForNewTestSignUps": "password",
+	"passwordForNewTestSignUps":: "",
 	"storeSandboxCookieValue": "",
 	"publicizeTwitterAccount": "",
 	"slackHook": "",
@@ -27,14 +27,9 @@
 	"signupInboxId": "",
 	"domainsInboxId": "",
 	"eyesKey": "",
-	"testSiteForNotifications": "example.wordpress.com",
 	"sauceUsername": "",
 	"sauceAccessKey": "",
-	"sauceUsernameIOS": "",
-	"sauceAccessKeyIOS": "",
-        "selfHostedURL": "",
-	"iOSLocalApp": "",
-	"reportWarningsToSlack": true,
+	"emailPrefix": "",
 	"testAccounts": {
 		"defaultUser": [
 			"username",
@@ -48,6 +43,18 @@
 			"username",
 			"password"
 		],
+		"jetpackUserPRESSABLE": [
+			"username",
+			"password"
+		],
+		"jetpackUserBLUEHOST": [
+			"username",
+			"password"
+		],
+		"jetpackUserGODADDY": [
+			"username",
+			"password"
+		],
 		"visualUser": [
 			"username",
 			"password"
@@ -57,42 +64,38 @@
 			"password"
 		],
 		"commentingUser": [
-		  "username",
-		  "password"
-		],
-		"notificationsUser": [
-		  "username",
-		  "password"
-		],
-		"eurAccountUser": [
-		  "username",
-		  "password"
-		],
-		"audAccountUser": [
-		  "username",
-		  "password"
-		],
-		"cadAccountUser": [
-		  "username",
-		  "password"
-		],
-		"gbpAccountUser": [
-		  "username",
-		  "password"
-		],
-		"jpyAccountUser": [
-		  "username",
-		  "password"
-		],
-		"usdAccountUser": [
-		  "username",
-		  "password"
-		],
-		"postNUXUser": [
 			"username",
 			"password"
-		]
-		"selfHostedUser": [
+		],
+		"notificationsUser": [
+			"username",
+			"password"
+		],
+		"eurAccountUser": [
+			"username",
+			"password"
+		],
+		"audAccountUser": [
+			"username",
+			"password"
+		],
+		"cadAccountUser": [
+			"username",
+			"password"
+		],
+		"gbpAccountUser": [
+			"username",
+			"password"
+		],
+		"jpyAccountUser": [
+			"username",
+			"password"
+		],
+		"usdAccountUser": [
+			"username",
+			"password"
+		],
+		"postNUXUser": [
 			"username",
 			"password"
 		]

--- a/run.sh
+++ b/run.sh
@@ -43,7 +43,7 @@ if [ $# -eq 0 ]; then
   usage
 fi
 
-while getopts ":Rpb:s:givwl:cm:fhjH:" opt; do
+while getopts ":Rpb:s:gjH:wl:cm:fivh" opt; do
   case $opt in
     R)
       REPORTER="-R spec-xunit-slack-reporter"


### PR DESCRIPTION
This PR does the following:

1) Moved the Config / Environment Variables section of the README up so it's seen before the instructions to execute run.sh
2) Cleaned up the NODE_CONFIG parameters, added and removed the necessary entries to match what's currently in use
3) Updated the local.example.json file with all necessary accounts and other missing fields
4) Updated argument order in run.sh to match the help output
