### PR TITLE
Removed references to USE_NEW_EDITOR flag

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -11,35 +11,19 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.post-editor__sidebar' ) );
 		this.publicizeMessageSelector = By.css( 'div.editor-sharing__message-input textarea' );
-		if ( driverManager.currentScreenSize() === 'mobile' && process.env.USE_NEW_EDITOR !== 'true' ) {
-			this.publishButtonSelector = By.css( '.editor-mobile-navigation .editor-publish-button' );
-		} else {
-			this.publishButtonSelector = By.css( '.editor-ground-control__publish-combo .editor-publish-button' )
-		}
+		this.publishButtonSelector = By.css( '.editor-mobile-navigation .editor-publish-button' );
 		this.switchToComponentOnMobileIfNecessary();
 	}
 	switchToComponentOnMobileIfNecessary() {
-		if ( process.env.USE_NEW_EDITOR === 'true' ) {
-			const driver = this.driver;
-			const contentSelector = By.css( 'div.is-section-post-editor' );
-			const cogSelector = By.css( 'button.editor-ground-control__toggle-sidebar' );
-			driverHelper.waitTillPresentAndDisplayed( driver, contentSelector );
-			driver.findElement( contentSelector ).getAttribute( 'class' ).then( ( c ) => {
-				if ( c.indexOf( 'focus-sidebar' ) < 0 ) {
-					driverHelper.clickWhenClickable( driver, cogSelector );
-				}
-			} );
-		} else {
-			const actionButtonsSelector = By.css( '.editor-mobile-navigation__tabs .gridicons-cog.editor-mobile-navigation__icon' );
-			const postStatusSelector = By.css( '.editor-ground-control__status' );
-			this.driver.findElement( postStatusSelector ).isDisplayed().then( ( postStatusDisplayed ) => {
-				if ( postStatusDisplayed === false ) {
-					driverHelper.clickWhenClickable( this.driver, actionButtonsSelector, this.explicitWaitMS );
-					let postStatus = this.driver.findElement( postStatusSelector );
-					this.driver.wait( until.elementIsVisible( postStatus ), this.explicitWaitMS, 'Could not locate the post status element in the editor sidebar when switching to it in mobile mode' );
-				}
-			} );
-		}
+		const driver = this.driver;
+		const contentSelector = By.css( 'div.is-section-post-editor' );
+		const cogSelector = By.css( 'button.editor-ground-control__toggle-sidebar' );
+		driverHelper.waitTillPresentAndDisplayed( driver, contentSelector );
+		driver.findElement( contentSelector ).getAttribute( 'class' ).then( ( c ) => {
+			if ( c.indexOf( 'focus-sidebar' ) < 0 ) {
+				driverHelper.clickWhenClickable( driver, cogSelector );
+			}
+		} );
 	}
 	ensureSaved() {
 		const saveSelector = By.css( 'button.editor-ground-control__save' );
@@ -199,12 +183,8 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 	setVisibilityToPrivate() {
 		let visibilitySelector;
 		const driver = this.driver;
-		if ( process.env.USE_NEW_EDITOR === 'true' ) {
-			this._expandOrCollapseSection( 'status', true );
-			visibilitySelector = By.css( '.editor-visibility button' );
-		} else {
-			visibilitySelector = By.css( '.post-editor__sidebar .editor-action-bar button.editor-visibility' );
-		}
+		this._expandOrCollapseSection( 'status', true );
+		visibilitySelector = By.css( '.editor-visibility button' );
 		driverHelper.clickWhenClickable( driver, visibilitySelector );
 		driverHelper.clickWhenClickable( driver, By.css( 'input[value=private]' ) );
 		driverHelper.clickWhenClickable( driver, By.css( '.dialog button.is-primary' ) ); //Click Yes to publish
@@ -214,12 +194,8 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 	setVisibilityToPasswordProtected( password ) {
 		let visibilitySelector;
 		const driver = this.driver;
-		if ( process.env.USE_NEW_EDITOR === 'true' ) {
-			this._expandOrCollapseSection( 'status', true );
-			visibilitySelector = By.css( '.editor-visibility button' );
-		} else {
-			visibilitySelector = By.css( '.post-editor__sidebar .editor-action-bar button.editor-visibility' );
-		}
+		this._expandOrCollapseSection( 'status', true );
+		visibilitySelector = By.css( '.editor-visibility button' );
 		driverHelper.clickWhenClickable( driver, visibilitySelector );
 		driverHelper.clickWhenClickable( driver, By.css( 'input[value=password]' ) );
 		return driverHelper.setWhenSettable( driver, By.css( 'div.editor-visibility__dialog input[type=text]' ), password, { secureValue: true } );
@@ -227,11 +203,7 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 
 	trashPost() {
 		let trashSelector;
-		if ( process.env.USE_NEW_EDITOR === 'true' ) {
-			trashSelector = By.css( 'button.editor-delete-post__button' );
-		} else {
-			trashSelector = By.css( '.post-editor__sidebar button.editor-delete-post' );
-		}
+		trashSelector = By.css( 'button.editor-delete-post__button' );
 		driverHelper.clickWhenClickable( this.driver, trashSelector );
 		return driverHelper.clickWhenClickable( this.driver, By.css( '.dialog button.is-primary' ) );
 	}

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -26,27 +26,14 @@ export default class EditorPage extends BaseContainer {
 		this.editorFrameName = by.css( '.mce-edit-area iframe' );
 		this.saveSelector = by.css( 'button.editor-ground-control__save' );
 
-		if ( process.env.USE_NEW_EDITOR === 'true' ) {
-			const contentSelector = by.css( 'div.is-section-post-editor' );
-			const cogSelector = by.css( 'button.editor-ground-control__toggle-sidebar' );
-			driverHelper.waitTillPresentAndDisplayed( driver, contentSelector );
-			driver.findElement( contentSelector ).getAttribute( 'class' ).then( ( c ) => {
-				if ( c.indexOf( 'focus-content' ) < 0 ) {
-					driverHelper.clickWhenClickable( driver, cogSelector );
-				}
-			} );
-		} else {
-			const writeButtonSelector = by.css( '.editor-mobile-navigation__tabs .gridicons-pencil.editor-mobile-navigation__icon' );
-			driver.findElement( writeButtonSelector ).isDisplayed().then( function( writeButtonDisplayed ) {
-				if ( writeButtonDisplayed === true ) {
-					driver.findElement( writeButtonSelector ).getAttribute( 'class' ).then( ( c ) => {
-						if ( c.indexOf( 'is-selected' ) < 0 ) {
-							driverHelper.clickWhenClickable( driver, writeButtonSelector );
-						}
-					} );
-				}
-			} );
-		}
+		const contentSelector = by.css( 'div.is-section-post-editor' );
+		const cogSelector = by.css( 'button.editor-ground-control__toggle-sidebar' );
+		driverHelper.waitTillPresentAndDisplayed( driver, contentSelector );
+		driver.findElement( contentSelector ).getAttribute( 'class' ).then( ( c ) => {
+			if ( c.indexOf( 'focus-content' ) < 0 ) {
+				driverHelper.clickWhenClickable( driver, cogSelector );
+			}
+		} );
 
 		this.waitForPage();
 		this.ensureEditorShown();

--- a/specs-jetpack-calypso/wp-jetpack-post-editor-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-post-editor-spec.js
@@ -276,13 +276,8 @@ test.describe( host + ' Jetpack Site: Editor: Posts (' + screenSize + ')', funct
 				} );
 
 				test.it( 'Can set visibility to private which immediately publishes it', function() {
-					if ( screenSize === 'mobile' || process.env.USE_NEW_EDITOR  ) {
-						const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
-						postEditorSidebarComponent.setVisibilityToPrivate();
-					} else {
-						const editorPage = new EditorPage( driver );
-						editorPage.setVisibilityToPrivate();
-					}
+					const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+					postEditorSidebarComponent.setVisibilityToPrivate();
 					const editorPage = new EditorPage( driver );
 					editorPage.viewPublishedPostOrPage();
 				} );
@@ -324,12 +319,8 @@ test.describe( host + ' Jetpack Site: Editor: Posts (' + screenSize + ')', funct
 			test.it( 'Can start a new post and enter post title and content - set to password protected', function() {
 				this.editorPage = new EditorPage( driver );
 				this.editorPage.enterTitle( blogPostTitle );
-				if ( screenSize === 'mobile' || process.env.USE_NEW_EDITOR  ) {
-					this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
-					this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
-				} else {
-					this.editorPage.setVisibilityToPasswordProtected( postPassword );
-				}
+				this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+				this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
 				this.editorPage = new EditorPage( driver );
 				this.editorPage.enterContent( blogPostQuote );
 				this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
@@ -517,13 +508,8 @@ test.describe( host + ' Jetpack Site: Editor: Posts (' + screenSize + ')', funct
 			} );
 
 			test.it( 'Can trash the new post', function() {
-				if ( screenSize === 'mobile' || process.env.USE_NEW_EDITOR ) {
-					const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
-					postEditorSidebarComponent.trashPost();
-				} else {
-					let editorPage = new EditorPage( driver );
-					editorPage.trashPost();
-				}
+				const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+				postEditorSidebarComponent.trashPost();
 			} );
 
 			test.it( 'Can then see the Reader page', function() {

--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -162,13 +162,8 @@ test.describe( 'Editor: Pages (' + screenSize + ')', function() {
 			} );
 
 			test.it( 'Can set visibility to private', function() {
-				if ( screenSize === 'mobile' || process.env.USE_NEW_EDITOR === 'true' ) {
-					const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
-					postEditorSidebarComponent.setVisibilityToPrivate();
-				} else {
-					const editorPage = new EditorPage( driver );
-					editorPage.setVisibilityToPrivate();
-				}
+				const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+				postEditorSidebarComponent.setVisibilityToPrivate();
 			} );
 
 			test.describe( 'Publish and View', function() {
@@ -223,13 +218,8 @@ test.describe( 'Editor: Pages (' + screenSize + ')', function() {
 			test.it( 'Can enter page title and content and set to password protected', function() {
 				this.editorPage = new EditorPage( driver );
 				this.editorPage.enterTitle( pageTitle );
-				if ( screenSize === 'mobile' || process.env.USE_NEW_EDITOR === 'true' ) {
-					this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
-					this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
-				} else {
-					this.editorPage = new EditorPage( driver );
-					this.editorPage.setVisibilityToPasswordProtected( postPassword );
-				}
+				this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+				this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
 				this.editorPage = new EditorPage( driver );
 				this.editorPage.enterContent( pageQuote );
 				this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -317,13 +317,8 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 				} );
 
 				test.it( 'Can set visibility to private which immediately publishes it', function() {
-					if ( screenSize === 'mobile' || process.env.USE_NEW_EDITOR === 'true' ) {
-						const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
-						postEditorSidebarComponent.setVisibilityToPrivate();
-					} else {
-						const editorPage = new EditorPage( driver );
-						editorPage.setVisibilityToPrivate();
-					}
+					const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+					postEditorSidebarComponent.setVisibilityToPrivate();
 					const editorPage = new EditorPage( driver );
 					editorPage.viewPublishedPostOrPage();
 				} );
@@ -396,13 +391,8 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 			test.it( 'Can enter post title and content and set to password protected', function() {
 				this.editorPage = new EditorPage( driver );
 				this.editorPage.enterTitle( blogPostTitle );
-				if ( screenSize === 'mobile' || process.env.USE_NEW_EDITOR === 'true' ) {
-					this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
-					this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
-				} else {
-					this.editorPage.setVisibilityToPasswordProtected( postPassword );
-				}
-				this.editorPage = new EditorPage( driver );
+				this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+				this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
 				this.editorPage.enterContent( blogPostQuote );
 				this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 				this.postEditorSidebarComponent.ensureSaved();
@@ -710,13 +700,8 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 			} );
 
 			test.it( 'Can trash the new post', function() {
-				if ( screenSize === 'mobile' || process.env.USE_NEW_EDITOR === 'true' ) {
-					const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
-					postEditorSidebarComponent.trashPost();
-				} else {
-					let editorPage = new EditorPage( driver );
-					editorPage.trashPost();
-				}
+				const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+				postEditorSidebarComponent.trashPost();
 			} );
 
 			test.it( 'Can then see the Reader page', function() {


### PR DESCRIPTION
Since the new editor is now live, I removed the code for the old one (mostly because I was forgetting to set the envvar locally and constantly hitting failing tests).