### PR TITLE
Remove step to stub out 1.gravatar.com in /etc/hosts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,6 @@ jobs:
             - /wp-e2e-tests/node_modules
           key: << checksum "package.json" >>
       - run: ./scripts/randomize.sh specs
-      - run:
-         name: Update hosts file
-         command: |
-           echo 127.0.0.1 1.gravatar.com | sudo tee -a /etc/hosts
-           cat /etc/hosts
       - run: ./scripts/run-wrapper.sh
       - store_test_results:
           path: reports/


### PR DESCRIPTION
The rampant network timeouts to 1.gravatar.com from last week seem to be resolved.

Closes #542 