### PR TITLE
Add Jetpack plans e2e scenario

### DIFF
--- a/lib/pages/plans-page.js
+++ b/lib/pages/plans-page.js
@@ -8,7 +8,7 @@ const until = webdriver.until;
 
 export default class PlansPage extends BaseContainer {
 	constructor( driver ) {
-		super( driver, by.css( '.current-plan' ) );
+		super( driver, by.css( '.is-section-plans' ) );
 	}
 	openPlansTab() {
 		driverHelper.ensureMobileMenuOpen( this.driver );
@@ -18,34 +18,19 @@ export default class PlansPage extends BaseContainer {
 	waitForComparison() {
 		return this.driver.wait( until.elementLocated( by.css( '.plans-features-main__group' ) ), this.explicitWaitMS, 'Could not locate the compare plans page' );
 	}
+
 	returnFromComparison() {
 		const selector = by.css( '.header-cake__back' );
 		return driverHelper.clickWhenClickable( this.driver, selector, this.explicitWaitMS );
 	}
-	purchasePremium() {
-		var d = webdriver.promise.defer();
 
-		var testCardHolder = 'End To End Testing';
-		var testVisaNumber = '4242424242424242'; // https://stripe.com/docs/testing#cards
-		var testVisaExpiry = '02/19';
-		var testCVV = '300';
-		var testCardCountryCode = 'TR'; // using Turkey to force Stripe as payment processor
-		var testCardPostCode = '4000';
-
-		this.driver.findElement( by.css( '.plan.value_bundle button' ) ).click();
-		let securePaymentComponent = new SecurePaymentComponent( this.driver );
-		securePaymentComponent.enterTestCreditCardDetails( testCardHolder, testVisaNumber, testVisaExpiry, testCVV, testCardCountryCode, testCardPostCode );
-		securePaymentComponent.submitPaymentDetails();
-
-		this.driver.wait( until.elementLocated( by.className( 'checkout-thank-you' ) ), this.explicitWaitMS, 'Could not locate the checkout thank you page' );
-
-		d.fulfill( true );
-		return d.promise;
-	}
-
-	// For GM 2016 Class!
 	confirmCurrentPlan( planName ) {
 		const selector = by.css( `.is-current.is-${planName}-plan` );
+		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, selector );
+	}
+
+	planTypesShown( planType ) {
+		const selector = by.css( `[data-e2e-plans="${planType}"]` );
 		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, selector );
 	}
 }

--- a/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -1,0 +1,73 @@
+import test from 'selenium-webdriver/testing';
+import config from 'config';
+import assert from 'assert';
+
+import * as driverManager from '../lib/driver-manager';
+import * as dataHelper from '../lib/data-helper';
+
+import LoginFlow from '../lib/flows/login-flow';
+
+import PlansPage from '../lib/pages/plans-page';
+import StatsPage from '../lib/pages/stats-page';
+
+import SidebarComponent from '../lib/components/sidebar-component';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
+
+var driver;
+
+test.before( 'Start Browser', function() {
+	this.timeout( startBrowserTimeoutMS );
+	driver = driverManager.startBrowser();
+} );
+
+test.describe( host + ' Jetpack Plans: (' + screenSize + ')', function() {
+	this.timeout( mochaTimeOut );
+
+	test.describe( 'Comparing Plans:', function() {
+		this.bailSuite( true );
+
+		test.before( 'Delete Cookies and Local Storage', function() {
+			return driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		} );
+
+		test.it( 'Login and Select My Site', function() {
+			this.loginFlow = new LoginFlow( driver, 'jetpackUser' + host );
+			return this.loginFlow.loginAndSelectMySite();
+		} );
+
+		test.describe( 'Can compare plans', function() {
+
+			test.it( 'Can Select Plans', function() {
+				this.statsPage = new StatsPage( driver );
+				this.statsPage.waitForPage();
+				this.sideBarComponent = new SidebarComponent( driver );
+				return this.sideBarComponent.selectPlan();
+			} );
+
+			test.it( 'Can See Plans', function() {
+				this.plansPage = new PlansPage( driver );
+				return this.plansPage.waitForPage();
+			} );
+
+			test.it( 'Can See Jetpack Plans for Comparison', function() {
+				this.plansPage = new PlansPage( driver );
+				this.plansPage.openPlansTab();
+				this.plansPage.waitForComparison();
+				return this.plansPage.planTypesShown( 'jetpack' ).then( ( displayed ) => {
+					assert( displayed, 'The Jetpack plans are NOT displayed' );
+				} );
+			} );
+
+			test.it( 'Can Verify Current Plan', function() {
+				const planName = 'premium';
+				return this.plansPage.confirmCurrentPlan( planName ).then( function( present ) {
+					assert( present, `Failed to detect correct plan (${planName})` );
+				} );
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
This adds a new scenario to the current Jetpack e2e tests in Calypso that checks the user's current plan and makes sure that Jetpack (NOT WordPress.com) plans are displayed