### PR TITLE
Delete content from invited editor when removing user

### DIFF
--- a/lib/pages/edit-team-member-page.js
+++ b/lib/pages/edit-team-member-page.js
@@ -8,6 +8,11 @@ export default class EditTeamMemberPage extends BaseContainer {
 		super( driver, By.css( '.edit-team-member-form' ) );
 	}
 
+	removeUserAndDeleteContent() {
+		DriverHelper.clickWhenClickable( this.driver, By.css( 'input[value="delete"]' ) );
+		return DriverHelper.clickWhenClickable( this.driver, By.css( '.delete-user__single-site button' ) );
+	}
+
 	removeSelectedUser() {
 		DriverHelper.clickWhenClickable( this.driver, By.css( '.delete-user__remove-user' ) );
 		return DriverHelper.clickWhenClickable( this.driver, By.css( '.dialog button.is-primary' ) );

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -194,7 +194,7 @@ testDescribe( 'Invites: (' + screenSize + ')', function() {
 									} );
 
 									test.it( 'Can remove the team member from the site', function() {
-										this.editTeamMemberPage.removeSelectedUser();
+										this.editTeamMemberPage.removeUserAndDeleteContent();
 										this.peoplePage = new PeoplePage( driver );
 										this.peoplePage.successNoticeDisplayed().then( ( displayed ) => {
 											assert.equal( displayed, true, 'The deletion successful notice was not shown on the people page.' );


### PR DESCRIPTION
There's now an option when removing a user with Editor permissions to delete all of their content (or re-assign it to another user).