### PR TITLE
Update/add after hook to mocha opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The local configurations are excluded from the repository, in order to prevent a
 
 ### To run an individual spec
 
-`./node_modules/mocha/bin/mocha specs/wp-log-in-out-spec.js lib/after.js`
+`./node_modules/.bin/mocha specs/wp-log-in-out-spec.js
 
 Note: you can also change the spec _temporarily_ the use the <code>.only</code> syntax so it is the only spec that runs (making sure this isn't committed)
 
@@ -86,7 +86,7 @@ You can run tests in different modes by setting an environment variable `BROWSER
 
 Eg:
 
-`env BROWSERSIZE=tablet ./node_modules/mocha/bin/mocha specs lib/after.js`
+`env BROWSERSIZE=tablet ./node_modules/.bin/mocha specs
 
 Or you can use the -s option on the run.sh script:
 

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,6 @@ REPORTER=""
 PARALLEL=0
 CANARY_PARALLEL=0
 JOBS=0
-AFTER="lib/after.js"
 OPTS=""
 SCREENSIZES="mobile,desktop"
 BRANCH=""
@@ -160,7 +159,7 @@ if [ $PARALLEL == 1 ]; then
   if [ $CIRCLE_NODE_INDEX == $MOBILE ]; then
       echo "Executing tests at mobile screen width"
       NC="--NODE_CONFIG='{$NODE_CONFIG_ARG}'"
-      CMD="env BROWSERSIZE=mobile $MOCHA $NC $GREP $REPORTER specs/ $AFTER"
+      CMD="env BROWSERSIZE=mobile $MOCHA $NC $GREP $REPORTER specs/"
 
       eval $CMD
       RETURN+=$?
@@ -168,7 +167,7 @@ if [ $PARALLEL == 1 ]; then
   if [ $CIRCLE_NODE_INDEX == $DESKTOP ]; then
       echo "Executing tests at desktop screen width"
       NC="--NODE_CONFIG='{$NODE_CONFIG_ARG}'"
-      CMD="env BROWSERSIZE=desktop $MOCHA $NC $GREP $REPORTER specs/ $AFTER"
+      CMD="env BROWSERSIZE=desktop $MOCHA $NC $GREP $REPORTER specs/"
 
       eval $CMD
       RETURN+=$?
@@ -181,7 +180,7 @@ else # Not a parallel run, just queue up the tests in sequence
     for size in ${SCREENSIZE_ARRAY[@]}; do
       for target in "${TARGETS[@]}"; do
         if [ "$target" != "" ]; then
-          CMD="env BROWSERSIZE=$size $MOCHA $NC $GREP $REPORTER $target $AFTER"
+          CMD="env BROWSERSIZE=$size $MOCHA $NC $GREP $REPORTER $target"
 
           eval $CMD
           RETURN+=$?

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,2 @@
 --compilers js:babel-register
+lib/after.js


### PR DESCRIPTION
It just occurred to me that there's already a feature of mocha that lets you apply command line options to every call (`test/mocha.opts`)...this PR just adds `lib/after.js` to that.  It _technically_ adds it to the beginning of the command line rather than the end where we had it before, but ordering doesn't really matter.

cc: @alisterscott 
h/t @chenchaoyi for the improvement idea to start with (#465)