### PR TITLE
Revert "Use run wrapper with CircleCI 2.0"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,6 @@ jobs:
             - /wp-e2e-tests/node_modules
           key: << checksum "package.json" >>
       - run: ./scripts/randomize.sh specs
-      - run: ./scripts/run-wrapper.sh
+      - run: ./run.sh -R -p -x
       - store_test_results:
           path: reports/

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -13,7 +13,7 @@ if [ "$NODE_ENV_OVERRIDE" != "" ]; then
   NODE_ENV=$NODE_ENV_OVERRIDE
 fi
 
-export TESTARGS="-R -p -x"
+export TESTARGS="-R -p"
 
 if [ "$RUN_SPECIFIED" == "true" ]; then
   TESTARGS=$RUN_ARGS
@@ -22,7 +22,7 @@ elif [[ "$CIRCLE_BRANCH" =~ .*[Jj]etpack.*|.*[Jj][Pp].* ]]; then
 elif [[ "$CIRCLE_BRANCH" =~ .*[Ww][Oo][Oo].* ]]; then
   TESTARGS="-R -W -u https://wpcalypso.wordpress.com" # Execute WooCommerce tests
 elif [ "$CIRCLE_BRANCH" == "master" ]; then
-  TESTARGS="-R -p -x" # Parallel execution, implies -g -s mobile,desktop
+  TESTARGS="-R -p" # Parallel execution, implies -g -s mobile,desktop
 fi
 
 if [ "$liveBranches" == "true" ]; then


### PR DESCRIPTION
The first test run after merging this change in worked fine, but every run since has had nothing but timeouts.  Trying a revert to see if this is really related...

Reverts Automattic/wp-e2e-tests#521