### PR TITLE
Run.sh now only interfaces with magellan

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,11 @@ module.exports = function( grunt ) {
 		shell: {
 			runTests: {
 				command: function( browserSize, sauceConfig ) {
-					return './run.sh -R -c -f -v -l ' + sauceConfig + ' -s ' + browserSize
+					// The run.sh script no longer supports this format with the switch to
+					// magellan as the test runner.   For now just calling mocha directly
+					// until Grunt can be replaced with magellan entirely (Issue 508)
+//					return './run.sh -R -c -f -v -l ' + sauceConfig + ' -s ' + browserSize
+					return `env BROWSERSIZE=${browserSize} ./node_modules/.bin/mocha --NODE_CONFIG='{"failVisdiffs":"true","sauce":"true","sauceConfig":"${sauceConfig}"}' -R spec-xunit-slack-reporter specs-visdiff/`
 				}
 			}
 		},

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ The local configurations are excluded from the repository, in order to prevent a
 ## Run tests
 
 
-### To run all the specs (in default browser sizes - mobile and desktop)
+### To run the default specs in parallel (in default browser sizes - mobile and desktop)
 
 `./run.sh -g`
 
-### To run all the specs in parallel
+- or -
 
 `./node_modules/.bin/magellan`
 
@@ -107,6 +107,7 @@ Or you can use the -s option on the run.sh script:
 
 The `run.sh` script takes the following parameters, which can be combined to execute a variety of suites
 ```
+-a [workers]	  - Number of parallel workers in Magellan (defaults to 3)
 -R		  - Use custom Slack/Spec/XUnit reporter, otherwise just use Spec reporter
 -p 		  - Execute the tests in parallel via CircleCI envvars (implies -g -s mobile,desktop)
 -b [branch]	  - Run tests on given branch via https://calypso.live

--- a/scripts/trigger-circle-ci-specific.sh
+++ b/scripts/trigger-circle-ci-specific.sh
@@ -4,6 +4,7 @@ _project=$1
 _branch=$2
 _circle_token=$3
 _run_args=$4
+_e2e_branch=$5
 
 trigger_build_url=https://circleci.com/api/v1/project/${_project}/tree/${_branch}?circle-token=${_circle_token}
 
@@ -11,7 +12,8 @@ post_data=$(cat <<EOF
 {
   "build_parameters": {
     "RUN_SPECIFIED": "true",
-    "RUN_ARGS": "${_run_args}"
+    "RUN_ARGS": "${_run_args}",
+    "E2E_BRANCH": "${_e2e_branch}"
   }
 }
 EOF)

--- a/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -24,7 +24,7 @@ test.before( function() {
 	driver = driverManager.startBrowser();
 } );
 
-test.describe( host + ' Jetpack Plans: (' + screenSize + ')', function() {
+test.describe( host + ' Jetpack Plans: (' + screenSize + ') @parallel', function() {
 	this.timeout( mochaTimeOut );
 
 	test.describe( 'Comparing Plans:', function() {

--- a/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
@@ -25,7 +25,7 @@ test.before( function() {
 	driver = driverManager.startBrowser();
 } );
 
-test.describe( `${host} Jetpack Sites on Calypso - Existing Plugins: '${ screenSize }'`, function() {
+test.describe( `${host} Jetpack Sites on Calypso - Existing Plugins: '${ screenSize }' @parallel`, function() {
 	this.timeout( mochaTimeOut );
 	this.bailSuite( true );
 
@@ -67,7 +67,7 @@ test.describe( `${host} Jetpack Sites on Calypso - Existing Plugins: '${ screenS
 	} );
 } );
 
