### PR TITLE
Hide animated elements causing IE11 issues in signup

### DIFF
--- a/lib/pages/signup/signup-processing-page.js
+++ b/lib/pages/signup/signup-processing-page.js
@@ -7,6 +7,11 @@ import * as slackNotifier from '../../slack-notifier';
 
 export default class SignupProcessingPage extends BaseContainer {
 	constructor( driver ) {
+		// Hides the floating background on signup that causes issues with Selenium/SauceLabs getting page loaded status
+		if ( global.browserName === 'Internet Explorer' ) {
+			driver.executeScript( 'document.querySelector( ".signup-processing-screen__floaties" ).style.display = "none"' );
+		}
+
 		super( driver, By.css( '.signup-processing__content' ) );
 		this.continueButtonSelector = By.css( 'button.email-confirmation__button' );
 	}
@@ -29,11 +34,7 @@ export default class SignupProcessingPage extends BaseContainer {
 	continueAlong() {
 		const self = this;
 		driverHelper.clickWhenClickable( self.driver, self.continueButtonSelector );
-		return self.driver.wait( () => {
-			return driverHelper.isElementPresent( self.driver, self.expectedElementSelector ).then( ( present ) => {
-				return !present;
-			} );
-		}, this.explicitWaitMS * 2 ).then( () => {
+		return driverHelper.waitTillNotPresent( self.driver, self.continueButtonSelector ).then( () => {
 			return true;
 		}, () => {
 			slackNotifier.warn( 'The signup processing page is still shown after continuing, trying to click continue again' );


### PR DESCRIPTION
This doesn't completely fix #562, but solves at least one problem.  Seems like the animated elements in the background of the signup processing page are causing the browser not to accurately report to Selenium that it's finished loading.  This PR just hides those elements.

My local testing was still showing problems after that step with bad status on whether it had clicked the Continue button or not, but I'm moving on from this problem for right now.  I'll continue work on it later.