### PR TITLE
Fixed path to babel-node

### DIFF
--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -5,10 +5,10 @@
 #    it will always say "screen size 'desktop'"
 if [ "$CIRCLE_NODE_INDEX" == "0" ]; then
   if [ "$SKIP_TEST_REGEX" != "" ]; then
-    babel-node --presets es2015 lib/slack-ping-cli.js "Attention! Tests are being skipped with pattern [$SKIP_TEST_REGEX]"
+    ./node_modules/.bin/babel-node --presets es2015 lib/slack-ping-cli.js "Attention! Tests are being skipped with pattern [$SKIP_TEST_REGEX]"
   fi
   if [ "$DISABLE_EMAIL" == "true" ]; then
-    babel-node --presets es2015 lib/slack-ping-cli.js "WARNING::: Any test that uses email is currently disabled as DISABLE_EMAIL is set to true"
+    ./node_modules/.bin/babel-node --presets es2015 lib/slack-ping-cli.js "WARNING::: Any test that uses email is currently disabled as DISABLE_EMAIL is set to true"
   fi
 fi
 


### PR DESCRIPTION
The Slack ping in run-wrapper wasn't executing because with the new Docker container it no longer had babel-node in the $PATH like it did with the stock CircleCI container.