### PR TITLE
Add default handling for -x flag on CI

### DIFF
--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -29,4 +29,9 @@ if [ "$liveBranches" == "true" ]; then
   TESTARGS+=" -b $branchName"
 fi
 
+# If on CI and the -x flag is not yet set, set it
+if [ "$CI" == "true" ] && [[ "$TESTARGS" != *"-x"* ]]; then
+  TESTARGS+=" -x"
+fi
+
 npm test


### PR DESCRIPTION
PR #526 added the -x flag to the run-wrapper.sh script explicitly in a few places, but it also needed to be added to the Jetpack and Woo steps.  But rather than do that and require that the flag be added every single time, I just added a check to see if we're on CI and add the flag then.

This makes the explicit changes redundant, and I was a little torn on whether to remove them, but it's not hurting anything so I left it as-is.

Closes #514 (again)