### PR TITLE
Even more protection for fs actions in reporter

### DIFF
--- a/lib/reporter/magellan-reporter.js
+++ b/lib/reporter/magellan-reporter.js
@@ -73,33 +73,32 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 						}
 
 						// Parse out failure messages and send to Slack
-						let xmlString = '';
 						try {
-							xmlString = fs.readFileSync( `${reportDir}/${reportPath}`, 'utf-8' );
+							const xmlString = fs.readFileSync( `${reportDir}/${reportPath}`, 'utf-8' );
+							const xmlData = XunitViewerParser.parse( xmlString );
+							const failures = xmlData[0].tests.
+								filter( ( t ) => {
+									return t.status === 'fail';
+								} );
+
+							failures.forEach( function( failure ) {
+								let fieldsObj = { Error: failure.message.split( /\n/ )[0] };
+								let testName = failure.classname + ': ' + failure.name;
+								if ( process.env.DEPLOY_USER ) {
+									fieldsObj['Git Diff'] = '<https://github.com/Automattic/wp-calypso/compare/' + process.env.PROD_REVISION + '...' + process.env.TO_DEPLOY_REVISION + '|Compare Commits>';
+									fieldsObj.Author = process.env.DEPLOY_USER;
+								}
+
+								slackClient.send( {
+									icon_emoji: ':a8c:',
+									text: `<!subteam^S0G7K98MB|flow-patrol-squad-team> Test Failed (${process.env.BROWSERSIZE}): *${testName}* - Build <https://circleci.com/gh/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}/${process.env.CIRCLE_BUILD_NUM}|#${process.env.CIRCLE_BUILD_NUM}>`,
+									fields: fieldsObj,
+									username: 'e2e Test Runner'
+								} );
+							} );
 						} catch ( e ) {
 							console.log( `Error reading report file, likely just timing race: ${e.message}` );
 						}
-						const xmlData = XunitViewerParser.parse( xmlString );
-						const failures = xmlData[0].tests.
-							filter( ( t ) => {
-								return t.status === 'fail';
-							} );
-
-						failures.forEach( function( failure ) {
-							let fieldsObj = { Error: failure.message.split( /\n/ )[0] };
-							let testName = failure.classname + ': ' + failure.name;
-							if ( process.env.DEPLOY_USER ) {
-								fieldsObj['Git Diff'] = '<https://github.com/Automattic/wp-calypso/compare/' + process.env.PROD_REVISION + '...' + process.env.TO_DEPLOY_REVISION + '|Compare Commits>';
-								fieldsObj.Author = process.env.DEPLOY_USER;
-							}
-
-							slackClient.send( {
-								icon_emoji: ':a8c:',
-								text: `<!subteam^S0G7K98MB|flow-patrol-squad-team> Test Failed (${process.env.BROWSERSIZE}): *${testName}* - Build <https://circleci.com/gh/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}/${process.env.CIRCLE_BUILD_NUM}|#${process.env.CIRCLE_BUILD_NUM}>`,
-								fields: fieldsObj,
-								username: 'e2e Test Runner'
-							} );
-						} );
 					} );
 				} );
 


### PR DESCRIPTION
The last change failed to account for the fact that if there was an error that it caught, then the XML object would be empty and the parser would choke on it.