### PR TITLE
Support theme magic search

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -54,7 +54,7 @@
         "version": "11.103"
     }
   },
-  "knownABTestKeys": [ "multiDomainRegistrationV1", "signupStore", "signupStoreBenchmarking", "browserNotifications", "domainSuggestionPopover", "signupThemeUpload", "siteTitleStep", "jetpackConnectPlansFirst", "userFirstSignup", "premiumSquaredPlansWording", "domainContactNewPhoneInput", "boostedPostSurvey", "readerSearchOnFollowing" ],
+  "knownABTestKeys": [ "multiDomainRegistrationV1", "signupStore", "signupStoreBenchmarking", "browserNotifications", "domainSuggestionPopover", "signupThemeUpload", "siteTitleStep", "jetpackConnectPlansFirst", "userFirstSignup", "premiumSquaredPlansWording", "domainContactNewPhoneInput", "boostedPostSurvey", "readerSearchOnFollowing", "siteTitleTour" ],
   "overrideABTests": [
 	[ "signupStore_20160927", "designTypeWithStore" ],
 	[ "browserNotifications_20160628", "disabled" ],

--- a/lib/pages/themes-page.js
+++ b/lib/pages/themes-page.js
@@ -69,11 +69,10 @@ export default class ThemesPage extends BaseContainer {
 	}
 
 	searchFor( phrase ) {
-		const searchToggleSelector = by.css( 'div.themes__search-card div.search' );
-		const searchFieldSelector = by.css( '.themes__search-card .search input' );
+		const searchToggleSelector = by.css( '#primary div.search' );
+		const searchFieldSelector = by.css( '#primary input.search__input' );
 		driverHelper.clickWhenClickable( this.driver, searchToggleSelector, this.explicitWaitMS );
-		driverHelper.waitForFieldClearable( this.driver, searchFieldSelector, this.explicitWaitMS );
-		this.driver.findElement( searchFieldSelector ).sendKeys( phrase );
+		driverHelper.setWhenSettable( this.driver, searchFieldSelector, phrase );
 		return this.waitUntilThemesLoaded();
 	}
 


### PR DESCRIPTION
Theme magic search is currently enabled in development and wp-calypso.

This adds support for this but also is backwards compatible as this is what is in production.