### PR TITLE
Added pixel.wp.com to Windows hosts file

### DIFF
--- a/scripts/fix-saucelabs-etc-hosts.bat
+++ b/scripts/fix-saucelabs-etc-hosts.bat
@@ -2,3 +2,4 @@
 echo. >> C:\Windows\System32\drivers\etc\hosts
 echo 127.0.0.1 lorempixel.com >> C:\Windows\System32\drivers\etc\hosts
 echo 127.0.0.1 placekitten.com >> C:\Windows\System32\drivers\etc\hosts
+echo 127.0.0.1 pixel.wp.com >> C:\Windows\System32\drivers\etc\hosts


### PR DESCRIPTION
Since we can't set the UA string on IE11, this is the workaround necessary to prevent Tracks events from firing on domain searches, etc on the IE11 NUX tests.  Ref p4qSXL-1Vr-p2