### PR TITLE
Proper subteam ping format for Slack

### DIFF
--- a/lib/reporter/lib/spec-xunit-slack-reporter.js
+++ b/lib/reporter/lib/spec-xunit-slack-reporter.js
@@ -47,7 +47,7 @@ function SpecXUnitSlack( runner ) {
 
 			slackClient.send( {
 				icon_emoji: ':a8c:',
-				text: '<!flow-patrol-squad-team> Test Failed: *' + test.fullTitle() + '* - Build <https://circleci.com/gh/' + process.env.CIRCLE_PROJECT_USERNAME + '/' + process.env.CIRCLE_PROJECT_REPONAME + '/' + process.env.CIRCLE_BUILD_NUM + '|#' + process.env.CIRCLE_BUILD_NUM + '>',
+				text: '<!subteam^S0G7K98MB|flow-patrol-squad-team> Test Failed: *' + test.fullTitle() + '* - Build <https://circleci.com/gh/' + process.env.CIRCLE_PROJECT_USERNAME + '/' + process.env.CIRCLE_PROJECT_REPONAME + '/' + process.env.CIRCLE_BUILD_NUM + '|#' + process.env.CIRCLE_BUILD_NUM + '>',
 				fields: fieldsObj,
 				username: 'e2e Test Runner'
 			} );

--- a/specs-visdiff/wp-devdocs-visdiff.js
+++ b/specs-visdiff/wp-devdocs-visdiff.js
@@ -86,11 +86,11 @@ test.describe( `DevDocs Visual Diff (${screenSizeName})`, function() {
 				let message = '';
 
 				if ( testResults.mismatches ) {
-					message = `<!flow-patrol-squad-team> Visual diff failed with ${testResults.mismatches} mismatches - ${testResults.appUrls.session}`;
+					message = `<!subteam^S0G7K98MB|flow-patrol-squad-team> Visual diff failed with ${testResults.mismatches} mismatches - ${testResults.appUrls.session}`;
 				} else if ( testResults.missing ) {
-					message = `<!flow-patrol-squad-team> Visual diff failed with ${testResults.missing} missing steps out of ${testResults.steps} - ${testResults.appUrls.session}`;
+					message = `<!subteam^S0G7K98MB|flow-patrol-squad-team> Visual diff failed with ${testResults.missing} missing steps out of ${testResults.steps} - ${testResults.appUrls.session}`;
 				} else if ( testResults.isNew ) {
-					message = `<!flow-patrol-squad-team> Visual diff marked as failed because it is a new baseline - ${testResults.appUrls.session}`;
+					message = `<!subteam^S0G7K98MB|flow-patrol-squad-team> Visual diff marked as failed because it is a new baseline - ${testResults.appUrls.session}`;
 				}
 
 				if ( message !== '' ) {


### PR DESCRIPTION
Follow-up to #394, as the subteam ping apparently has a unique format for the API - To ping a subteam there’s extra special formatting - https://api.slack.com/docs/message-formatting#linking_to_channels_and_users (down under Variables for some reason) 