### PR TITLE
Ensure page is saved before setting Sharing options (workaround)

### DIFF
--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -64,6 +64,8 @@ test.describe( 'Editor: Pages (' + screenSize + ')', function() {
 
 			test.it( 'Can disable sharing buttons', function() {
 				let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+				let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+				postEditorToolbarComponent.ensureSaved();
 				postEditorSidebarComponent.expandSharingSection();
 				postEditorSidebarComponent.setSharingButtons( false );
 				postEditorSidebarComponent.closeSharingSection();


### PR DESCRIPTION
Workaround for Calypso timing bug https://github.com/Automattic/wp-calypso/issues/14853 where the Sharing options aren't populated before a draft is saved.