### PR TITLE
Add support for editor layout design

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -19,15 +19,27 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 		this.switchToComponentOnMobileIfNecessary();
 	}
 	switchToComponentOnMobileIfNecessary() {
-		const actionButtonsSelector = By.css( '.editor-mobile-navigation__tabs .gridicons-cog.editor-mobile-navigation__icon' );
-		const postStatusSelector = By.css( '.editor-ground-control__status' );
-		this.driver.findElement( postStatusSelector ).isDisplayed().then( ( postStatusDisplayed ) => {
-			if ( postStatusDisplayed === false ) {
-				driverHelper.clickWhenClickable( this.driver, actionButtonsSelector, this.explicitWaitMS );
-				let postStatus = this.driver.findElement( postStatusSelector );
-				this.driver.wait( until.elementIsVisible( postStatus ), this.explicitWaitMS, 'Could not locate the post status element in the editor sidebar when switching to it in mobile mode' );
-			}
-		} );
+		if ( process.env.USE_NEW_EDITOR === 'true' ) {
+			const driver = this.driver;
+			const contentSelector = By.css( 'div.is-section-post-editor' );
+			const cogSelector = By.css( 'button.editor-ground-control__toggle-sidebar' );
+			driverHelper.waitTillPresentAndDisplayed( driver, contentSelector );
+			driver.findElement( contentSelector ).getAttribute( 'class' ).then( ( c ) => {
+				if ( c.indexOf( 'focus-sidebar' ) < 0 ) {
+					driverHelper.clickWhenClickable( driver, cogSelector );
+				}
+			} );
+		} else {
+			const actionButtonsSelector = By.css( '.editor-mobile-navigation__tabs .gridicons-cog.editor-mobile-navigation__icon' );
+			const postStatusSelector = By.css( '.editor-ground-control__status' );
+			this.driver.findElement( postStatusSelector ).isDisplayed().then( ( postStatusDisplayed ) => {
+				if ( postStatusDisplayed === false ) {
+					driverHelper.clickWhenClickable( this.driver, actionButtonsSelector, this.explicitWaitMS );
+					let postStatus = this.driver.findElement( postStatusSelector );
+					this.driver.wait( until.elementIsVisible( postStatus ), this.explicitWaitMS, 'Could not locate the post status element in the editor sidebar when switching to it in mobile mode' );
+				}
+			} );
+		}
 	}
 	ensureSaved() {
 		const saveSelector = By.css( 'button.editor-ground-control__save' );
@@ -185,8 +197,14 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 	}
 
 	setVisibilityToPrivate() {
-		const visibilitySelector = By.css( '.post-editor__sidebar .editor-action-bar button.editor-visibility' );
+		let visibilitySelector;
 		const driver = this.driver;
+		if ( process.env.USE_NEW_EDITOR === 'true' ) {
+			this._expandOrCollapseSection( 'status', true );
+			visibilitySelector = By.css( '.editor-visibility button' );
+		} else {
+			visibilitySelector = By.css( '.post-editor__sidebar .editor-action-bar button.editor-visibility' );
+		}
 		driverHelper.clickWhenClickable( driver, visibilitySelector );
 		driverHelper.clickWhenClickable( driver, By.css( 'input[value=private]' ) );
 		driverHelper.clickWhenClickable( driver, By.css( '.dialog button.is-primary' ) ); //Click Yes to publish
@@ -194,21 +212,40 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 	}
 
 	setVisibilityToPasswordProtected( password ) {
-		const visibilitySelector = By.css( '.post-editor__sidebar .editor-action-bar button.editor-visibility' );
+		let visibilitySelector;
 		const driver = this.driver;
+		if ( process.env.USE_NEW_EDITOR === 'true' ) {
+			this._expandOrCollapseSection( 'status', true );
+			visibilitySelector = By.css( '.editor-visibility button' );
+		} else {
+			visibilitySelector = By.css( '.post-editor__sidebar .editor-action-bar button.editor-visibility' );
+		}
 		driverHelper.clickWhenClickable( driver, visibilitySelector );
 		driverHelper.clickWhenClickable( driver, By.css( 'input[value=password]' ) );
 		return driverHelper.setWhenSettable( driver, By.css( 'div.editor-visibility__dialog input[type=text]' ), password, { secureValue: true } );
 	}
 
 	trashPost() {
-		driverHelper.clickWhenClickable( this.driver, By.css( '.post-editor__sidebar button.editor-delete-post' ) );
+		let trashSelector;
+		if ( process.env.USE_NEW_EDITOR === 'true' ) {
+			trashSelector = By.css( 'button.editor-delete-post__button' );
+		} else {
+			trashSelector = By.css( '.post-editor__sidebar button.editor-delete-post' );
+		}
+		driverHelper.clickWhenClickable( this.driver, trashSelector );
 		return driverHelper.clickWhenClickable( this.driver, By.css( '.dialog button.is-primary' ) );
 	}
 
 	_expandOrCollapseSection( sectionName, expand = true ) {
-		const headerSelector = By.css( `div.editor-${sectionName}` );
-		const toggleSelector = By.css( `div.editor-${sectionName} button.accordion__toggle` );
+		let headerSelector;
+		let toggleSelector;
+		if ( sectionName === 'status' ) {
+			headerSelector = By.css( `div.accordion` );
+			toggleSelector = By.css( `div.accordion button.accordion__toggle` );
+		} else {
+			headerSelector = By.css( `div.editor-${sectionName}` );
+			toggleSelector = By.css( `div.editor-${sectionName} button.accordion__toggle` );
+		}
 		const explicitWaitMS = this.explicitWaitMS;
 		const driver = this.driver;
 

--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -11,7 +11,7 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.post-editor__sidebar' ) );
 		this.publicizeMessageSelector = By.css( 'div.editor-sharing__message-input textarea' );
-		if ( driverManager.currentScreenSize() === 'mobile' ) {
+		if ( driverManager.currentScreenSize() === 'mobile' && process.env.USE_NEW_EDITOR !== 'true' ) {
 			this.publishButtonSelector = By.css( '.editor-mobile-navigation .editor-publish-button' );
 		} else {
 			this.publishButtonSelector = By.css( '.editor-ground-control__publish-combo .editor-publish-button' )

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -26,16 +26,26 @@ export default class EditorPage extends BaseContainer {
 		this.editorFrameName = by.css( '.mce-edit-area iframe' );
 		this.saveSelector = by.css( 'button.editor-ground-control__save' );
 
-		const writeButtonSelector = by.css( '.editor-mobile-navigation__tabs .gridicons-pencil.editor-mobile-navigation__icon' );
-		driver.findElement( writeButtonSelector ).isDisplayed().then( function( writeButtonDisplayed ) {
-			if ( writeButtonDisplayed === true ) {
-				driver.findElement( writeButtonSelector ).getAttribute( 'class' ).then( ( c ) => {
-					if ( c.indexOf( 'is-selected' ) < 0 ) {
-						driverHelper.clickWhenClickable( driver, writeButtonSelector );
-					}
-				} );
-			}
-		} );
+		if ( process.env.USE_NEW_EDITOR === 'true' ) {
+			const cogSelector = by.css( 'div.is-section-post-editor' );
+			driverHelper.waitTillPresentAndDisplayed( driver, cogSelector );
+			driver.findElement( cogSelector ).getAttribute( 'class' ).then( ( c ) => {
+				if ( c.indexOf( 'focus-content' ) < 0 ) {
+					driverHelper.clickWhenClickable( driver, cogSelector );
+				}
+			} );
+		} else {
+			const writeButtonSelector = by.css( '.editor-mobile-navigation__tabs .gridicons-pencil.editor-mobile-navigation__icon' );
+			driver.findElement( writeButtonSelector ).isDisplayed().then( function( writeButtonDisplayed ) {
+				if ( writeButtonDisplayed === true ) {
+					driver.findElement( writeButtonSelector ).getAttribute( 'class' ).then( ( c ) => {
+						if ( c.indexOf( 'is-selected' ) < 0 ) {
+							driverHelper.clickWhenClickable( driver, writeButtonSelector );
+						}
+					} );
+				}
+			} );
+		}
 
 		this.waitForPage();
 		this.ensureEditorShown();

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -27,9 +27,10 @@ export default class EditorPage extends BaseContainer {
 		this.saveSelector = by.css( 'button.editor-ground-control__save' );
 
 		if ( process.env.USE_NEW_EDITOR === 'true' ) {
-			const cogSelector = by.css( 'div.is-section-post-editor' );
-			driverHelper.waitTillPresentAndDisplayed( driver, cogSelector );
-			driver.findElement( cogSelector ).getAttribute( 'class' ).then( ( c ) => {
+			const contentSelector = by.css( 'div.is-section-post-editor' );
+			const cogSelector = by.css( 'button.editor-ground-control__toggle-sidebar' );
+			driverHelper.waitTillPresentAndDisplayed( driver, contentSelector );
+			driver.findElement( contentSelector ).getAttribute( 'class' ).then( ( c ) => {
 				if ( c.indexOf( 'focus-content' ) < 0 ) {
 					driverHelper.clickWhenClickable( driver, cogSelector );
 				}

--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -162,7 +162,7 @@ test.describe( 'Editor: Pages (' + screenSize + ')', function() {
 			} );
 
 			test.it( 'Can set visibility to private', function() {
-				if ( screenSize === 'mobile' ) {
+				if ( screenSize === 'mobile' || process.env.USE_NEW_EDITOR === 'true' ) {
 					const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 					postEditorSidebarComponent.setVisibilityToPrivate();
 				} else {
@@ -223,7 +223,7 @@ test.describe( 'Editor: Pages (' + screenSize + ')', function() {
 			test.it( 'Can enter page title and content and set to password protected', function() {
 				this.editorPage = new EditorPage( driver );
 				this.editorPage.enterTitle( pageTitle );
-				if ( screenSize === 'mobile' ) {
+				if ( screenSize === 'mobile' || process.env.USE_NEW_EDITOR === 'true' ) {
 					this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 					this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
 				} else {

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -317,7 +317,7 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 				} );
 
 				test.it( 'Can set visibility to private which immediately publishes it', function() {
-					if ( screenSize === 'mobile' ) {
+					if ( screenSize === 'mobile' || process.env.USE_NEW_EDITOR === 'true' ) {
 						const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 						postEditorSidebarComponent.setVisibilityToPrivate();
 					} else {
@@ -396,7 +396,7 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 			test.it( 'Can enter post title and content and set to password protected', function() {
 				this.editorPage = new EditorPage( driver );
 				this.editorPage.enterTitle( blogPostTitle );
-				if ( screenSize === 'mobile' ) {
+				if ( screenSize === 'mobile' || process.env.USE_NEW_EDITOR === 'true' ) {
 					this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 					this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
 				} else {
@@ -710,7 +710,7 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 			} );
 
 			test.it( 'Can trash the new post', function() {
-				if ( screenSize === 'mobile' ) {
+				if ( screenSize === 'mobile' || process.env.USE_NEW_EDITOR === 'true' ) {
 					const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 					postEditorSidebarComponent.trashPost();
 				} else {


### PR DESCRIPTION
This is controlled by an environment variable USE_NEW_EDITOR which should be set to true on CircleCI when the editor goes live from this PR: https://github.com/Automattic/wp-calypso/pull/11536