-test.describe( `${host} Jetpack Sites on Calypso - Searching Plugins: '${ screenSize }'`, function() {
+test.describe( `${host} Jetpack Sites on Calypso - Searching Plugins: '${ screenSize }' @parallel`, function() {
 	this.timeout( mochaTimeOut );
 	this.bailSuite( true );
 

--- a/specs-jetpack-calypso/wp-jetpack-post-editor-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-post-editor-spec.js
@@ -37,7 +37,7 @@ test.describe( host + ' Jetpack Site: Editor: Posts (' + screenSize + ')', funct
 	this.bailSuite( true );
 	this.timeout( mochaTimeOut );
 
-	test.describe( 'Public Posts:', function() {
+	test.describe( 'Public Posts: @parallel', function() {
 		let fileDetails;
 
 		test.before( function() {
@@ -236,7 +236,7 @@ test.describe( host + ' Jetpack Site: Editor: Posts (' + screenSize + ')', funct
 		} );
 	} );
 
-	test.describe( 'Private Posts:', function() {
+	test.describe( 'Private Posts: @parallel', function() {
 		test.before( function() {
 			driverManager.clearCookiesAndDeleteLocalStorage( driver );
 		} );
@@ -300,7 +300,7 @@ test.describe( host + ' Jetpack Site: Editor: Posts (' + screenSize + ')', funct
 		} );
 	} );
 
-	test.describe( 'Password Protected Posts:', function() {
+	test.describe( 'Password Protected Posts: @parallel', function() {
 		this.bailSuite( true );
 
 		test.before( function() {
@@ -479,7 +479,7 @@ test.describe( host + ' Jetpack Site: Editor: Posts (' + screenSize + ')', funct
 		} );
 	} );
 
-	test.describe( 'Trash Post:', function() {
+	test.describe( 'Trash Post: @parallel', function() {
 		this.bailSuite( true );
 
 		test.before( function() {
@@ -522,7 +522,7 @@ test.describe( host + ' Jetpack Site: Editor: Posts (' + screenSize + ')', funct
 		} );
 	} );
 
-	test.describe( 'Edit a Post:', function() {
+	test.describe( 'Edit a Post: @parallel', function() {
 		this.bailSuite( true );
 
 		test.it( 'Delete Cookies and Local Storage', function() {
@@ -614,7 +614,7 @@ test.describe( host + ' Jetpack Site: Editor: Posts (' + screenSize + ')', funct
 		} );
 	} );
 
-	test.describe( 'Insert a contact form:', function() {
+	test.describe( 'Insert a contact form: @parallel', function() {
 		this.bailSuite( true );
 
 		test.it( 'Delete Cookies and Local Storage', function() {

--- a/specs-jetpack-calypso/wp-jetpack-settings-writing-media-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-settings-writing-media-spec.js
@@ -21,7 +21,7 @@ test.before( function() {
 	driver = driverManager.startBrowser();
 } );
 
-test.describe( `${host} Jetpack Settings on Calypso: '${ screenSize }'`, function() {
+test.describe( `${host} Jetpack Settings on Calypso: '${ screenSize }' @parallel`, function() {
 	this.timeout( mochaTimeOut );
 	this.bailSuite( true );
 

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -281,7 +281,7 @@ test.describe( 'Editor: Posts (' + screenSize + ')', function() {
 		} );
 	} );
 
-	test.describe( 'Basic Public Post @canary0 @parallel', function() {
+	test.describe( 'Basic Public Post @canary @parallel', function() {
 		this.bailSuite( true );
 
 		test.it( 'Delete Cookies and Local Storage', function() {

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -187,7 +187,7 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 		} );
 	} );
 
-	test.describe( 'Sign up for a site on a premium paid plan through main flow @canary1 @parallel', function() {
+	test.describe( 'Sign up for a site on a premium paid plan through main flow @canary @parallel', function() {
 		this.bailSuite( true );
 
 		const blogName = dataHelper.getNewBlogName();
@@ -455,7 +455,7 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 		} );
 	} );
 
-	test.describe( 'Partially sign up for a site on a business paid plan w/ domain name coming in via /create as business flow @canary2 @parallel', function() {
+	test.describe( 'Partially sign up for a site on a business paid plan w/ domain name coming in via /create as business flow @canary @parallel', function() {
 		this.bailSuite( true );
 
 		const siteName = dataHelper.getNewBlogName();


### PR DESCRIPTION
Currently run.sh kicks off all of the tests using mocha directly, except in the case where the `-p` flag is passed, which is really only used on CircleCI when multiple containers are allocated.

This PR removes all direct calls to mocha (with one exception noted below), instead running everything via the Magellan test runner.  This enables parallel processing on a single container in the wrapper repos (Canary, Jetpack, Woo, IE11 NUX).

The exception there are the visdiff tests, which currently aren't structured well to take advantage of it.  Issue #508 is tracking the future change to fix that.

Unfortunately, only the visdiff wrapper repo was built with a capability to run against a specific branch from the main repo, so before merging this change in I want to add that in to at least one of the other wrappers to test this out.  I'm curious whether this will work on the wrapper repos at all as-is, since they're all still configured for CircleCI 1.0, and we've only ever run magellan on 2.0.  I'll give that all a go in the morning.