### PR TITLE
Changed selector for View Post link

### DIFF
--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -62,7 +62,7 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 	}
 
 	viewPublishedPostOrPage( { reloadPageTwice = false } = {} ) {
-		const viewPostSelector = By.css( '.editor-notice a.notice__action' );
+		const viewPostSelector = By.css( '.editor-action-bar__cell.is-right a' );
 		const driver = this.driver;
 
 		driverHelper.waitTillPresentAndDisplayed( this.driver, viewPostSelector );


### PR DESCRIPTION
New 'View Post' behavior from https://github.com/Automattic/wp-calypso/issues/11981