### PR TITLE
Revert "Ensure page is saved before setting Sharing options (workaround)"

### DIFF
--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -64,8 +64,6 @@ test.describe( 'Editor: Pages (' + screenSize + ')', function() {
 
 			test.it( 'Can disable sharing buttons', function() {
 				let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
-				let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
-				postEditorToolbarComponent.ensureSaved();
 				postEditorSidebarComponent.expandSharingSection();
 				postEditorSidebarComponent.setSharingButtons( false );
 				postEditorSidebarComponent.closeSharingSection();


### PR DESCRIPTION
The source issue was fixed in https://github.com/Automattic/wp-calypso/pull/14855

Reverts Automattic/wp-e2e-tests#563