### PR TITLE
Run canary tests in parallel

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,7 @@ MOCHA=./node_modules/mocha/bin/mocha
 GRUNT=./node_modules/.bin/grunt
 REPORTER=""
 PARALLEL=0
+CANARY_PARALLEL=0
 JOBS=0
 AFTER="lib/after.js"
 OPTS=""
@@ -102,8 +103,13 @@ while getopts ":Rpb:s:gjCH:wl:cm:fivh" opt; do
       TARGET="specs-jetpack-calypso/"
       ;;
     C)
-	  GREP="-g '@canary'"
-	  MOCHA+=" --compilers js:babel-register"
+      if [ "$CI" != "true" ]; then
+        GREP="-g '@canary$CIRCLE_NODE_INDEX'"
+        CANARY_PARALLEL=1
+      else
+        GREP="-g '@canary'"
+      fi
+
       SCREENSIZES="mobile"
       TARGET="specs/"
       ;;
@@ -166,7 +172,7 @@ if [ $PARALLEL == 1 ]; then
 else # Not a parallel run, just queue up the tests in sequence
   NC="--NODE_CONFIG='{$NODE_CONFIG_ARG}'"
 
-  if [ "$CI" != "true" ] || [ $CIRCLE_NODE_INDEX == 0 ]; then
+  if [ "$CI" != "true" ] || [ $CIRCLE_NODE_INDEX == 0 ] || [ $CANARY_PARALLEL == 1 ]; then
     IFS=, read -r -a SCREENSIZE_ARRAY <<< "$SCREENSIZES"
     for size in ${SCREENSIZE_ARRAY[@]}; do
       for target in "${TARGETS[@]}"; do

--- a/run.sh
+++ b/run.sh
@@ -103,7 +103,7 @@ while getopts ":Rpb:s:gjCH:wl:cm:fivh" opt; do
       TARGET="specs-jetpack-calypso/"
       ;;
     C)
-      if [ "$CI" != "true" ]; then
+      if [ "$CI" == "true" ]; then
         GREP="-g '@canary$CIRCLE_NODE_INDEX'"
         CANARY_PARALLEL=1
       else

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -238,7 +238,7 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 		} );
 	} );
 
-	test.describe( 'Basic Public Post @canary', function() {
+	test.describe( 'Basic Public Post @canary0', function() {
 		this.bailSuite( true );
 
 		test.it( 'Delete Cookies and Local Storage', function() {

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -186,7 +186,7 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 		} );
 	} );
 
-	test.describe( 'Sign up for a site on a premium paid plan through main flow @canary', function() {
+	test.describe( 'Sign up for a site on a premium paid plan through main flow @canary1', function() {
 		this.bailSuite( true );
 
 		const blogName = dataHelper.getNewBlogName();
@@ -443,7 +443,7 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 		} );
 	} );
 
-	test.describe( 'Partially sign up for a site on a business paid plan w/ domain name coming in via /create as business flow @canary', function() {
+	test.describe( 'Partially sign up for a site on a business paid plan w/ domain name coming in via /create as business flow @canary2', function() {
 		this.bailSuite( true );
 
 		const siteName = dataHelper.getNewBlogName();


### PR DESCRIPTION
This adds support for running the canary tests in parallel.  Each test is hard-coded to a specific container via the `@canary[#]` flag, so if we add more tests or containers they'll need to be assigned appropriately.

Fixes #461 