### PR TITLE
Removed verification of text widget content for now

### DIFF
--- a/lib/pages/customizer-page.js
+++ b/lib/pages/customizer-page.js
@@ -265,7 +265,7 @@ export default class CustomizerPage extends BaseContainer {
 		driverHelper.clickWhenClickable( this.driver, addWidgetSelector );
 		driverHelper.clickWhenClickable( this.driver, by.css( '#widget-tpl-text-1' ) );
 		driverHelper.setWhenSettable( this.driver, by.css( 'li.expanded input.widefat' ), widgetTitle );
-		driverHelper.setWhenSettable( this.driver, by.css( 'li.expanded textarea.widefat' ), widgetContent );
+//		driverHelper.setWhenSettable( this.driver, by.css( 'li.expanded textarea.widefat' ), widgetContent );
 		return driverHelper.clickWhenClickable( this.driver, by.css( 'li.expanded .widget-control-close' ) );
 	}
 
@@ -385,7 +385,7 @@ export default class CustomizerPage extends BaseContainer {
 
 	previewShowsWidget( widgetTitle, widgetContent ) {
 		this.driver.sleep( 2000 ); //This is required to show the custom header
-		const selector = by.xpath( `//h2[normalize-space(text())="${widgetTitle}"]/following-sibling::div[normalize-space(text())="${widgetContent}"]` );
+		const selector = by.xpath( `//h2[normalize-space(text())="${widgetTitle}"]` );
 		this._ensurePreviewViewOnMobile();
 		this._switchToPreviewiFrame();
 		const visible = driverHelper.isEventuallyPresentAndDisplayed( this.driver, selector );


### PR DESCRIPTION
WordPress 4.8 is active on WordPress.com now, and with that comes a rich text editor for the Text Widget, which broke the verification test.  This PR just removes the content verification, since the title field still works as it did before.

I'll investigate further in the morning and see how easy it will be to add content verification back in.  The editor is inside an iframe, which complicates things with Selenium.