### PR TITLE
Remove the check to dismiss alerts only on test environments

### DIFF
--- a/lib/after.js
+++ b/lib/after.js
@@ -105,7 +105,7 @@ test.afterEach( function() {
 	this.timeout( afterHookTimeoutMS );
 	const driver = global.__BROWSER__;
 
-	if ( ! global.__MOBILE__ && ( this.currentTest.state === 'failed' ) && ( config.util.getEnv( 'NODE_ENV' ) === 'test' ) ) {
+	if ( ! global.__MOBILE__ && ( this.currentTest.state === 'failed' ) ) {
 		driverManager.dismissAllAlerts( driver );
 	}
 } );


### PR DESCRIPTION
Alerts currently remain open when running locally which causes subsequent tests to fail. This removes the check to only dismiss tests when running on non TEST environments.