### PR TITLE
Add e2e test for leaving reader comment

### DIFF
--- a/lib/pages/reader-page.js
+++ b/lib/pages/reader-page.js
@@ -12,24 +12,31 @@ export default class ReaderPage extends BaseContainer {
 		}
 		super( driver, by.css( '.is-section-reader' ), visit, url );
 	}
+
 	siteOfLatestPost() {
-		return this.driver.findElement( by.css( 'article.reader__card .site__domain' ) ).getText();
+		return this.driver.findElement( by.css( '.reader-visit-link' ) ).getAttribute('href').then( ( href ) => {
+			return href.split('/')[2];
+		} );
 	}
+
 	likeLatestPost() {
-		return driverHelper.clickWhenClickable( this.driver, by.css( 'article.reader__card .like-button' ) );
+		return driverHelper.clickWhenClickable( this.driver, by.css( '.reader-post-card .like-button' ) );
 	}
+
 	latestPostIsLiked() {
-		return this.driver.findElement( by.css( 'article.reader__card .like-button' ) ).getAttribute( 'class' ).then( ( classNames ) => {
+		return this.driver.findElement( by.css( '.reader-post-card .like-button' ) ).getAttribute( 'class' ).then( ( classNames ) => {
 			return classNames.includes( 'is-liked' );
 		} );
 	}
+
 	latestPostTitle() {
-		return this.driver.findElement( by.css( 'article.reader__card .reader__post-title' ) ).getText();
+		return this.driver.findElement( by.css( '.reader-post-card__title' ) ).getText();
 	}
+
 	commentOnLatestPost( comment ) {
 		driverHelper.clickWhenClickable( this.driver, by.css( '.comment-button' ) );
 		driverHelper.setWhenSettable( this.driver, by.css( '.comments__form textarea' ), comment );
 		driverHelper.clickWhenClickable( this.driver, by.css( '.comments__form button' ) );
-		return this.driver.wait( until.elementLocated( by.css( '.comment__moderation' ) ), this.explicitWaitMS, 'Could not see the comment moderation message after submitting a new comment' );
+		return this.driver.wait( until.elementLocated( by.css( '.comments__comment-moderation' ) ), this.explicitWaitMS, 'Could not see the comment moderation message after submitting a new comment' );
 	}
 }

--- a/lib/pages/reader-page.js
+++ b/lib/pages/reader-page.js
@@ -14,8 +14,8 @@ export default class ReaderPage extends BaseContainer {
 	}
 
 	siteOfLatestPost() {
-		return this.driver.findElement( by.css( '.reader-visit-link' ) ).getAttribute('href').then( ( href ) => {
-			return href.split('/')[2];
+		return this.driver.findElement( by.css( '.reader-visit-link' ) ).getAttribute( 'href' ).then( ( href ) => {
+			return href.split( '/' )[2];
 		} );
 	}
 
@@ -37,6 +37,9 @@ export default class ReaderPage extends BaseContainer {
 		driverHelper.clickWhenClickable( this.driver, by.css( '.comment-button' ) );
 		driverHelper.setWhenSettable( this.driver, by.css( '.comments__form textarea' ), comment );
 		driverHelper.clickWhenClickable( this.driver, by.css( '.comments__form button' ) );
+	}
+
+	waitForModeratedCommentToAppear() {
 		return this.driver.wait( until.elementLocated( by.css( '.comments__comment-moderation' ) ), this.explicitWaitMS, 'Could not see the comment moderation message after submitting a new comment' );
 	}
 }

--- a/lib/pages/reader-page.js
+++ b/lib/pages/reader-page.js
@@ -36,7 +36,7 @@ export default class ReaderPage extends BaseContainer {
 	commentOnLatestPost( comment ) {
 		driverHelper.clickWhenClickable( this.driver, by.css( '.comment-button' ) );
 		driverHelper.setWhenSettable( this.driver, by.css( '.comments__form textarea' ), comment );
-		driverHelper.clickWhenClickable( this.driver, by.css( '.comments__form button' ) );
+		return driverHelper.clickWhenClickable( this.driver, by.css( '.comments__form button' ) );
 	}
 
 	waitForModeratedCommentToAppear() {

--- a/lib/pages/reader-page.js
+++ b/lib/pages/reader-page.js
@@ -1,5 +1,6 @@
-import { By as by, until } from 'selenium-webdriver';
+import { By as by } from 'selenium-webdriver';
 import config from 'config';
+import URL from 'url';
 
 import BaseContainer from '../base-container.js';
 import * as driverHelper from '../driver-helper.js';
@@ -15,7 +16,7 @@ export default class ReaderPage extends BaseContainer {
 
 	siteOfLatestPost() {
 		return this.driver.findElement( by.css( '.reader-visit-link' ) ).getAttribute( 'href' ).then( ( href ) => {
-			return href.split( '/' )[2];
+			return URL.parse( href ).host;
 		} );
 	}
 
@@ -40,6 +41,6 @@ export default class ReaderPage extends BaseContainer {
 	}
 
 	waitForModeratedCommentToAppear() {
-		return this.driver.wait( until.elementLocated( by.css( '.comments__comment-moderation' ) ), this.explicitWaitMS, 'Could not see the comment moderation message after submitting a new comment' );
+		return driverHelper.waitTillPresentAndDisplayed( this.driver, by.css( '.comments__comment-moderation' ) );
 	}
 }

--- a/specs/wp-reader-spec.js
+++ b/specs/wp-reader-spec.js
@@ -66,13 +66,14 @@ test.describe( 'Reader: (' + screenSize + ') @parallel', function() {
 					return this.loginFlow.login();
 				} );
 
-				test.it( 'Can delete the new comment', function() {
+				test.it( 'Can delete the new comment (and wait for UNDO grace period so it is actually deleted)', function() {
 					this.navBarComponent = new NavbarComponent( driver );
 					this.navBarComponent.openNotifications();
 					this.notificationsComponent = new NotificationsComponent( driver );
 					this.notificationsComponent.selectCommentByText( this.comment );
 					this.notificationsComponent.trashComment();
-					return this.notificationsComponent.waitForUndoMessage();
+					this.notificationsComponent.waitForUndoMessage();
+					return this.notificationsComponent.waitForUndoMessageToDisappear();
 				} );
 			} );
 		} );

--- a/specs/wp-reader-spec.js
+++ b/specs/wp-reader-spec.js
@@ -28,12 +28,11 @@ test.describe( 'Reader: (' + screenSize + ') @parallel', function() {
 	this.timeout( mochaTimeOut );
 
 	test.before( function() {
-			driverManager.clearCookiesAndDeleteLocalStorage( driver );
-		} );
+		driverManager.clearCookiesAndDeleteLocalStorage( driver );
+	} );
 
 	test.describe( 'Log in as commenting user', function() {
 		test.it( 'Can log in as commenting user', function() {
-			const commentingUser = 'e2eflowtestingcommenter';
 			this.loginFlow = new LoginFlow( driver, 'commentingUser' );
 			return this.loginFlow.login();
 		} );
@@ -44,19 +43,24 @@ test.describe( 'Reader: (' + screenSize + ') @parallel', function() {
 				return this.readerPage.waitForPage();
 			} );
 
-			test.it( 'The latest post is on the expected test site', function () {
+			test.it( 'The latest post is on the expected test site', function() {
 				const testSiteForNotifications = config.get( 'testSiteForNotifications' );
 				return this.readerPage.siteOfLatestPost().then( ( siteOfLatestPost ) => {
-					assert.equal( siteOfLatestPost, testSiteForNotifications, 'The site feed is not the expected test site' );
+					assert.equal( siteOfLatestPost, testSiteForNotifications, 'The latest post is not on the expected test site' );
 				} );
 			} );
 
 			test.it( 'Can comment on the latest post', function() {
 				this.comment = dataHelper.randomPhrase();
-				return this.readerPage.commentOnLatestPost( this.comment );
+				this.readerPage.commentOnLatestPost( this.comment );
+				return this.readerPage.waitForModeratedCommentToAppear();
 			} );
 
 			test.describe( 'Delete the new comment', function() {
+				test.before( function() {
+					driverManager.clearCookiesAndDeleteLocalStorage( driver );
+				} );
+
 				test.it( 'Can log in as test site owner', function() {
 					this.loginFlow = new LoginFlow( driver, 'notificationsUser' );
 					return this.loginFlow.login();

--- a/specs/wp-reader-spec.js
+++ b/specs/wp-reader-spec.js
@@ -1,0 +1,76 @@
+import test from 'selenium-webdriver/testing';
+import config from 'config';
+import assert from 'assert';
+
+import LoginFlow from '../lib/flows/login-flow.js';
+
+import ReaderPage from '../lib/pages/reader-page.js';
+
+import NavbarComponent from '../lib/components/navbar-component.js';
+import NotificationsComponent from '../lib/components/notifications-component.js';
+
+import * as driverManager from '../lib/driver-manager.js';
+import * as dataHelper from '../lib/data-helper.js';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+
+let driver;
+
+test.before( 'Start Browser', function() {
+	this.timeout( startBrowserTimeoutMS );
+	driver = driverManager.startBrowser();
+} );
+
+test.describe( 'Reader: (' + screenSize + ') @parallel', function() {
+	this.bailSuite( true );
+	this.timeout( mochaTimeOut );
+
+	test.before( function() {
+			driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		} );
+
+	test.describe( 'Log in as commenting user', function() {
+		test.it( 'Can log in as commenting user', function() {
+			const commentingUser = 'e2eflowtestingcommenter';
+			this.loginFlow = new LoginFlow( driver, 'commentingUser' );
+			return this.loginFlow.login();
+		} );
+
+		test.describe( 'Leave a comment on the latest post in the Reader', function() {
+			test.it( 'Can see the Reader stream', function() {
+				this.readerPage = new ReaderPage( driver );
+				return this.readerPage.waitForPage();
+			} );
+
+			test.it( 'The latest post is on the expected test site', function () {
+				const testSiteForNotifications = config.get( 'testSiteForNotifications' );
+				return this.readerPage.siteOfLatestPost().then( ( siteOfLatestPost ) => {
+					assert.equal( siteOfLatestPost, testSiteForNotifications, 'The site feed is not the expected test site' );
+				} );
+			} );
+
+			test.it( 'Can comment on the latest post', function() {
+				this.comment = dataHelper.randomPhrase();
+				return this.readerPage.commentOnLatestPost( this.comment );
+			} );
+
+			test.describe( 'Delete the new comment', function() {
+				test.it( 'Can log in as test site owner', function() {
+					this.loginFlow = new LoginFlow( driver, 'notificationsUser' );
+					return this.loginFlow.login();
+				} );
+
+				test.it( 'Can delete the new comment', function() {
+					this.navBarComponent = new NavbarComponent( driver );
+					this.navBarComponent.openNotifications();
+					this.notificationsComponent = new NotificationsComponent( driver );
+					this.notificationsComponent.selectCommentByText( this.comment );
+					this.notificationsComponent.trashComment();
+					return this.notificationsComponent.waitForUndoMessage();
+				} );
+			} );
+		} );
+	} );
+} );

--- a/specs/wp-reader-spec.js
+++ b/specs/wp-reader-spec.js
@@ -18,7 +18,7 @@ const screenSize = driverManager.currentScreenSize();
 
 let driver;
 
-test.before( 'Start Browser', function() {
+test.before( function() {
 	this.timeout( startBrowserTimeoutMS );
 	driver = driverManager.startBrowser();
 } );

--- a/specs/wp-reader-spec.js
+++ b/specs/wp-reader-spec.js
@@ -52,8 +52,7 @@ test.describe( 'Reader: (' + screenSize + ') @parallel', function() {
 
 			test.it( 'Can comment on the latest post', function() {
 				this.comment = dataHelper.randomPhrase();
-				this.readerPage.commentOnLatestPost( this.comment );
-				return this.readerPage.waitForModeratedCommentToAppear();
+				return this.readerPage.commentOnLatestPost( this.comment );
 			} );
 
 			test.describe( 'Delete the new comment', function() {


### PR DESCRIPTION
This PR fixes #477:

- It updates the existing ReaderPage class with current classes and reader behavior.
- It also adds a new reader spec to test leaving a comment from the reader.

As with the current notifications spec, the comment may not necessarily be deleted from the test site even if the notification confirms it was deleted (and the final test passes). We'll need to address that issue for both specs per https://github.com/Automattic/wp-e2e-tests/issues/535.