### PR TITLE
Moved DISABLE_EMAIL ping to limit occurrences

### DIFF
--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -7,6 +7,9 @@ if [ "$CIRCLE_NODE_INDEX" == "0" ]; then
   if [ "$SKIP_TEST_REGEX" != "" ]; then
     babel-node --presets es2015 lib/slack-ping-cli.js "Attention! Tests are being skipped with pattern [$SKIP_TEST_REGEX]"
   fi
+  if [ "$DISABLE_EMAIL" == "true" ]; then
+    babel-node --presets es2015 lib/slack-ping-cli.js "WARNING::: Any test that uses email is currently disabled as DISABLE_EMAIL is set to true"
+  fi
 fi
 
 if [ "$NODE_ENV_OVERRIDE" != "" ]; then

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -27,8 +27,6 @@ import * as dataHelper from '../lib/data-helper.js';
 
 import EmailClient from '../lib/email-client.js';
 
-import * as SlackNotifier from '../lib/slack-notifier';
-
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
@@ -44,7 +42,6 @@ test.before( function() {
 // Faked out test.describe function to enable dynamic skipping of e-mail tests
 let testDescribe = test.describe;
 if ( process.env.DISABLE_EMAIL === 'true' ) {
-	SlackNotifier.warn( 'WARNING::: Any test that uses email is currently disabled as DISABLE_EMAIL is set to true' );
 	testDescribe = test.xdescribe;
 }
 

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -40,7 +40,6 @@ test.before( function() {
 // Faked out test.describe function to enable dynamic skipping of e-mail tests
 let testDescribe = test.describe;
 if ( process.env.DISABLE_EMAIL === 'true' ) {
-	SlackNotifier.warn( 'WARNING::: Any test that uses email is currently disabled as DISABLE_EMAIL is set to true' );
 	testDescribe = test.xdescribe;
 }
 
@@ -535,7 +534,6 @@ testDescribe( 'Sign Up (' + screenSize + ')', function() {
 							}
 						} );
 					} );
-
 
 					test.describe( 'Step Five: Account', function() {
 						test.it( 'Can then enter account details', function() {


### PR DESCRIPTION
With Magellan running each test in its own mocha instance this ping was being sent out dozens of times on each run.  This PR moves the ping to the run-wrapper instead so it only goes out once.