### PR TITLE
More specific selector for logout on mobile

### DIFF
--- a/lib/pages/profile-page.js
+++ b/lib/pages/profile-page.js
@@ -9,7 +9,7 @@ const by = webdriver.By;
 export default class ProfilePage extends BaseContainer {
 	constructor( driver ) {
 		super( driver, by.className( 'me-profile-settings' ) );
-		this.closeProfileViewSelector = by.css( 'header.current-section' );
+		this.closeProfileViewSelector = by.css( 'header.current-section a' );
 		this.signOutSelector = by.css( '.me-sidebar__signout-button' );
 	}
 	clickSignOut() {


### PR DESCRIPTION
Calypso PR https://github.com/Automattic/wp-calypso/pull/14829 broke some of the styling on the sidebar for /me, and it was only caught by chance.  The tests were set to click the `<header>` element to open the sidebar menu on mobile, which was obscured by this change.

This PR makes it more specific to click the `<a>` element inside the header to let the tests continue to function.  But we might as well revert this after the Calypso styling issue is fixed, since it was nice to find a visual layout bug this way 😄 