### PR TITLE
Add editor test for 'Revert to Draft'

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -112,6 +112,13 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 			}
 		} );
 	}
+	
+	revertToDraft() {
+		let revertDraftSelector = By.css( 'button.edit-post-status__revert-to-draft' );
+		this._expandOrCollapseSection( 'status', true );
+		driverHelper.waitTillPresentAndDisplayed( this.driver, revertDraftSelector );
+		driverHelper.clickWhenClickable( this.driver, revertDraftSelector );
+	}
 
 	setVisibilityToPrivate() {
 		let visibilitySelector;

--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -100,4 +100,14 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 			return classNames.includes( 'is-pending' );
 		} );
 	}
+	
+	waitForIsDraftStatus() {
+		return driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.editor-status-label.is-draft' ) );
+	}
+	
+	statusIsDraft() {
+		return this.driver.findElement( By.css( '.editor-status-label' ) ).getAttribute( 'class' ).then( ( classNames ) => {
+			return classNames.includes( 'is-draft' );
+		} );
+	}
 }

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -893,7 +893,7 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 		} );
 	} );
 	
-	test.describe( 'Revert a post to draft', function() {
+	test.describe( 'Revert a post to draft: @parallel', function() {
 		this.bailSuite( true );
 		
 		test.before( function() {

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -892,4 +892,52 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 			} );
 		} );
 	} );
+	
+	test.describe( 'Revert a post to draft', function() {
+		this.bailSuite( true );
+		
+		test.before( function() {
+			driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		} );
+		
+		test.describe( 'Publish a new post', function() {
+			const originalBlogPostTitle = dataHelper.randomPhrase();
+			const blogPostQuote = 'To really be of help to others we need to be guided by compassion.\n— Dalai Lama\n';
+			
+			test.it( 'Can log in', function() {
+				this.loginFlow = new LoginFlow( driver );
+				return this.loginFlow.loginAndStartNewPost();
+			} );
+			
+			test.it( 'Can enter post title and content', function() {
+				this.editorPage = new EditorPage( driver );
+				this.editorPage.enterTitle( originalBlogPostTitle );
+				this.editorPage.enterContent( blogPostQuote );
+				
+				return this.editorPage.errorDisplayed().then( ( errorShown ) => {
+					return assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
+				} );
+			} );
+			
+			test.it( 'Can publish the post', function() {
+				this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+				this.postEditorToolbarComponent.ensureSaved();
+				this.postEditorToolbarComponent.publishPost();
+				return this.postEditorToolbarComponent.waitForSuccessViewPostNotice();
+			} );
+		} );
+			
+		test.describe( 'Revert the post to draft', function() {
+			
+			test.it( 'Can revert the post to draft', function() {
+				let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+				let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+				postEditorSidebarComponent.revertToDraft();
+				postEditorToolbarComponent.waitForIsDraftStatus();
+				postEditorToolbarComponent.statusIsDraft().then( ( isDraft ) => {
+					assert.equal( isDraft, true, 'The post is not set as draft' );
+				} );
+			} );
+		} );
+	} );
 } );


### PR DESCRIPTION
Resolves #413 by adding a new test to revert a published post to draft status. @alisterscott since you've worked on these tests I'd really appreciate your feedback. :)

I also think there's potential for moving some of the repeated tests in this spec (such as `Can enter post title and content` or `Can publish the post`) into an editor flow under `lib/flows`. If that sounds like a reasonable approach I can work consolidating those in a followup PR.