### PR TITLE
Remove step-header class dependency

### DIFF
--- a/lib/pages/signup/start-page.js
+++ b/lib/pages/signup/start-page.js
@@ -24,7 +24,7 @@ export default class StartPage extends BaseContainer {
 
 		let ABTestControlFlow = flow !== '' ? flow : 'main';
 
-		super( driver, By.css( '.step-header' ), visit, url );
+		super( driver, By.css( '.step-wrapper' ), visit, url );
 		this.checkForUnknownABTestKeys();
 		this.setABTestControlGroupsInLocalStorage( url, culture, ABTestControlFlow );
 	}


### PR DESCRIPTION
Use `.step-wrapper` over `.step-header` for test. `.step-header` will be removed.

Fixes #553 