### PR TITLE
Add first WooCommerce e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The local configurations are excluded from the repository, in order to prevent a
 
 ### To run an individual spec
 
-`./node_modules/.bin/mocha specs/wp-log-in-out-spec.js
+`./node_modules/.bin/mocha specs/wp-log-in-out-spec.js`
 
 Note: you can also change the spec _temporarily_ the use the <code>.only</code> syntax so it is the only spec that runs (making sure this isn't committed)
 
@@ -103,7 +103,8 @@ The `run.sh` script takes the following parameters, which can be combined to exe
 -b [branch]	  - Run tests on given branch via https://calypso.live
 -s		  - Screensizes in a comma-separated list (defaults to mobile,desktop)
 -g		  - Execute general tests in the specs/ directory
--j 		  - Execute Jetpack tests in the specs-jetpack-calypso/ directory
+-j 		  - Execute Jetpack tests in the specs-jetpack-calypso/ directory (desktop and mobile)
+-W		  - Execute WooCommerce tests in the specs-woocommerce/ directory (desktop and mobile)
 -H [host]	  - Specify an alternate host for Jetpack tests
 -w		  - Only execute signup tests on Windows/IE11, not compatible with -g flag
 -l [config]	  - Execute the critical visdiff tests via Sauce Labs with the given configuration

--- a/lib/pages/woocommerce/add-product-page.js
+++ b/lib/pages/woocommerce/add-product-page.js
@@ -1,0 +1,12 @@
+import webdriver from 'selenium-webdriver';
+import config from 'config';
+import BaseContainer from '../../base-container.js';
+
+const by = webdriver.By;
+
+export default class AddProductPage extends BaseContainer {
+	constructor( driver, visit = false ) {
+		const url = config.get( 'calypsoBaseURL' ) + '/store/products/add';
+		super( driver, by.css( '.product-variations' ), visit, url );
+	}
+}

--- a/lib/pages/woocommerce/store-page.js
+++ b/lib/pages/woocommerce/store-page.js
@@ -1,0 +1,12 @@
+import webdriver from 'selenium-webdriver';
+import config from 'config';
+import BaseContainer from '../../base-container.js';
+
+const by = webdriver.By;
+
+export default class StorePage extends BaseContainer {
+	constructor( driver, visit = false ) {
+		const url = config.get( 'calypsoBaseURL' ) + '/store';
+		super( driver, by.css( '.woocommerce__main' ), visit, url );
+	}
+}

--- a/lib/pages/woocommerce/store-stats-page.js
+++ b/lib/pages/woocommerce/store-stats-page.js
@@ -1,0 +1,12 @@
+import webdriver from 'selenium-webdriver';
+import config from 'config';
+import BaseContainer from '../../base-container.js';
+
+const by = webdriver.By;
+
+export default class StoreStatsPage extends BaseContainer {
+	constructor( driver, visit = false ) {
+		const url = config.get( 'calypsoBaseURL' ) + '/store/stats';
+		super( driver, by.css( '.woocommerce.stats' ), visit, url );
+	}
+}

--- a/run.sh
+++ b/run.sh
@@ -27,7 +27,8 @@ usage () {
 -b [branch]	  - Run tests on given branch via https://calypso.live
 -s		  - Screensizes in a comma-separated list (defaults to mobile,desktop)
 -g		  - Execute general tests in the specs/ directory
--j 		  - Execute Jetpack tests in the specs-jetpack-calypso/ directory
+-j 		  - Execute Jetpack tests in the specs-jetpack-calypso/ directory (desktop and mobile)
+-W		  - Execute WooCommerce tests in the specs-woocommerce/ directory (desktop and mobile)
 -C		  - Execute tests tagged with @canary
 -H [host]	  - Specify an alternate host for Jetpack tests
 -w		  - Only execute signup tests on Windows/IE11, not compatible with -g flag
@@ -47,7 +48,7 @@ if [ $# -eq 0 ]; then
   usage
 fi
 
-while getopts ":Rpb:s:gjCH:wl:cm:fivxh" opt; do
+while getopts ":Rpb:s:gjWCH:wl:cm:fivxh" opt; do
   case $opt in
     R)
       REPORTER="-R spec-xunit-slack-reporter"
@@ -101,6 +102,11 @@ while getopts ":Rpb:s:gjCH:wl:cm:fivxh" opt; do
       MOCHA+=" --compilers js:babel-register"
       SCREENSIZES="desktop,mobile"
       TARGET="specs-jetpack-calypso/"
+      ;;
+    W)
+      MOCHA+=" --compilers js:babel-register"
+      SCREENSIZES="desktop,mobile"
+      TARGET="specs-woocommerce/"
       ;;
     C)
       if [ "$CI" == "true" ]; then

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -19,7 +19,7 @@ if [ "$RUN_SPECIFIED" == "true" ]; then
   TESTARGS=$RUN_ARGS
 elif [[ "$CIRCLE_BRANCH" =~ .*[Jj]etpack.*|.*[Jj][Pp].* ]]; then
   TESTARGS="-R -j" # Execute Jetpack tests
-elif [[ "$CIRCLE_BRANCH" =~ .*[Wo][Oo][Oo].* ]]; then
+elif [[ "$CIRCLE_BRANCH" =~ .*[Ww][Oo][Oo].* ]]; then
   TESTARGS="-R -W" # Execute WooCommerce tests
 elif [ "$CIRCLE_BRANCH" == "master" ]; then
   TESTARGS="-R -p" # Parallel execution, implies -g -s mobile,desktop

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -19,6 +19,8 @@ if [ "$RUN_SPECIFIED" == "true" ]; then
   TESTARGS=$RUN_ARGS
 elif [[ "$CIRCLE_BRANCH" =~ .*[Jj]etpack.*|.*[Jj][Pp].* ]]; then
   TESTARGS="-R -j" # Execute Jetpack tests
+elif [[ "$CIRCLE_BRANCH" =~ .*[Wo][Oo][Oo].* ]]; then
+  TESTARGS="-R -W" # Execute WooCommerce tests
 elif [ "$CIRCLE_BRANCH" == "master" ]; then
   TESTARGS="-R -p" # Parallel execution, implies -g -s mobile,desktop
 fi

--- a/specs-woocommerce/wp-woocommerce-spec.js
+++ b/specs-woocommerce/wp-woocommerce-spec.js
@@ -1,0 +1,35 @@
+import assert from 'assert';
+import test from 'selenium-webdriver/testing';
+
+import config from 'config';
+import * as driverManager from '../lib/driver-manager';
+
+import StatsPage from '../lib/pages/stats-page';
+
+import LoginFlow from '../lib/flows/login-flow';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+
+let driver;
+
+test.before( function() {
+	this.timeout( startBrowserTimeoutMS );
+	driver = driverManager.startBrowser();
+} );
+
+test.describe( `WooCommerce on Calypso: '${ screenSize }'`, function() {
+	this.timeout( mochaTimeOut );
+	this.bailSuite( true );
+
+	test.before( function() {
+		driverManager.clearCookiesAndDeleteLocalStorage( driver );
+	} );
+
+	test.it( 'Can see stats page for a WooCommerce site', function() {
+		let loginFlow = new LoginFlow( driver, 'wooCommerceUser' );
+		loginFlow.loginAndSelectMySite();
+		this.statsPage = new StatsPage( driver );
+	} );
+} );

--- a/specs-woocommerce/wp-woocommerce-spec.js
+++ b/specs-woocommerce/wp-woocommerce-spec.js
@@ -4,7 +4,9 @@ import test from 'selenium-webdriver/testing';
 import config from 'config';
 import * as driverManager from '../lib/driver-manager';
 
-import StatsPage from '../lib/pages/stats-page';
+import StorePage from '../lib/pages/woocommerce/store-page';
+import AddProductPage from '../lib/pages/woocommerce/add-product-page';
+import StoreStatsPage from '../lib/pages/woocommerce/store-stats-page';
 
 import LoginFlow from '../lib/flows/login-flow';
 
@@ -27,9 +29,30 @@ test.describe( `WooCommerce on Calypso: '${ screenSize }'`, function() {
 		driverManager.clearCookiesAndDeleteLocalStorage( driver );
 	} );
 
-	test.it( 'Can see stats page for a WooCommerce site', function() {
-		let loginFlow = new LoginFlow( driver, 'wooCommerceUser' );
-		loginFlow.loginAndSelectMySite();
-		this.statsPage = new StatsPage( driver );
+	// Login as WooCommerce store user
+	test.before( function() {
+		this.loginFlow = new LoginFlow( driver, 'wooCommerceUser' );
+		this.loginFlow.loginAndSelectMySite();
+	} );
+
+	test.it( 'Can see store placeholder page when visiting /store', function() {
+		this.storePage = new StorePage( driver, true );
+		this.storePage.displayed().then( ( shown ) => {
+			assert( shown, 'Could not see the WooCommerce store page after visting /store' );
+		} );
+	} );
+
+	test.it( 'Can see the add product placeholder page when visiting /store/products/add', function() {
+		this.addProductPage = new AddProductPage( driver, true );
+		this.addProductPage.displayed().then( ( shown ) => {
+			assert( shown, 'Could not see the WooCommerce add product page after visting /store/products/add' );
+		} );
+	} );
+
+	test.it( 'Can see the add store stats placeholder page when visiting /store/stats', function() {
+		this.storeStatsPage = new StoreStatsPage( driver, true );
+		this.storeStatsPage.displayed().then( ( shown ) => {
+			assert( shown, 'Could not see the WooCommerce add product page after visting /store/stats' );
+		} );
 	} );
 } );


### PR DESCRIPTION
This adds the very first WooCommerce test against Calypso

It just logs on as the new `wooCommerceUser` user and checks My Stats are shown so not actual WooCommerce testing yet.  But this spec can be used from now on to build upon this.