### PR TITLE
Remove select list clicks before selecting values

### DIFF
--- a/lib/components/secure-payment-component.js
+++ b/lib/components/secure-payment-component.js
@@ -14,7 +14,6 @@ export default class SecurePaymentComponent extends BaseContainer {
 		this.driver.findElement( By.id( 'number' ) ).sendKeys( testVisaNumber );
 		driverHelper.setWhenSettable( this.driver, By.id( 'expiration-date' ), testVisaExpiry );
 		driverHelper.setWhenSettable( this.driver, By.id( 'cvv' ), testCVV );
-		driverHelper.clickWhenClickable( this.driver, By.css( 'div.country select' ) );
 		driverHelper.clickWhenClickable( this.driver, By.css( `div.country select option[value="${testCardCountryCode}"]` ) );
 		return driverHelper.setWhenSettable( this.driver, By.id( 'postal-code' ), testCardPostCode );
 	}

--- a/lib/pages/invite-people-page.js
+++ b/lib/pages/invite-people-page.js
@@ -18,7 +18,6 @@ export default class InvitePeoplePage extends BaseContainer {
 		}
 
 		DriverHelper.setWhenSettable( self.driver, By.css( 'input.token-field__input' ), email );
-		DriverHelper.clickWhenClickable( self.driver, By.css( 'select#role' ) );
 		DriverHelper.clickWhenClickable( self.driver, By.css( `select#role option[value=${role}]` ) );
 		DriverHelper.setWhenSettable( self.driver, By.css( '#message' ), message );
 

--- a/lib/pages/signup/checkout-page.js
+++ b/lib/pages/signup/checkout-page.js
@@ -14,18 +14,15 @@ export default class CheckOutPage extends BaseContainer {
 		driverHelper.setWhenSettable( this.driver, By.id( 'last-name' ), lastName );
 		driverHelper.setWhenSettable( this.driver, By.id( 'email' ), domainEmailAddress );
 
-		driverHelper.clickWhenClickable( this.driver, By.css( 'select.phone-input__country-select' ) );
 		driverHelper.clickWhenClickable( this.driver, By.css( `select.phone-input__country-select option[value="${countryCode}"]` ));
 
 		driverHelper.setWhenSettable( this.driver, By.css( 'input[name="phone"]' ), phoneNumber );
 
-		driverHelper.clickWhenClickable( this.driver, By.css( 'select[name=country-code]' ) );
 		driverHelper.clickWhenClickable( this.driver, By.css( `select[name=country-code] option[value="${countryCode}"]` ) );
 
 		driverHelper.setWhenSettable( this.driver, By.id( 'address-1' ), address );
 		driverHelper.setWhenSettable( this.driver, By.id( 'city' ), city );
 
-		driverHelper.clickWhenClickable( this.driver, By.css( 'select[name=state]' ) );
 		driverHelper.clickWhenClickable( this.driver, By.css( `select[name=state] option[value="${stateCode}"]` ) );
 
 		return driverHelper.setWhenSettable( this.driver, By.id( 'postal-code' ), postalCode );


### PR DESCRIPTION
This fixes the issue where select list selection would steal focus.

Blog post: https://watirmelon.blog/2017/03/31/webdriverjs-select-lists-in-chrome

**Before**

![d](https://cloud.githubusercontent.com/assets/128826/24539807/8bc09d70-1633-11e7-939e-7d0c4d74131c.gif)

**After**

![e](https://cloud.githubusercontent.com/assets/128826/24539812/95a3088c-1633-11e7-8338-f06e0745e422.gif)
