### PR TITLE
Use new targeting for posts menu item

### DIFF
--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -32,7 +32,7 @@ export default class SidebarComponent extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	selectAddNewPage() {
-		let selector = By.css( '.pages a.sidebar__button' );
+		let selector = By.css( '.sites-navigation [data-post-type="page"] a.sidebar__button' );
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	selectSiteSwitcher() {
@@ -42,7 +42,7 @@ export default class SidebarComponent extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, By.css( '.all-sites a' ) );
 	}
 	selectViewThisSite() {
-		return driverHelper.clickWhenClickable( this.driver, By.css( 'a[data-tip-target="site-card-preview"]' ) );
+		return driverHelper.clickWhenClickable( this.driver, By.css( 'a.current-site__view-site' ) );
 	}
 	selectPlugins() {
 		this.driver.findElement( By.css( '.sites-navigation .plugins a' ) ).click();

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -52,7 +52,7 @@ export default class SidebarComponent extends BaseContainer {
 		return this.driver.findElement( By.css( '.sites-navigation .settings a' ) ).click();
 	}
 	selectPosts() {
-		const selector = By.css( '.sites-navigation .posts a:not(.sidebar__button)' );
+		const selector = By.css( '.sites-navigation [data-post-type="post"] a:not(.sidebar__button)' );
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	customizeTheme() {


### PR DESCRIPTION
This PR relies on https://github.com/Automattic/wp-calypso/pull/13824

Previously we were also inconsistent by having classes for posts and pages in a plural form and everything else in the singular. Now it's only singular.