### PR TITLE
Rework branch control for Slack pings

### DIFF
--- a/lib/reporter/magellan-reporter.js
+++ b/lib/reporter/magellan-reporter.js
@@ -25,82 +25,86 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 		}
 	} );
 
+	// Only enable Slack messages on the master branch
+	let slackClient = { send: function() {} };
 	if ( config.has( 'slackHook' ) && process.env.CIRCLE_BRANCH === 'master' ) {
-		let slackClient = slack( config.get( 'slackHook' ) );
+		slackClient = slack( config.get( 'slackHook' ) );
+	}
 
-		source.on( 'message', function( msg ) {
-			if ( msg.type === 'worker-status' ) {
-				const passCondition = msg.passed;
-				const failCondition = !msg.passed && msg.status === 'finished' && test.maxAttempts === test.attempts + 1;
-				const testObject = {
-					title: test.locator.title,
-					fullTitle: test.locator.name,
-					duration: test.runningTime,
-					err: {}
-				};
-				const reportDir = testRun.tempAssetPath + '/reports';
-				const screenshotDir = testRun.tempAssetPath + '/screenshots';
+	source.on( 'message', function( msg ) {
+		if ( msg.type === 'worker-status' ) {
+			const passCondition = msg.passed;
+			const failCondition = !msg.passed && msg.status === 'finished' && test.maxAttempts === test.attempts + 1;
+			const testObject = {
+				title: test.locator.title,
+				fullTitle: test.locator.name,
+				duration: test.runningTime,
+				err: {}
+			};
+			const reportDir = testRun.tempAssetPath + '/reports';
+			const screenshotDir = testRun.tempAssetPath + '/screenshots';
 
-				// Notify if the test was retried
-				if ( passCondition && test.attempts > 0 ) {
-					slackClient.send( {
-						icon_emoji: ':a8c:',
-						text: `FYI - The following test failed, retried, and passed: (${process.env.BROWSERSIZE}) ${testObject.title} - Build <https://circleci.com/gh/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}/${process.env.CIRCLE_BUILD_NUM}|#${process.env.CIRCLE_BUILD_NUM}>`,
-						username: 'e2e Test Runner'
-					} );
-				}
+			// Notify if the test was retried
+			if ( passCondition && test.attempts > 0 ) {
+				slackClient.send( {
+					icon_emoji: ':a8c:',
+					text: `FYI - The following test failed, retried, and passed: (${process.env.BROWSERSIZE}) ${testObject.title} - Build <https://circleci.com/gh/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}/${process.env.CIRCLE_BUILD_NUM}|#${process.env.CIRCLE_BUILD_NUM}>`,
+					username: 'e2e Test Runner'
+				} );
+			}
 
-				// If the test failed on the final retry, send Slack notifications
-				if ( failCondition ) {
-					// Reports
-					fs.readdir( reportDir, function( dirErr, files ) {
-						if ( dirErr ) {
-							return 1;
+			// If the test failed on the final retry, send Slack notifications
+			if ( failCondition ) {
+				// Reports
+				fs.readdir( reportDir, function( dirErr, files ) {
+					if ( dirErr ) {
+						return 1;
+					}
+
+					files.forEach( function( reportPath ) {
+						if ( ! reportPath.match( /xml$/i ) ) {
+							return;
 						}
 
-						files.forEach( function( reportPath ) {
-							if ( ! reportPath.match( /xml$/i ) ) {
-								return;
+						// Parse out failure messages and send to Slack
+						const xmlString = fs.readFileSync( `${reportDir}/${reportPath}`, 'utf-8' );
+						const xmlData = XunitViewerParser.parse( xmlString );
+						const failures = xmlData[0].tests.
+							filter( ( t ) => {
+								return t.status === 'fail';
+							} );
+
+						failures.forEach( function( failure ) {
+							let fieldsObj = { Error: failure.message.split( /\n/ )[0] };
+							let testName = failure.classname + ': ' + failure.name;
+							if ( process.env.DEPLOY_USER ) {
+								fieldsObj['Git Diff'] = '<https://github.com/Automattic/wp-calypso/compare/' + process.env.PROD_REVISION + '...' + process.env.TO_DEPLOY_REVISION + '|Compare Commits>';
+								fieldsObj.Author = process.env.DEPLOY_USER;
 							}
 
-							// Parse out failure messages and send to Slack
-							const xmlString = fs.readFileSync( `${reportDir}/${reportPath}`, 'utf-8' );
-							const xmlData = XunitViewerParser.parse( xmlString );
-							const failures = xmlData[0].tests.
-								filter( ( t ) => {
-									return t.status === 'fail';
-								} );
-
-							failures.forEach( function( failure ) {
-								let fieldsObj = { Error: failure.message.split( /\n/ )[0] };
-								let testName = failure.classname + ': ' + failure.name;
-								if ( process.env.DEPLOY_USER ) {
-									fieldsObj['Git Diff'] = '<https://github.com/Automattic/wp-calypso/compare/' + process.env.PROD_REVISION + '...' + process.env.TO_DEPLOY_REVISION + '|Compare Commits>';
-									fieldsObj.Author = process.env.DEPLOY_USER;
-								}
-
-								slackClient.send( {
-									icon_emoji: ':a8c:',
-									text: `<!subteam^S0G7K98MB|flow-patrol-squad-team> Test Failed (${process.env.BROWSERSIZE}): *${testName}* - Build <https://circleci.com/gh/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}/${process.env.CIRCLE_BUILD_NUM}|#${process.env.CIRCLE_BUILD_NUM}>`,
-									fields: fieldsObj,
-									username: 'e2e Test Runner'
-								} );
+							slackClient.send( {
+								icon_emoji: ':a8c:',
+								text: `<!subteam^S0G7K98MB|flow-patrol-squad-team> Test Failed (${process.env.BROWSERSIZE}): *${testName}* - Build <https://circleci.com/gh/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}/${process.env.CIRCLE_BUILD_NUM}|#${process.env.CIRCLE_BUILD_NUM}>`,
+								fields: fieldsObj,
+								username: 'e2e Test Runner'
 							} );
 						} );
 					} );
+				} );
 
-					// Screenshots
-					fs.readdir( screenshotDir, function( dirErr, files ) {
-						if ( dirErr ) {
-							return 1;
+				// Screenshots
+				fs.readdir( screenshotDir, function( dirErr, files ) {
+					if ( dirErr ) {
+						return 1;
+					}
+
+					files.forEach( function( screenshotPath ) {
+						if ( ! screenshotPath.match( /png$/i ) ) {
+							return;
 						}
 
-						files.forEach( function( screenshotPath ) {
-							if ( ! screenshotPath.match( /png$/i ) ) {
-								return;
-							}
-
-							// Send screenshot to Slack
+						// Send screenshot to Slack on master branch only
+						if ( config.has( 'slackTokenForScreenshots' ) && process.env.CIRCLE_BRANCH === 'master' ) {
 							const SlackUpload = require( 'node-slack-upload' );
 							const slackUpload = new SlackUpload( config.get( 'slackTokenForScreenshots' ) );
 
@@ -115,67 +119,65 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 										text: `Build <https://circleci.com/gh/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}/${process.env.CIRCLE_BUILD_NUM}|#${process.env.CIRCLE_BUILD_NUM}> Upload to slack failed: '${err}'`,
 										username: 'e2e Test Runner'
 									} );
-								} else {
-									console.log( 'done' );
 								}
 							} );
-						} );
-					} );
-				}
-
-				// Pass or fail, if this was the last run move the logs and screenshots to CI artifact directories
-				if ( passCondition || failCondition ) {
-					// Reports
-					fs.readdir( reportDir, function( dirErr, reportFiles ) {
-						if ( dirErr ) {
-							return 1;
 						}
-
-						reportFiles.forEach( function( reportPath ) {
-							if ( ! reportPath.match( /xml$/i ) ) {
-								return;
-							}
-
-							// Move to /reports for CircleCI artifacts
-							fs.rename( `${reportDir}/${reportPath}`, `./reports/${testRun.guid}_${reportPath}`, function( moveErr ) {
-								if ( moveErr ) {
-									slackClient.send( {
-										icon_emoji: ':a8c:',
-										text: `Build <https://circleci.com/gh/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}/${process.env.CIRCLE_BUILD_NUM}|#${process.env.CIRCLE_BUILD_NUM}> Moving file to /reports failed: '${moveErr}'`,
-										username: 'e2e Test Runner'
-									} );
-								}
-							} );
-						} );
 					} );
-
-					// Screenshots
-					fs.readdir( screenshotDir, function( dirErr, screenshotFiles ) {
-						if ( dirErr ) {
-							return 1;
-						}
-
-						screenshotFiles.forEach( function( screenshotPath ) {
-							if ( ! screenshotPath.match( /png$/i ) ) {
-								return;
-							}
-
-							// Move to /screenshots for CircleCI artifacts
-							fs.rename( `${screenshotDir}/${screenshotPath}`, `./screenshots/${screenshotPath}`, function( moveErr ) {
-								if ( moveErr ) {
-									slackClient.send( {
-										icon_emoji: ':a8c:',
-										text: `Build <https://circleci.com/gh/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}/${process.env.CIRCLE_BUILD_NUM}|#${process.env.CIRCLE_BUILD_NUM}> Moving file to /screenshots failed: '${moveErr}'`,
-										username: 'e2e Test Runner'
-									} );
-								}
-							} );
-						} );
-					} );
-				}
+				} );
 			}
-		} );
-	}
+
+			// Pass or fail, if this was the last run move the logs and screenshots to CI artifact directories
+			if ( passCondition || failCondition ) {
+				// Reports
+				fs.readdir( reportDir, function( dirErr, reportFiles ) {
+					if ( dirErr ) {
+						return 1;
+					}
+
+					reportFiles.forEach( function( reportPath ) {
+						if ( ! reportPath.match( /xml$/i ) ) {
+							return;
+						}
+
+						// Move to /reports for CircleCI artifacts
+						fs.rename( `${reportDir}/${reportPath}`, `./reports/${testRun.guid}_${reportPath}`, function( moveErr ) {
+							if ( moveErr ) {
+								slackClient.send( {
+									icon_emoji: ':a8c:',
+									text: `Build <https://circleci.com/gh/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}/${process.env.CIRCLE_BUILD_NUM}|#${process.env.CIRCLE_BUILD_NUM}> Moving file to /reports failed: '${moveErr}'`,
+									username: 'e2e Test Runner'
+								} );
+							}
+						} );
+					} );
+				} );
+
+				// Screenshots
+				fs.readdir( screenshotDir, function( dirErr, screenshotFiles ) {
+					if ( dirErr ) {
+						return 1;
+					}
+
+					screenshotFiles.forEach( function( screenshotPath ) {
+						if ( ! screenshotPath.match( /png$/i ) ) {
+							return;
+						}
+
+						// Move to /screenshots for CircleCI artifacts
+						fs.rename( `${screenshotDir}/${screenshotPath}`, `./screenshots/${screenshotPath}`, function( moveErr ) {
+							if ( moveErr ) {
+								slackClient.send( {
+									icon_emoji: ':a8c:',
+									text: `Build <https://circleci.com/gh/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}/${process.env.CIRCLE_BUILD_NUM}|#${process.env.CIRCLE_BUILD_NUM}> Moving file to /screenshots failed: '${moveErr}'`,
+									username: 'e2e Test Runner'
+								} );
+							}
+						} );
+					} );
+				} );
+			}
+		}
+	} );
 };
 
 module.exports = Reporter;


### PR DESCRIPTION
Previously the Magellan reporter was only moving the report and screenshot files to the CircleCI artifacts directories for the master branch.  This PR reworks it so that it moves them for all branches, and only restricts the portions that send screenshots and messages to Slack.