### PR TITLE
Moved Slack token for screenshots from envvar to NODE_CONFIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ A full list of config values are:
 | publicizeTwitterAccount | This is the name of the test twitter account connected to your test username | @endtoendtesting | Yes | **NO** |
 | passwordForNewTestSignUps | This is the password that will be set for new sign ups created for testing purposes | alongcomplexpassword%### | Yes | **NO** |
 | storeSandboxCookieValue | This is a secret cookie value used for testing payments |  | No | **NO** |
-| slackHook | This is a Slack incoming webhook where notifications are sent for new accounts that are created (https://my.slack.com/services/new/incoming-webhook -- requires Slack login) | https://hooks.slack.com/services/XXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX | No | **NO** |
+| slackHook | This is a Slack incoming webhook where notifications are sent for test status (https://my.slack.com/services/new/incoming-webhook -- requires Slack login) | https://hooks.slack.com/services/XXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX | No | **NO** |
+| slackTokenForScreenshots | This is a Slack token used for uploading screenshots (https://api.slack.com/custom-integrations/legacy-tokens -- requires Slack login) | XXXX-XXXXXXXXXX-XXXXXXXXXX-XXXXXXXXXXX-XXXXXXXXXX | No | **NO** |
 | emailPrefix | A string to stick on the beginning of the e-mail addresses used for invites and signups | username | No | **NO** |
 | testAccounts | A JSON object with username/password pairs assigned to keynames for easy retrieval.  The necessary accounts can be found in the config/local.example.json file.  | {"defaultUser": ["username1","password1"], "multiSiteUser": ["username2","password2"] } | No | **NO** |
 | highlightElements | Boolean to indicate whether to visually highlight elements being interacted with on the page | true | No | Yes |

--- a/config/local.example.json
+++ b/config/local.example.json
@@ -22,6 +22,7 @@
 	"storeSandboxCookieValue": "",
 	"publicizeTwitterAccount": "",
 	"slackHook": "",
+	"slackTokenForScreenshots": "",	
 	"mailosaurAPIKey": "",
 	"inviteInboxId": "",
 	"signupInboxId": "",

--- a/lib/after.js
+++ b/lib/after.js
@@ -66,8 +66,8 @@ test.afterEach( function() {
 		return driver.takeScreenshot().then( ( data ) => {
 			let screenshotPath = mediaHelper.writeScreenshot( data, prefix );
 
-			if ( process.env.SLACK_TOKEN && process.env.CIRCLE_BRANCH === 'master' ) {
-				let slackUpload = new SlackUpload( process.env.SLACK_TOKEN );
+			if ( config.has( 'slackTokenForScreenshots' ) && config.get( 'slackTokenForScreenshots' ) && process.env.CIRCLE_BRANCH === 'master' ) {
+				let slackUpload = new SlackUpload( config.get( 'slackTokenForScreenshots' ) );
 
 				slackUpload.uploadFile( {
 					file: fs.createReadStream( screenshotPath ),


### PR DESCRIPTION
The token required for uploading images to Slack is now included in the NODE_CONFIG instead of a standalone envvar