### PR TITLE
Added getrockerbox.com to /etc/hosts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,7 @@ machine:
   hosts:
     linkedin.com: 127.0.0.1
     snap.licdn.com: 127.0.0.1
+    getrockerbox.com: 127.0.0.1
 
 general:
   artifacts:


### PR DESCRIPTION
This host isn't caught by our ad blocker, and is causing timeouts on the logged-out homepage.  I'm looking into how to add it to the blocker at runtime, but for now just stubbing it out in /etc/hosts and moving on.