### PR TITLE
Fix media modal tests for new action bar

### DIFF
--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -113,13 +113,6 @@ export default class EditorPage extends BaseContainer {
 	deleteMedia() {
 		const driver = this.driver;
 		let deleteSelector = webdriver.By.css( '.editor-media-modal__delete' );
-		if ( screenSize === 'mobile' ) {
-			const ellipsisSelector = webdriver.By.css( '.editor-media-modal__secondary-action.is-mobile' );
-			driver.wait( until.elementLocated( ellipsisSelector ), this.explicitWaitMS, 'Could not locate the ellipsis button' );
-			const ellipsisButton = driver.findElement( ellipsisSelector );
-			ellipsisButton.click();
-			deleteSelector = webdriver.By.xpath( "//button[contains(@class, 'popover__menu-item') and contains(text(), 'Delete' )]" );
-		}
 		driver.wait( until.elementLocated( deleteSelector ), this.explicitWaitMS, 'Could not locate the delete button in the media library' );
 		const deleteButton = driver.findElement( deleteSelector );
 		driver.wait( until.elementIsEnabled( deleteButton ), this.explicitWaitMS, 'The delete button is not enabled' );

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -133,7 +133,8 @@ export default class EditorPage extends BaseContainer {
 
 	dismissMediaModal() {
 		const driver = this.driver;
-		driver.findElement( by.css( '.editor-media-modal__secondary-actions + .button' ) ).click();
+		const cancelSelector = webdriver.By.xpath( "//div[contains(@class, 'editor-media-modal')]//span[contains(@class, 'dialog__button-label') and contains(text(), 'Cancel' )]" );
+		driver.findElement( cancelSelector ).click();
 		driver.wait( elementIsNotPresent( '.dialog__backdrop.is-full-screen' ), this.explicitWaitMS, 'Dialog is still present' );
 	}
 


### PR DESCRIPTION
This PR updates the selectors in the `deleteMedia` and `dismissMediaModal` page helpers.

### Testing Instructions
- Test against the Calypso branch`try/media-section-v2` in https://github.com/Automattic/wp-calypso/pull/11822
- The upload media suite should be ✅  on all viewport sizes
```bash
$> ./node_modules/mocha/bin/mocha specs/wp-media-upload-spec.js
$> env  BROWSERSIZE=mobile ./node_modules/mocha/bin/mocha specs/wp-media-upload-spec.js
$> env  BROWSERSIZE=tablet ./node_modules/mocha/bin/mocha specs/wp-media-upload-spec.js
```