### PR TITLE
Use run wrapper with CircleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,6 @@ jobs:
             - /wp-e2e-tests/node_modules
           key: << checksum "package.json" >>
       - run: ./scripts/randomize.sh specs
-      - run: ./run.sh -R -p -x
+      - run: ./scrips/run-wrapper.sh
       - store_test_results:
           path: reports/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,6 @@ jobs:
             - /wp-e2e-tests/node_modules
           key: << checksum "package.json" >>
       - run: ./scripts/randomize.sh specs
-      - run: ./scrips/run-wrapper.sh
+      - run: ./scripts/run-wrapper.sh
       - store_test_results:
           path: reports/

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -13,7 +13,7 @@ if [ "$NODE_ENV_OVERRIDE" != "" ]; then
   NODE_ENV=$NODE_ENV_OVERRIDE
 fi
 
-export TESTARGS="-R -p"
+export TESTARGS="-R -p -x"
 
 if [ "$RUN_SPECIFIED" == "true" ]; then
   TESTARGS=$RUN_ARGS
@@ -22,7 +22,7 @@ elif [[ "$CIRCLE_BRANCH" =~ .*[Jj]etpack.*|.*[Jj][Pp].* ]]; then
 elif [[ "$CIRCLE_BRANCH" =~ .*[Ww][Oo][Oo].* ]]; then
   TESTARGS="-R -W -u https://wpcalypso.wordpress.com" # Execute WooCommerce tests
 elif [ "$CIRCLE_BRANCH" == "master" ]; then
-  TESTARGS="-R -p" # Parallel execution, implies -g -s mobile,desktop
+  TESTARGS="-R -p -x" # Parallel execution, implies -g -s mobile,desktop
 fi
 
 if [ "$liveBranches" == "true" ]; then


### PR DESCRIPTION
When we moved to CircleCI 2.0 I accidentally cut the run-wrapper.sh script out of the loop, which meant the special handling for Jetpack and Woo branches wasn't being executed.

Fixes #514 