### PR TITLE
Force redirect to /read for Reader

### DIFF
--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -58,7 +58,7 @@ export default class LoginFlow {
 	loginAndStartNewPost() {
 		this.login();
 
-		let readerPage = new ReaderPage( this.driver );
+		let readerPage = new ReaderPage( this.driver, true );
 		readerPage.waitForPage();
 
 		let navbarComponent = new NavbarComponent( this.driver );
@@ -96,7 +96,7 @@ export default class LoginFlow {
 	loginAndSelectMySite() {
 		this.login();
 
-		let readerPage = new ReaderPage( this.driver );
+		let readerPage = new ReaderPage( this.driver, true );
 		readerPage.waitForPage();
 
 		let navbarComponent = new NavbarComponent( this.driver );

--- a/lib/pages/reader-page.js
+++ b/lib/pages/reader-page.js
@@ -6,7 +6,7 @@ import * as driverHelper from '../driver-helper.js';
 
 export default class ReaderPage extends BaseContainer {
 	constructor( driver, visit = false ) {
-		let url = config.get( 'calypsoBaseURL' );
+		let url = config.get( 'calypsoBaseURL' ) + '/read';
 		if ( config.has( 'liveBranch' ) && config.get( 'liveBranch' ) === 'true' ) {
 			url = url + '?branch=' + config.get( 'branchName' );
 		}


### PR DESCRIPTION
With https://github.com/Automattic/wp-calypso/pull/14070 a new feature has been added to Calypso that remembers the last place you were and redirects you there when you visit `/`.  It's currently only active on development and wpcalypso, but will eventually move to production.

It breaks a few of our tests that expect the Reader to load.   This PR fixes that by updating the `ReaderPage` object to visit `/read` instead of just `calypsoBaseURL`.  This also required updating a couple of the login flows to force a visit to the Reader (via that URL) instead of just assuming that it would load upon login.