### PR TITLE
Fix notifications spec trashing the comment

### DIFF
--- a/lib/components/notifications-component.js
+++ b/lib/components/notifications-component.js
@@ -6,14 +6,16 @@ import BaseContainer from '../base-container.js';
 export default class NotificationsComponent extends BaseContainer {
 	constructor( driver ) {
 		super( driver, by.css( '#wpnc-panel' ) );
+		this.undoSelector = by.css( '.wpnc__undo-item' );
 	}
+
 	selectComments() {
 		driverHelper.clickWhenClickable( this.driver, by.css( 'li[data-filter-name="comments"]' ) );
 		return this.driver.wait( until.elementLocated( by.css( 'li.wpnc__comment' ) ), this.explicitWaitMS, 'Could not locate comments in the comments pane' );
 	}
+
 	allCommentsContent() {
-		let text = this.driver.findElement( by.css( '.wpnc__notes' ) ).getText();
-		return text;
+		return this.driver.findElement( by.css( '.wpnc__notes' ) ).getText();
 	}
 	selectCommentByText( commentText ) {
 		const commentSelector = by.xpath( `//div[normalize-space(text())='${commentText}']` );
@@ -26,13 +28,14 @@ export default class NotificationsComponent extends BaseContainer {
 		this.driver.wait( until.elementLocated( trashPostSelector ), self.explicitWaitMS, 'Could not locate the trash comment button' );
 		const trashPostElement = self.driver.findElement( trashPostSelector );
 		this.driver.wait( until.elementIsVisible( trashPostElement ), self.explicitWaitMS, 'The trash post comment is not visible' );
-		driverHelper.clickWhenClickable( self.driver, trashPostSelector );
-		return self.driver.wait( until.elementLocated( by.css( '.wpnc__undo-item' ) ), this.explicitWaitMS ).then( () => { }, () => {
-			driverHelper.clickWhenClickable( self.driver, trashPostSelector );
-		} );
+		return driverHelper.clickWhenClickable( self.driver, trashPostSelector );
 	}
 
 	waitForUndoMessage() {
-		return this.driver.wait( until.elementLocated( by.css( '.wpnc__undo-item' ) ), this.explicitWaitMS, 'Could not locate the undo trash message' );
+		return driverHelper.waitTillPresentAndDisplayed( this.driver, this.undoSelector );
+	}
+
+	waitForUndoMessageToDisappear() {
+		return driverHelper.waitTillNotPresent( this.driver, this.undoSelector );
 	}
 }

--- a/lib/components/notifications-component.js
+++ b/lib/components/notifications-component.js
@@ -28,7 +28,10 @@ export default class NotificationsComponent extends BaseContainer {
 		this.driver.wait( until.elementLocated( trashPostSelector ), self.explicitWaitMS, 'Could not locate the trash comment button' );
 		const trashPostElement = self.driver.findElement( trashPostSelector );
 		this.driver.wait( until.elementIsVisible( trashPostElement ), self.explicitWaitMS, 'The trash post comment is not visible' );
-		return driverHelper.clickWhenClickable( self.driver, trashPostSelector );
+		driverHelper.clickWhenClickable( self.driver, trashPostSelector );
+		return self.driver.wait( until.elementLocated( by.css( '.wpnc__undo-item' ) ), this.explicitWaitMS ).then( () => { }, () => {
+			driverHelper.clickWhenClickable( self.driver, trashPostSelector );
+		} );
 	}
 
 	waitForUndoMessage() {

--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -131,7 +131,7 @@ export function elementIsNotPresent( driver, cssSelector ) {
 	return this.isElementPresent( driver, by.css( cssSelector ) ).then( function( isPresent ) {
 		return ! isPresent;
 	} );
-};
+}
 
 export function waitForFieldClearable( driver, selector ) {
 	return driver.wait( function() {
@@ -193,6 +193,17 @@ export function unsetCheckbox( driver, selector ) {
 			}
 		} );
 	} );
+}
+
+export function waitTillNotPresent( driver, selector, waitOverride ) {
+	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
+	let self = this;
+
+	return driver.wait( function() {
+		return self.isElementPresent( driver, selector ).then( function( isPresent ) {
+			return ! isPresent;
+		} );
+	}, timeoutWait, `Timed out waiting for element with ${selector.using} of '${selector.value}' to NOT be present` );
 }
 
 /**

--- a/specs/wp-notifications-spec.js
+++ b/specs/wp-notifications-spec.js
@@ -58,6 +58,7 @@ test.describe( 'Notifications: (' + screenSize + ') @parallel', function() {
 
 			test.it( 'Can leave a comment', function() {
 				this.comment = dataHelper.randomPhrase();
+				console.log( this.comment );
 				return this.viewPostPage.leaveAComment( this.comment );
 			} );
 
@@ -98,7 +99,8 @@ test.describe( 'Notifications: (' + screenSize + ') @parallel', function() {
 					test.it( 'Can delete the comment', function() {
 						this.notificationsComponent.selectCommentByText( this.comment );
 						this.notificationsComponent.trashComment();
-						return this.notificationsComponent.waitForUndoMessage();
+						this.notificationsComponent.waitForUndoMessage();
+						return this.notificationsComponent.waitForUndoMessageToDisappear();
 					} );
 				} );
 			} );

--- a/specs/wp-notifications-spec.js
+++ b/specs/wp-notifications-spec.js
@@ -57,7 +57,7 @@ test.describe( 'Notifications: (' + screenSize + ') @parallel', function() {
 			} );
 
 			test.it( 'Can leave a comment', function() {
-				this.comment = dataHelper.randomPhrase();
+				this.comment = dataHelper.randomPhrase() + ' TBD';
 				return this.viewPostPage.leaveAComment( this.comment );
 			} );
 
@@ -95,7 +95,7 @@ test.describe( 'Notifications: (' + screenSize + ') @parallel', function() {
 						} );
 					} );
 
-					test.it( 'Can delete the comment', function() {
+					test.it( 'Can delete the comment (and wait for UNDO grace period so it is actually deleted)', function() {
 						this.notificationsComponent.selectCommentByText( this.comment );
 						this.notificationsComponent.trashComment();
 						this.notificationsComponent.waitForUndoMessage();

--- a/specs/wp-notifications-spec.js
+++ b/specs/wp-notifications-spec.js
@@ -58,7 +58,6 @@ test.describe( 'Notifications: (' + screenSize + ') @parallel', function() {
 
 			test.it( 'Can leave a comment', function() {
 				this.comment = dataHelper.randomPhrase();
-				console.log( this.comment );
 				return this.viewPostPage.leaveAComment( this.comment );
 			} );
 


### PR DESCRIPTION
As @rachelmcr pointed out in #535, closing the browser quickly after clicking trash doesn't actually send the request to delete the comment.

This PR waits until the 'Undo' button disappears so that the request is sent (rather than waiting for an arbitrary time).

Fixes #535