### PR TITLE
Use docker-compose to eliminate messy command lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,12 @@ By default the tests start their own Selenium server in the background, which in
 
 *Note that this command needs to be run from the root of the wp-e2e-tests repo, as the `-v $(pwd):$(pwd):ro` flag needs to be in that location to share the uBlock extension location inside the container.  The `-p 5902:5900` flag opens VNC for access at `localhost:5902`, with password "secret".  The `-d` flag runs in the background, replace with `-it` if you want to view the Selenium server output on the screen.  If running in the background you can stop it with the `docker kill selenium` command.  The `-v /dev/shm:/dev/shm` flag is necessary to provide sufficient shared memory for Chrome.
 
-A few additional steps are necessary if you want to connect that Selenium server to a locally running branch of Calypso.  It requires that you also run wp-calypso from a Docker container, but all of the networking/hosts file updates are handled by the Docker daemon.  These steps assume you've already configured Calypso for Docker.
+A couple additional steps are necessary if you want to connect that Selenium server to a locally running branch of Calypso.  This runs two separate containers, for both Selenium and Calypso, and handles all the networking in between them.  These steps assume you've already configured and built Calypso for Docker with an image name of `wp-calypso`.
 
-1. `docker network create e2e` (This is a one-time setup step)
-1. (From wp-calypso) `docker run --name=wpcalypso.wordpress.com --network=e2e -it --rm -e PORT=80 -e NODE_ENV='production' -e CALYPSO_ENV='wpcalypso' wp-calypso`
-1. (From wp-e2e-tests) `docker run -d --rm  -v /dev/shm:/dev/shm -v $(pwd):$(pwd):ro -p 4444:4444 -p 5902:5900 --network=e2e selenium/standalone-chrome-debug`
 1. Set your `calypsoBaseUrl` config variable to `http://wpcalypso.wordpress.com` (note the http, not https)
+1. From the `wp-e2e-tests` directory, run `docker-compose up -d`
+
+The `-d` flag causes it to run in the background, omit that if you want to see the Selenium and Calypso console output.  To stop the containers, run `docker-compose down`.
 
 ### To run inside a Docker container
 We can also run the entire test suite (including Selenium) from within the context of a Docker container, which allows us to force a particular version of Chrome/driver to reduce compatibility issues.  This would mostly be useful from a CI server.

--- a/README.md
+++ b/README.md
@@ -123,19 +123,18 @@ The `run.sh` script takes the following parameters, which can be combined to exe
 By default the tests start their own Selenium server in the background, which in turn launches a Chrome browser on your desktop where you can watch the tests execute.  This can be a bit of a headache if you're trying to do other work while the tests are running, as the browser may occasionally steal focus back (although that's mostly been resolved).  The easiest way to run "headlessly" without a visible window is to run a separate Selenium server via Docker.  There are lots of options for this on Docker Hub, but I recommend [this one](https://hub.docker.com/r/selenium/standalone-chrome-debug/), as it also allows you to VNC into the container if you do want to view the results.  Just drop the "-debug" from these steps if you don't need that feature.
 
 1. If you haven't already, [install Docker](https://docs.docker.com/engine/installation/)
-1. `docker pull selenium/standalone-chrome-debug`
-1. `docker run -d --rm -v /dev/shm:/dev/shm -v $(pwd):$(pwd):ro -p 4444:4444 -p 5902:5900 --name=selenium selenium/standalone-chrome-debug`*
 1. `export SELENIUM_REMOTE_URL=http://localhost:4444/wd/hub`
+1. `docker-compose up -d`
 1. Execute your tests as normal, and no browser will appear
 
-*Note that this command needs to be run from the root of the wp-e2e-tests repo, as the `-v $(pwd):$(pwd):ro` flag needs to be in that location to share the uBlock extension location inside the container.  The `-p 5902:5900` flag opens VNC for access at `localhost:5902`, with password "secret".  The `-d` flag runs in the background, replace with `-it` if you want to view the Selenium server output on the screen.  If running in the background you can stop it with the `docker kill selenium` command.  The `-v /dev/shm:/dev/shm` flag is necessary to provide sufficient shared memory for Chrome.
+*Note that this command needs to be run from the root of the wp-e2e-tests repo to enable data sharing from the host.  It opens VNC access at `localhost:5902`, with password "secret".  The `-d` flag runs in the background, omit that if you want to view the Selenium server output on the screen.  If running in the background you can stop it with the `docker-compose down` command.
 
 A couple additional steps are necessary if you want to connect that Selenium server to a locally running branch of Calypso.  This runs two separate containers, for both Selenium and Calypso, and handles all the networking in between them.  These steps assume you've already configured and built Calypso for Docker with an image name of `wp-calypso`.
 
 1. Set your `calypsoBaseUrl` config variable to `http://wpcalypso.wordpress.com` (note the http, not https)
-1. From the `wp-e2e-tests` directory, run `docker-compose up -d`
+1. From the `wp-e2e-tests` directory, run `docker-compose -f docker-compose-calypso.yml up -d`
 
-The `-d` flag causes it to run in the background, omit that if you want to see the Selenium and Calypso console output.  To stop the containers, run `docker-compose down`.
+Note that you'll need to supply the `-f docker-compose-calypso.yml` parameter to the `down` command as well, or you'll get a warning message about orphaned containers.
 
 ### To run inside a Docker container
 We can also run the entire test suite (including Selenium) from within the context of a Docker container, which allows us to force a particular version of Chrome/driver to reduce compatibility issues.  This would mostly be useful from a CI server.

--- a/docker-compose-calypso.yml
+++ b/docker-compose-calypso.yml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+  selenium:
+    image: selenium/standalone-chrome-debug:3.3.0
+    ports:
+      - "4444:4444"
+      - "5902:5900"
+    volumes:
+      - ${PWD}:${PWD}
+      - /dev/shm:/dev/shm
+    links:
+      - "wp-calypso:wpcalypso.wordpress.com"
+  wp-calypso:
+    image: wp-calypso
+    user: root
+    environment:
+      - PORT=80
+      - NODE_ENV=production
+      - CALYPSO_ENV=wpcalypso

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,4 @@ services:
       - "5902:5900"
     volumes:
       - ${PWD}:${PWD}
-    links:
-      - "wp-calypso:wpcalypso.wordpress.com"
-  wp-calypso:
-    image: wp-calypso
-    user: root
-    environment:
-      - PORT=80
-      - NODE_ENV=production
-      - CALYPSO_ENV=wpcalypso
+      - /dev/shm:/dev/shm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+  selenium:
+    image: selenium/standalone-chrome-debug:3.3.0
+    ports:
+      - "4444:4444"
+      - "5902:5900"
+    volumes:
+      - ${PWD}:${PWD}
+    links:
+      - "wp-calypso:wpcalypso.wordpress.com"
+  wp-calypso:
+    image: wp-calypso
+    user: root
+    environment:
+      - PORT=80
+      - NODE_ENV=production
+      - CALYPSO_ENV=wpcalypso


### PR DESCRIPTION
This abstracts all of the messy command line options needed to configure Docker-based Selenium runs into a docker-compose file, for both standalone and local Calypso runs.