### PR TITLE
Run all visdiffs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function( grunt ) {
 					// magellan as the test runner.   For now just calling mocha directly
 					// until Grunt can be replaced with magellan entirely (Issue 508)
 //					return './run.sh -R -c -f -v -l ' + sauceConfig + ' -s ' + browserSize
-					return `env BROWSERSIZE=${browserSize} ./node_modules/.bin/mocha --NODE_CONFIG='{"failVisdiffs":"true","sauce":"true","sauceConfig":"${sauceConfig}"}' -R spec-xunit-slack-reporter specs-visdiff/`
+					return `env BROWSERSIZE=${browserSize} ./node_modules/.bin/mocha --NODE_CONFIG='{"failVisdiffs":"true","sauce":"true","sauceConfig":"${sauceConfig}"}' -R spec-xunit-slack-reporter specs-visdiff/ || echo true`
 				}
 			}
 		},


### PR DESCRIPTION
With #531 the Gruntfile config was changed so the visdiffs would bypass run.sh in order to avoid using Magellan and keep using Grunt (for now).  But the way I did that failed to account for the fact that Grunt cancels all the tests once a single one fails, so subsequent visdiffs aren't being run.  (This is the main argument for #508)

This PR just short-circuits that so that it will always return success and keep going