### PR TITLE
Adds a workaround for the failing signup tests on wpcalypso

### DIFF
--- a/lib/after.js
+++ b/lib/after.js
@@ -155,7 +155,7 @@ test.after( function() {
 	const driver = global.__BROWSER__;
 
 	if ( ( config.has( 'sauce' ) && config.get( 'sauce' ) ) || config.util.getEnv( 'NODE_ENV' ) === 'test' ) {
-		return driverManager.quitBrowser( driver );
+//		return driverManager.quitBrowser( driver );
 	}
 
 	// For mobile non-SauceLabs runs, force orientation back to Portrait to prevent issues re-using the emulator for later tests -- TODO re-evaluate this...

--- a/lib/after.js
+++ b/lib/after.js
@@ -155,7 +155,7 @@ test.after( function() {
 	const driver = global.__BROWSER__;
 
 	if ( ( config.has( 'sauce' ) && config.get( 'sauce' ) ) || config.util.getEnv( 'NODE_ENV' ) === 'test' ) {
-//		return driverManager.quitBrowser( driver );
+		return driverManager.quitBrowser( driver );
 	}
 
 	// For mobile non-SauceLabs runs, force orientation back to Portrait to prevent issues re-using the emulator for later tests -- TODO re-evaluate this...

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -282,6 +282,7 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 								test.it( 'Verify login screen not present', () => {
 									return driver.getCurrentUrl().then( ( url ) => {
 										if ( url.match( /wp-login.php/ ) ) {
+											SlackNotifier.warn( 'WARNING: Signup process sent me to the login screen!' );
 											let newUrl = url.replace( /^.*redirect_to=/, '' );
 											return driver.get( decodeURIComponent( newUrl ) );
 										}
@@ -526,6 +527,18 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 							test.it( 'Can then see the sign up processing page which will finish automatically move along', function() {
 								this.signupProcessingPage = new SignupProcessingPage( driver );
 								return this.signupProcessingPage.waitToDisappear();
+							} );
+
+							test.it( 'Verify login screen not present', () => {
+								return driver.getCurrentUrl().then( ( url ) => {
+									if ( url.match( /wp-login.php/ ) ) {
+										SlackNotifier.warn( 'WARNING: Signup process sent me to the login screen!' );
+										let newUrl = url.replace( /^.*redirect_to=/, '' );
+										return driver.get( decodeURIComponent( newUrl ) );
+									}
+
+									return true;
+								} );
 							} );
 
 							test.describe( 'Step Seven: Secure Payment Page', function() {

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -280,7 +280,7 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 								} );
 
 								test.it( 'Verify login screen not present', () => {
-									return driver.getCurrentUrl( ( url ) => {
+									return driver.getCurrentUrl().then( ( url ) => {
 										if ( url.match( /wp-login.php/ ) ) {
 											let newUrl = url.replace( /^.*redirect_to=/, '' );
 											return driver.get( decodeURIComponent( newUrl ) );

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -186,7 +186,7 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 		} );
 	} );
 
-	test.describe( 'Sign up for a site on a premium paid plan through main flow @canary', function() {
+	test.describe.only( 'Sign up for a site on a premium paid plan through main flow @canary', function() {
 		this.bailSuite( true );
 
 		const blogName = dataHelper.getNewBlogName();
@@ -277,6 +277,17 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 								test.it( 'Can then see the sign up processing page which will automatically move along', function() {
 									this.signupProcessingPage = new SignupProcessingPage( driver );
 									return this.signupProcessingPage.waitToDisappear();
+								} );
+
+								test.it( 'Verify login screen not present', () => {
+									return driver.getCurrentUrl( ( url ) => {
+										if ( url.match( /wp-login.php/ ) ) {
+											let newUrl = url.replace( /^.*redirect_to=/, '' );
+											return driver.get( decodeURIComponent( newUrl ) );
+										}
+
+										return true;
+									} );
 								} );
 
 								test.describe( 'Step Seven: Secure Payment Page', function() {

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -186,7 +186,7 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 		} );
 	} );
 
-	test.describe.only( 'Sign up for a site on a premium paid plan through main flow @canary', function() {
+	test.describe( 'Sign up for a site on a premium paid plan through main flow @canary', function() {
 		this.bailSuite( true );
 
 		const blogName = dataHelper.getNewBlogName();


### PR DESCRIPTION
The signup tests running as part of the Canary builds against wpcalypso are frequently failing because the user is being redirected to the login screen instead of the checkout page.  This PR adds a check to those steps to handle the failure and retry.