### PR TITLE
Use run wrapper with ci 2.0 again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,6 @@ jobs:
             - /wp-e2e-tests/node_modules
           key: << checksum "package.json" >>
       - run: ./scripts/randomize.sh specs
-      - run: ./run.sh -R -p -x
+      - run: ./scripts/run-wrapper.sh
       - store_test_results:
           path: reports/

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-echo "ARGS='$@'"
 MOCHA=./node_modules/.bin/mocha
 MAGELLAN=./node_modules/.bin/magellan
 GRUNT=./node_modules/.bin/grunt

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+echo "ARGS='$@'"
 MOCHA=./node_modules/.bin/mocha
 MAGELLAN=./node_modules/.bin/magellan
 GRUNT=./node_modules/.bin/grunt

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -29,5 +29,4 @@ if [ "$liveBranches" == "true" ]; then
   TESTARGS+=" -b $branchName"
 fi
 
-echo "TESTARGS='$TESTARGS'"
 npm test

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -21,7 +21,7 @@ elif [[ "$CIRCLE_BRANCH" =~ .*[Jj]etpack.*|.*[Jj][Pp].* ]]; then
   TESTARGS="-R -j" # Execute Jetpack tests
 elif [[ "$CIRCLE_BRANCH" =~ .*[Ww][Oo][Oo].* ]]; then
   TESTARGS="-R -W -u https://wpcalypso.wordpress.com" # Execute WooCommerce tests
-elif [ "$CIRCLE_BRANCH" == "fix/use-run-wrapper-with-ci-2.0-again" ]; then
+elif [ "$CIRCLE_BRANCH" == "master" ]; then
   TESTARGS="-R -p -x" # Parallel execution, implies -g -s mobile,desktop
 fi
 

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -13,7 +13,7 @@ if [ "$NODE_ENV_OVERRIDE" != "" ]; then
   NODE_ENV=$NODE_ENV_OVERRIDE
 fi
 
-export TESTARGS="-R -p"
+export TESTARGS="-R -p -x"
 
 if [ "$RUN_SPECIFIED" == "true" ]; then
   TESTARGS=$RUN_ARGS
@@ -21,12 +21,13 @@ elif [[ "$CIRCLE_BRANCH" =~ .*[Jj]etpack.*|.*[Jj][Pp].* ]]; then
   TESTARGS="-R -j" # Execute Jetpack tests
 elif [[ "$CIRCLE_BRANCH" =~ .*[Ww][Oo][Oo].* ]]; then
   TESTARGS="-R -W -u https://wpcalypso.wordpress.com" # Execute WooCommerce tests
-elif [ "$CIRCLE_BRANCH" == "master" ]; then
-  TESTARGS="-R -p" # Parallel execution, implies -g -s mobile,desktop
+elif [ "$CIRCLE_BRANCH" == "fix/use-run-wrapper-with-ci-2.0-again" ]; then
+  TESTARGS="-R -p -x" # Parallel execution, implies -g -s mobile,desktop
 fi
 
 if [ "$liveBranches" == "true" ]; then
   TESTARGS+=" -b $branchName"
 fi
 
+echo "TESTARGS='$TESTARGS'"
 npm test


### PR DESCRIPTION
No code changes here from the previous attempt (#521).  The problem last time was that the trigger used to kick off the runs on Calypso deploys wasn't updated to also pass the `-x` flag.