### PR TITLE
Added theme switch spec for Jetpack sites

### DIFF
--- a/specs-jetpack-calypso/wp-jetpack-theme-switch-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-theme-switch-spec.js
@@ -24,7 +24,7 @@ test.before( function() {
 	driver = driverManager.startBrowser();
 } );
 
-test.describe( host + 'Themes: (' + screenSize + ')', function() {
+test.describe( host + ' Themes: (' + screenSize + ')', function() {
 	this.timeout( mochaTimeOut );
 	this.bailSuite( true );
 

--- a/specs-jetpack-calypso/wp-jetpack-theme-switch-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-theme-switch-spec.js
@@ -24,7 +24,7 @@ test.before( function() {
 	driver = driverManager.startBrowser();
 } );
 
-test.describe( host + ' Themes: (' + screenSize + ')', function() {
+test.describe( host + ' Themes: (' + screenSize + ') @parallel', function() {
 	this.timeout( mochaTimeOut );
 	this.bailSuite( true );
 

--- a/specs-jetpack-calypso/wp-jetpack-theme-switch-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-theme-switch-spec.js
@@ -1,0 +1,66 @@
+import test from 'selenium-webdriver/testing';
+import config from 'config';
+import assert from 'assert';
+
+import * as driverManager from '../lib/driver-manager.js';
+import * as dataHelper from '../lib/data-helper';
+
+import LoginFlow from '../lib/flows/login-flow.js';
+
+import ThemesPage from '../lib/pages/themes-page.js';
+import ThemePreviewPage from '../lib/pages/theme-preview-page.js';
+import ThemeDetailPage from '../lib/pages/theme-detail-page.js';
+import ThemeDialogComponent from '../lib/components/theme-dialog-component.js';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
+
+var driver;
+
+test.before( function() {
+	this.timeout( startBrowserTimeoutMS );
+	driver = driverManager.startBrowser();
+} );
+
+test.describe( host + 'Themes: (' + screenSize + ')', function() {
+	this.timeout( mochaTimeOut );
+	this.bailSuite( true );
+
+	test.describe( 'Switching Themes:', function() {
+		test.it( 'Delete Cookies and Login', function() {
+			driverManager.clearCookiesAndDeleteLocalStorage( driver );
+			let loginFlow = new LoginFlow( driver, `jetpackUser${host}` );
+			loginFlow.loginAndSelectThemes();
+		} );
+
+		test.describe( 'Can switch themes', function() {
+			test.it( 'Can select a different theme', function() {
+				this.themesPage = new ThemesPage( driver );
+				this.themesPage.searchFor( 'Twenty F' );
+				this.themesPage.waitForThemeStartingWith( 'Twenty F' );
+				return this.themesPage.selectNewThemeStartingWith( 'Twenty F' );
+			} );
+
+			test.it( 'Can see theme details page and open the live demo', function() {
+				this.themeDetailPage = new ThemeDetailPage( driver );
+				return this.themeDetailPage.openLiveDemo();
+			} );
+
+			test.it( 'Can activate the theme from the theme preview page', function() {
+				this.themePreviewPage = new ThemePreviewPage( driver );
+				this.themePreviewPage.activate();
+			} );
+
+			test.it( 'Can see the theme thanks dialog and go back to the theme details page', function() {
+				this.themeDialogComponent = new ThemeDialogComponent( driver );
+				this.themeDialogComponent.goBackToThemes();
+				this.themeDetailPage = new ThemeDetailPage( driver );
+				this.themeDetailPage.displayed().then( function( displayed ) {
+					assert.equal( displayed, true, 'Could not see the theme detail page after activating a new theme' );
+				} );
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
@alisterscott I finally got time to get involved with the Jetpack tests, and figured I'd start by just porting over a simple one from the main specs directory.  It works great on the sites we have set up on Bluehost and Pressable, but fails on GoDaddy.  I assume because the Jetpack version is out of date over there.

I just wanted to check with you before I upgraded it, though, to make sure it wasn't an older version on purpose.  And I of course just wanted a sanity check on this PR to make sure there's nothing different that you've been doing for the Jetpack specs that I'm missing.