### PR TITLE
Add spec to purchase Jetpack plan from wp-admin upgrade nudge

### DIFF
--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -1,4 +1,5 @@
 import LoginPage from '../pages/login-page.js';
+import WPAdminLoginPage from '../pages/wp-admin/wp-admin-logon-page';
 import ReaderPage from '../pages/reader-page.js';
 import StatsPage from '../pages/stats-page.js';
 
@@ -45,19 +46,25 @@ export default class LoginFlow {
 		return localConfig[ account ];
 	}
 
-	login() {
-		let testUserName, testPassword;
+	login( { jetpackSSO = false } = {} ) {
+		let testUserName, testPassword, loginURL, loginPage;
 
 		const accountInfo = LoginFlow.getAccountConfig( this.account );
 
 		if ( accountInfo !== undefined ) {
 			testUserName = accountInfo[0];
 			testPassword = accountInfo[1];
+			loginURL = accountInfo[2]; // Will only be populated for Jetpack sites
 		} else {
 			throw new Error( `Account key '${this.account}' not found in the configuration` );
 		}
 
-		let loginPage = new LoginPage( this.driver, true );
+		if ( loginURL !== undefined && jetpackSSO ) {
+			loginPage = new WPAdminLoginPage( this.driver, loginURL, { visit: true } );
+			return loginPage.logonSSO();
+		}
+
+		loginPage = new LoginPage( this.driver, true );
 		return loginPage.login( testUserName, testPassword );
 	}
 

--- a/lib/pages/jetpack-plans-sales-page.js
+++ b/lib/pages/jetpack-plans-sales-page.js
@@ -1,0 +1,16 @@
+import webdriver from 'selenium-webdriver';
+import BaseContainer from '../base-container.js';
+import * as driverHelper from '../driver-helper.js';
+
+const by = webdriver.By;
+
+export default class JetpackPlansSalesPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.className( 'cta-install' ) );
+	}
+
+	clickPurchaseButton() {
+		const selector = by.css( '.cta-install a' );
+		return driverHelper.clickWhenClickable( this.driver, selector );
+	}
+}

--- a/lib/pages/login-page.js
+++ b/lib/pages/login-page.js
@@ -7,10 +7,14 @@ import * as driverHelper from '../driver-helper.js';
 import * as slackNotifier from '../slack-notifier.js';
 
 export default class LoginPage extends BaseContainer {
-	constructor( driver, visit ) {
+	constructor( driver, visit, overrideURL ) {
 		const authURL = config.get( 'authURL' );
 		const baseURL = config.get( 'calypsoBaseURL' );
-		const loginURL = `${authURL}?redirect_to=${baseURL}`;
+		let loginURL = `${authURL}?redirect_to=${baseURL}`;
+
+		if ( typeof overrideURL === 'string' ) {
+			loginURL = overrideURL;
+		}
 
 		super( driver, By.css( '#loginform' ), visit, loginURL );
 	}

--- a/lib/pages/plans-page.js
+++ b/lib/pages/plans-page.js
@@ -1,7 +1,6 @@
 import webdriver from 'selenium-webdriver';
 import BaseContainer from '../base-container.js';
 import * as driverHelper from '../driver-helper.js';
-import SecurePaymentComponent from '../components/secure-payment-component.js';
 
 const by = webdriver.By;
 const until = webdriver.until;

--- a/lib/pages/wp-admin/wp-admin-add-post-page.js
+++ b/lib/pages/wp-admin/wp-admin-add-post-page.js
@@ -1,0 +1,99 @@
+import { By as by, until } from 'selenium-webdriver';
+import BaseContainer from '../../base-container';
+import * as driverHelper from '../../driver-helper';
+
+export default class WPAdminAddPostPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( '#post' ) );
+		this.editorFrameName = by.css( '#content_ifr' );
+	}
+
+	publicizeDefaults() {
+		return this.driver.findElement( by.css( '#publicize-defaults' ) ).getText();
+	}
+
+	enterCustomPublicizeMessage( customMessage ) {
+		this._openPublicizeDetails();
+		return driverHelper.setWhenSettable( this.driver, by.css( 'textarea#wpas-title' ), customMessage );
+	}
+
+	enterTitle( title ) {
+		return driverHelper.setWhenSettable( this.driver, by.css( '#title' ), title );
+	}
+
+	enterContent( blogPostText ) {
+		this.driver.wait( until.ableToSwitchToFrame( this.editorFrameName ), this.explicitWaitMS, 'Could not locate the editor iFrame.' );
+		this.driver.findElement( by.css( '#tinymce' ) ).sendKeys( blogPostText );
+		return this.driver.switchTo().defaultContent();
+	}
+
+	enterPostImage( fileDetails ) {
+		const self = this;
+		const newFile = fileDetails.file;
+		const insertImageSelector = by.css( '.media-button-insert' );
+
+		driverHelper.clickWhenClickable( self.driver, by.css( '#insert-media-button' ) );
+		self.driver.findElement( by.css( 'input[type="file"]' ) ).sendKeys( newFile );
+		self.driver.wait( function() {
+			return self.driver.findElement( insertImageSelector ).getAttribute( 'disabled' ).then( ( d ) => {
+				return d !== 'true';
+			} );
+		}, this.explicitWaitMS, 'The insert into post button is still disabled after uploading the image' );
+		return driverHelper.clickWhenClickable( self.driver, insertImageSelector );
+	}
+
+	waitUntilImageInserted( fileDetails ) {
+		const self = this;
+		const newImageName = fileDetails.imageName;
+		self.driver.wait( until.ableToSwitchToFrame( self.editorFrameName ), self.explicitWaitMS, 'Could not locate the editor iFrame.' );
+		self.driver.wait( until.elementLocated( by.css( `img[src*="${ newImageName }"]` ) ), this.explicitWaitMS, 'Could not locate image in editor, check it is visible' );
+		return self.driver.switchTo().defaultContent();
+	}
+
+	publicizeMessageShown() {
+		const self = this;
+		const selector = by.css( 'textarea#wpas-title' );
+		self._openPublicizeDetails();
+		self.driver.wait( function() {
+			return self.driver.findElement( selector ).getText( ).then( ( t ) => {
+				return t !== '';
+			} );
+		}, this.explicitWaitMS, 'The publicize message is still blank after waiting for it to not be' );
+		return this.driver.findElement( selector ).getText();
+	}
+
+	_openPublicizeDetails() {
+		const self = this;
+		const openSelector = by.css( 'a#publicize-form-edit' );
+
+		return self.driver.findElement( openSelector ).then( ( openElement ) => {
+			return openElement.isDisplayed().then( ( displayed ) => {
+				if ( displayed === true ) {
+					return driverHelper.clickWhenClickable( self.driver, openSelector );
+				}
+			} )
+		} );
+	}
+
+	publish() {
+		const self = this;
+		const publishSelector = by.css( '#publish' );
+		const publishedSelector = by.css( '#message.updated' );
+		self.driver.wait( function() {
+			return self.driver.findElement( publishSelector ).getAttribute( 'disabled' ).then( ( d ) => {
+				return d !== 'true';
+			} );
+		}, this.explicitWaitMS, 'The publish button is still disabled after waiting for it' );
+		driverHelper.clickWhenClickable( this.driver, publishSelector );
+		driverHelper.isEventuallyPresentAndDisplayed( this.driver, publishedSelector ).then( ( published ) => {
+			if ( published === false ) {
+				driverHelper.clickWhenClickable( this.driver, publishSelector );
+			}
+		} );
+		return driverHelper.waitTillPresentAndDisplayed( this.driver, publishedSelector );
+	}
+
+	viewPostLink() {
+		return this.driver.findElement( by.css( '#message a') ).getAttribute( 'href' );
+	}
+}

--- a/lib/pages/wp-admin/wp-admin-css-stylesheet-editor-page.js
+++ b/lib/pages/wp-admin/wp-admin-css-stylesheet-editor-page.js
@@ -1,0 +1,12 @@
+import { By as by } from 'selenium-webdriver';
+import BaseContainer from '../../base-container';
+
+export default class WPAdminCSSStylesheetEditorPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( 'body.appearance_page_editcss' ) );
+	}
+
+	customCSSDisplayed() {
+		return this.driver.findElement( by.css( '#safecss' ) ).getAttribute( 'value' );
+	}
+}

--- a/lib/pages/wp-admin/wp-admin-customizer-page.js
+++ b/lib/pages/wp-admin/wp-admin-customizer-page.js
@@ -1,0 +1,23 @@
+import { By as by, until } from 'selenium-webdriver';
+import BaseContainer from '../../base-container';
+
+// import * as driverHelper from '../../driver-helper';
+// import * as driverManager from '../../driver-manager';
+
+export default class WpAdminCustomizerPage extends BaseContainer {
+	constructor( driver ) {
+		const expectedElementSelector = by.css( '.wp-customizer' );
+		super( driver, expectedElementSelector );
+	}
+
+	relatedPostsSectionShown() {
+		let present = false;
+
+		present = this.driver.wait( until.elementLocated( by.css( '#sub-accordion-section-jetpack_relatedposts' ) ), this.explicitWaitMS ).then( () => {
+			return true;
+		}, ( ) => {
+			return false;
+		} );
+		return present;
+	}
+}

--- a/lib/pages/wp-admin/wp-admin-home-page.js
+++ b/lib/pages/wp-admin/wp-admin-home-page.js
@@ -1,0 +1,11 @@
+import { By as by } from 'selenium-webdriver';
+import config from 'config';
+import BaseContainer from '../../base-container';
+
+export default class WPAdminHomePage extends BaseContainer {
+	constructor( driver, visit = false ) {
+		const jetpackSite = config.get( 'jetpacksite' );
+		const wpAdminURL = `https://${jetpackSite}/wp-admin`;
+		super( driver, by.css( '#dashboard-widgets-wrap' ), visit, wpAdminURL );
+	}
+}

--- a/lib/pages/wp-admin/wp-admin-jetpack-page.js
+++ b/lib/pages/wp-admin/wp-admin-jetpack-page.js
@@ -17,6 +17,16 @@ export default class WPAdminJetpackPage extends BaseContainer {
 	}
 
 	atAGlanceDisplayed() {
-		return driverHelper.isElementPresent( driver, by.css( '.jp-at-a-glance' ) );
+		return driverHelper.isElementPresent( this.driver, by.css( '.jp-at-a-glance' ) );
+	}
+
+	openPlansTab() {
+		const selector = by.css( '.dops-section-nav__panel li.dops-section-nav-tab:nth-child(2) a' );
+		return driverHelper.clickWhenClickable( this.driver, selector );
+	}
+
+	clickUpgradeNudge() {
+		const selector = by.css( 'a.dops-notice__action[href*="upgrade"]' );
+		return driverHelper.clickWhenClickable( this.driver, selector, 10000 );
 	}
 }

--- a/lib/pages/wp-admin/wp-admin-jetpack-page.js
+++ b/lib/pages/wp-admin/wp-admin-jetpack-page.js
@@ -1,0 +1,22 @@
+import { By as by } from 'selenium-webdriver';
+import BaseContainer from '../../base-container';
+
+import * as driverHelper from '../../driver-helper';
+
+export default class WPAdminJetpackPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( '#jp-plugin-container' ) );
+	}
+
+	connectWordPressCom() {
+		const selector = by.css( 'a.jp-jetpack-connect__button' );
+		driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
+		this.driver.sleep( 1000 ).then( () => {
+			return driverHelper.clickWhenClickable( this.driver, selector );
+		} );
+	}
+
+	atAGlanceDisplayed() {
+		return driverHelper.isElementPresent( driver, by.css( '.jp-at-a-glance' ) );
+	}
+}

--- a/lib/pages/wp-admin/wp-admin-jetpack-settings-page.js
+++ b/lib/pages/wp-admin/wp-admin-jetpack-settings-page.js
@@ -1,0 +1,174 @@
+import { By as by } from 'selenium-webdriver';
+import BaseContainer from '../../base-container';
+
+import * as driverHelper from '../../driver-helper';
+import * as driverManager from '../../driver-manager';
+
+export default class WPAdminJetpackSettingsPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( '#jp-plugin-container' ) );
+	}
+
+	chooseTabNamed( tabName ) {
+		const self = this;
+		if ( driverManager.currentScreenSize() === 'mobile' ) {
+			const dropDownSelector = by.css( '.dops-section-nav' );
+			const tabSelector = by.xpath( `//span[text()="${tabName}"]` );
+			self.driver.findElement( dropDownSelector ).then( ( headerElement ) => {
+				headerElement.getAttribute( 'class' ).then( ( classes ) => {
+					if ( classes.indexOf( 'is-open' ) === -1 ) {
+						driverHelper.clickWhenClickable( self.driver, dropDownSelector );
+					}
+				} );
+			} );
+			return driverHelper.clickWhenClickable( self.driver, tabSelector );
+		} else {
+			const tabSelector = by.css( `a[href="#${tabName.toLowerCase()}"]` );
+			return driverHelper.clickWhenClickable( self.driver, tabSelector );
+		}
+	}
+
+	expandFeatureNamed( featureName ) {
+		const self = this;
+		const sectionSelector = by.xpath( `//div[text()="${featureName}"]/../../../..` );
+		const sectionExpandSelector = by.xpath( `//div[text()="${featureName}"]/../../../..//button` );
+		self.driver.findElement( sectionSelector ).then( ( sectionElement ) => {
+			sectionElement.getAttribute( 'class' ).then( ( classes ) => {
+				if ( classes.indexOf( 'is-expanded' ) === -1 ) {
+					return driverHelper.clickWhenClickable( self.driver, sectionExpandSelector );
+				}
+			} );
+		} );
+	}
+
+	disableFeatureNamed( featureName ) {
+		const self = this;
+		const featureToggleSelector = WPAdminJetpackSettingsPage._getFeatureToggleSelector( featureName );
+
+		return self.driver.findElement( featureToggleSelector ).then( ( toggleElement ) => {
+			return toggleElement.getAttribute( 'aria-checked' ).then( ( checked ) => {
+				if ( checked === 'true' ) {
+					driverHelper.clickWhenClickable( self.driver, featureToggleSelector );
+					return self._waitAndDismissSuccessNotice();
+				}
+			} );
+		} );
+	}
+
+	enableFeatureNamed( featureName ) {
+		const self = this;
+		const featureToggleSelector = WPAdminJetpackSettingsPage._getFeatureToggleSelector( featureName );
+		return self.driver.findElement( featureToggleSelector ).then( ( toggleElement ) => {
+			return toggleElement.getAttribute( 'aria-checked' ).then( ( checked ) => {
+				if ( checked === 'false' ) {
+					driverHelper.clickWhenClickable( self.driver, featureToggleSelector );
+					return self._waitAndDismissSuccessNotice();
+				}
+			} );
+		} );
+	}
+
+	followSettingsLink( featureName ) {
+		const selector = by.xpath( `//div[text()="${featureName}"]/../../../..//a[@rel="external"]` );
+		return driverHelper.clickWhenClickable( this.driver, selector );
+	}
+
+	saveFeatureSettings( featureName ) {
+		const selector = by.xpath( `//div[text()="${featureName}"]/../../../..//button[@type="submit"]` );
+		driverHelper.clickWhenClickable( this.driver, selector );
+		return driverHelper.waitTillPresentAndDisplayed( this.driver, by.css( '.global-notices .is-success' ) );
+	}
+
+	linkToEmailsFollowersDisplayed( jetpackSite ) {
+		const selector = by.css( `a[href="https://wordpress.com/people/email-followers/${jetpackSite}"]` );
+		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, selector );
+	}
+
+	disconnectJetpack() {
+		const self = this;
+		const disconnectSelector = by.xpath( '//button[text()="Disconnect Jetpack"]' );
+		driverHelper.isElementPresent( self.driver, disconnectSelector ).then( ( present ) => {
+			if ( present === true ) {
+				driverHelper.clickWhenClickable( self.driver, disconnectSelector );
+				return self.driver.switchTo().alert().then( function( alert ) {
+					return alert.accept();
+				} );
+			}
+		} );
+	}
+
+	setRelatedPostsHeader() {
+		const selector = by.css( 'input[name="show_headline"]' );
+		return driverHelper.setCheckbox( this.driver, selector );
+	}
+
+	unsetRelatedPostsHeader() {
+		const selector = by.css( 'input[name="show_headline"]' );
+		return driverHelper.unsetCheckbox( this.driver, selector );
+	}
+
+	setRelatedPostsLarge() {
+		const selector = by.css( 'input[name="show_thumbnails"]' );
+		return driverHelper.setCheckbox( this.driver, selector );
+	}
+
+	unsetRelatedPostsLarge() {
+		const selector = by.css( 'input[name="show_thumbnails"]' );
+		return driverHelper.unsetCheckbox( this.driver, selector );
+	}
+
+	chooseLikesPerPost() {
+		const selector = by.xpath( '//span[text()="Turned on per post"]/..//input[@type="radio"]' );
+		return driverHelper.clickWhenClickable( this.driver, selector );
+	}
+
+	chooseLikesForAllPosts() {
+		const selector = by.xpath( '//span[text()="On for all posts"]/..//input[@type="radio"]' );
+		return driverHelper.clickWhenClickable( this.driver, selector );
+	}
+
+	followLikeSettingsLink() {
+		const self = this;
+		const selector = by.xpath( '//div[text()="Likes"]/../../../..//p/a' );
+		return self.driver.findElement( selector ).then( ( element ) => {
+			return element.getAttribute( 'href' ).then( ( href ) => {
+				return self.driver.get( href );
+			} );
+		} );
+	}
+
+	showAFollowBlogOptionInComments() {
+		const selector = by.css( 'input[name="stb_enabled"]' );
+		driverHelper.unsetCheckbox( this.driver, selector );
+		return driverHelper.setCheckbox( this.driver, selector );
+	}
+
+	showAFollowCommentsOptionInComments() {
+		const selector = by.css( 'input[name="stc_enabled"]' );
+		driverHelper.unsetCheckbox( this.driver, selector );
+		return driverHelper.setCheckbox( this.driver, selector );
+	}
+
+	searchFor( term ) {
+		const self = this;
+		const searchButtonSelector = by.css( 'div[role="search"]' );
+		const searchOpenSelector = by.css( 'div[role="search"].is-open' );
+		const searchInputSelector = by.css( 'div[role="search"] input[type="search"]' );
+
+		driverHelper.isElementPresent( self.driver, searchOpenSelector ).then( ( present ) => {
+			if ( present === false ) {
+				return driverHelper.clickWhenClickable( self.driver, searchButtonSelector );
+			}
+		} );
+		return driverHelper.setWhenSettable( self.driver, searchInputSelector, term );
+	}
+
+	static _getFeatureToggleSelector( featureName ) {
+		return by.xpath( `//div[text()="${featureName}"]/../../../..//span[@class="dops-foldable-card__summary"]//span[@class="form-toggle__switch"]` );
+	}
+
+	_waitAndDismissSuccessNotice() {
+		const dismissSuccessNoticeSelector = by.css( '.global-notices .is-success .dops-notice__dismiss' );
+		return driverHelper.clickWhenClickable( this.driver, dismissSuccessNoticeSelector );
+	}
+}

--- a/lib/pages/wp-admin/wp-admin-logon-page.js
+++ b/lib/pages/wp-admin/wp-admin-logon-page.js
@@ -1,0 +1,29 @@
+import { By as by } from 'selenium-webdriver';
+import * as driverHelper from '../../driver-helper';
+
+import GenericLogonPage from '../login-page';
+
+export default class WPAdminLogonPage extends GenericLogonPage {
+	constructor( driver, wpAdminUrl, { visit = false, forceStandardLogon = false } = {} ) {
+		super( driver, visit, wpAdminUrl );
+		if ( forceStandardLogon === true ) {
+			this.ensureWPAdminStandardLogonShown();
+		}
+	}
+
+	ensureWPAdminStandardLogonShown() {
+		const self = this;
+		self.driver.findElement( by.tagName( 'body' ) ).getAttribute( 'class' ).then( ( bodyClasses ) => {
+			if ( bodyClasses.indexOf( 'jetpack-sso-form-display' ) > -1 ) {
+				return driverHelper.clickWhenClickable( self.driver, by.css( '.jetpack-sso-toggle.wpcom' ) );
+			}
+		} );
+		return self.waitForPage();
+	}
+
+	logonSSO() {
+		const selector = by.css( '.jetpack-sso.button' );
+
+		return driverHelper.clickWhenClickable( this.driver, selector );
+	}
+}

--- a/lib/pages/wp-admin/wp-admin-omnisearch-page.js
+++ b/lib/pages/wp-admin/wp-admin-omnisearch-page.js
@@ -1,0 +1,8 @@
+import { By as by } from 'selenium-webdriver';
+import BaseContainer from '../../base-container';
+
+export default class WPAdminOmnisearchPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( '.omnisearch-form' ) );
+	}
+}

--- a/lib/pages/wp-admin/wp-admin-plugins-page.js
+++ b/lib/pages/wp-admin/wp-admin-plugins-page.js
@@ -1,0 +1,50 @@
+import { By as by } from 'selenium-webdriver';
+import config from 'config';
+import BaseContainer from '../../base-container';
+
+import * as driverHelper from '../../driver-helper';
+
+export default class WPAdminPluginsPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( '.plugins' ) );
+	}
+
+	JetpackVersionInstalled() {
+		return this.driver.findElement( by.css( 'tr[data-slug="jetpack-by-wordpress-com"] .plugin-version-author-uri,tr[data-slug="jetpack"] .plugin-version-author-uri' ) ).getText().then( ( txt ) => {
+			return txt.split( '|' )[0].trim();
+		} );
+	}
+
+	deactivateJetpack() {
+		const self = this;
+		const deactivateSelector = by.css( 'tr[data-slug="jetpack-by-wordpress-com"] .deactivate,tr[data-slug="jetpack"] .deactivate' );
+		return driverHelper.isElementPresent( this.driver, deactivateSelector ).then( ( located ) => {
+			if ( located === true ) {
+				return driverHelper.clickWhenClickable( self.driver, deactivateSelector );
+			}
+		} );
+	}
+
+	activateJetpack() {
+		const self = this;
+		const activateSelector = by.css( 'tr[data-slug="jetpack-by-wordpress-com"] .activate,tr[data-slug="jetpack"] .activate' );
+		return driverHelper.isElementPresent( this.driver, activateSelector ).then( ( located ) => {
+			if ( located === true ) {
+				return driverHelper.clickWhenClickable( self.driver, activateSelector );
+			}
+		} );
+	}
+
+	updateJetpack() {
+		const self = this;
+		const longWait = config.get( 'explicitWaitMS' ) * 3;
+		const updateSelector = by.css( 'tr[data-slug="jetpack-by-wordpress-com"] .activate,tr[data-slug="jetpack"] a.update-link' );
+		const updatedSelector = by.css( '.update-message.notice-success' );
+		return driverHelper.isElementPresent( this.driver, updateSelector ).then( ( located ) => {
+			if ( located === true ) {
+				driverHelper.clickWhenClickable( self.driver, updateSelector );
+				return driverHelper.waitTillPresentAndDisplayed( self.driver, updatedSelector, longWait );
+			}
+		} );
+	}
+}

--- a/lib/pages/wp-admin/wp-admin-settings-sharing-page.js
+++ b/lib/pages/wp-admin/wp-admin-settings-sharing-page.js
@@ -1,0 +1,129 @@
+import { By as by } from 'selenium-webdriver';
+import BaseContainer from '../../base-container';
+
+import * as driverHelper from '../../driver-helper';
+
+export default class WPAdminSettingsSharingPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( '#publicize-form' ) );
+		this.closeDialogIfAppears();
+	}
+
+	closeDialogIfAppears() {
+		const self = this;
+		return driverHelper.isElementPresent( self.driver, by.css( '#TB_window' ) ).then( ( present ) => {
+			if ( present === true ) {
+				return driverHelper.clickWhenClickable( self.driver, by.css( '#TB_window input[value="OK"]' ) );
+			}
+		} );
+	}
+
+	addTwitterConnection() {
+		this._addService( 'twitter' );
+	}
+
+	addTumblrConnection() {
+		this._addService( 'tumblr' );
+	}
+
+	removeTwitterIfExists() {
+		this._removeService( 'twitter' );
+	}
+
+	removeTumblrIfExists() {
+		this._removeService( 'tumblr' );
+	}
+
+	twitterAccountShown( twitterUserName ) {
+		const selector = by.css( `.publicize-profile-link[href="https://twitter.com/${twitterUserName}"]` );
+		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, selector );
+	}
+
+	tumblrBlogShown( tumblrBlogName ) {
+		const selector = by.css( `.publicize-profile-link[href="http://${tumblrBlogName}.tumblr.com/"]` );
+		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, selector );
+	}
+
+	facebookPageShown( facebookPageName ) {
+		const selector = by.css( `.publicize-profile-link[href="https://www.facebook.com/${facebookPageName.toLowerCase()}/"]` );
+		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, selector );
+	}
+
+	availableSharingButtons() {
+		return this.driver.findElements( by.css( '#available-services .service' ) );
+	}
+
+	enabledSharingButtons() {
+		return this.driver.findElements( by.css( '#enabled-services .service' ) );
+	}
+
+	previewedSharingButtons() {
+		return this.driver.findElements( by.css( '#live-preview .preview .preview-item' ) );
+	}
+
+	showButtonsOnFrontPage() {
+		this._enableButtonCheckbox( 'index' );
+	}
+
+	showButtonsOnPosts() {
+		this._enableButtonCheckbox( 'post' );
+	}
+
+	showButtonsOnPages() {
+		this._enableButtonCheckbox( 'page' );
+	}
+
+	showButtonsOnMedia() {
+		this._enableButtonCheckbox( 'attachment' );
+	}
+
+	saveChanges() {
+		driverHelper.clickWhenClickable( this.driver, by.css( 'p.submit input[type="submit"]' ) );
+		return driverHelper.waitTillPresentAndDisplayed( this.driver, by.css( '.updated' ) );
+	}
+
+	setButtonStyleToIconAndText() {
+		driverHelper.clickWhenClickable( this.driver, by.css( 'select#button_style' ) );
+		return driverHelper.clickWhenClickable( this.driver, by.css( 'select#button_style option[value="icon-text"]' ) );
+	}
+
+	sharingActivated( name ) {
+		const selector = by.css( `#enabled-services .share-${name}` );
+		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, selector );
+	}
+
+	sharingPreviewIncludes( name ) {
+		const selector = by.css( `#live-preview ul.preview .share-${name}` );
+		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, selector );
+	}
+
+	_enableButtonCheckbox( type ) {
+		const checkBoxSelector = by.css( `input[type="checkbox"][value="${type}"]` );
+		driverHelper.setCheckbox( this.driver, checkBoxSelector );
+	}
+
+	_addService( serviceName ) {
+		const self = this;
+		const addServiceButtonSelector = by.css( `a.publicize-add-connection[href*="service=${serviceName}"]` );
+		return driverHelper.clickWhenClickable( self.driver, addServiceButtonSelector );
+	}
+
+	_removeService( serviceName ) {
+		const self = this;
+		const removeServiceSelector = by.css( `a[title="Disconnect"][href*="service=${serviceName}"]` );
+		return driverHelper.isElementPresent( self.driver, removeServiceSelector ).then( ( elementIsPresent ) => {
+			if ( elementIsPresent ) {
+				return self.driver.findElements( removeServiceSelector ).then( ( elements ) => {
+					if ( elements.length > 1 ) {
+						throw new Error( `There are more than 1 ${serviceName} accounts configured - this function can only remove one!` );
+					}
+					driverHelper.clickWhenClickable( self.driver, removeServiceSelector );
+					self.driver.switchTo().alert().then( function( alert ) {
+						alert.accept();
+					} );
+					return driverHelper.waitTillPresentAndDisplayed( self.driver, by.css( 'div.updated' ) );
+				} );
+			}
+		} );
+	}
+}

--- a/lib/pages/wp-admin/wp-admin-sidebar.js
+++ b/lib/pages/wp-admin/wp-admin-sidebar.js
@@ -24,7 +24,7 @@ export default class WPAdminSidebar extends BaseContainer {
 
 	selectJetpack() {
 		const jetpackMenuSelector = by.css( '#toplevel_page_jetpack' );
-		const menuItemSelector = by.css( '#toplevel_page_jetpack li a[href$="jetpack"]' );
+		const menuItemSelector = by.css( '#toplevel_page_jetpack li a[href$="jetpack#/dashboard"]' );
 
 		return this._selectMenuItem( jetpackMenuSelector, menuItemSelector );
 	}

--- a/lib/pages/wp-admin/wp-admin-sidebar.js
+++ b/lib/pages/wp-admin/wp-admin-sidebar.js
@@ -1,0 +1,68 @@
+import { By as by } from 'selenium-webdriver';
+import BaseContainer from '../../base-container';
+import * as driverManager from '../../driver-manager';
+import * as driverHelper from '../../driver-helper';
+
+export default class WPAdminSidebar extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( '#adminmenumain' ) );
+		if ( driverManager.currentScreenSize() === 'mobile' ) {
+			this.driver.findElement( by.css( '#wpwrap' ) ).getAttribute( 'class' ).then( ( classValue ) => {
+				if ( classValue !== 'wp-responsive-open' ) {
+					driverHelper.clickWhenClickable( this.driver, by.css( '#wp-admin-bar-menu-toggle' ) );
+				}
+			} );
+		}
+	}
+
+	selectPlugins() {
+		const plugInMenuSelector = by.css( '#menu-plugins' );
+		const plugInMenuItemSelector = by.css( '#menu-plugins li a[href="plugins.php"]' );
+
+		return this._selectMenuItem( plugInMenuSelector, plugInMenuItemSelector );
+	}
+
+	selectJetpack() {
+		const jetpackMenuSelector = by.css( '#toplevel_page_jetpack' );
+		const menuItemSelector = by.css( '#toplevel_page_jetpack li a[href$="jetpack"]' );
+
+		return this._selectMenuItem( jetpackMenuSelector, menuItemSelector );
+	}
+
+	selectJetpackSettings() {
+		const jetpackMenuSelector = by.css( '#toplevel_page_jetpack' );
+		const menuItemSelector = by.css( '#toplevel_page_jetpack li a[href$="jetpack#/settings"]' );
+
+		return this._selectMenuItem( jetpackMenuSelector, menuItemSelector );
+	}
+
+	selectSettingsSharing() {
+		const settingsSelector = by.css( '#menu-settings' );
+		const itemSelector = by.css( '#menu-settings a[href$="sharing"]' );
+
+		return this._selectMenuItem( settingsSelector, itemSelector );
+	}
+
+	selectSnippets() {
+		const settingsSelector = by.css( '#toplevel_page_snippets' );
+		const itemSelector = by.css( '#toplevel_page_snippets a.wp-first-item[href$="snippets"]' );
+
+		return this._selectMenuItem( settingsSelector, itemSelector );
+	}
+
+	selectAppearanceEditCSS() {
+		const settingsSelector = by.css( '#menu-appearance' );
+		const itemSelector = by.css( '#menu-appearance a[href$="editcss"]' );
+
+		return this._selectMenuItem( settingsSelector, itemSelector );
+	}
+
+	_selectMenuItem( menuSelector, menuItemSelector ) {
+		this.driver.findElement( menuSelector ).getAttribute( 'class' ).then( ( classes ) => {
+			if ( classes.indexOf( 'wp-menu-open' ) === -1 ) {
+				driverHelper.clickWhenClickable( this.driver, menuSelector );
+			}
+		} );
+		return driverHelper.followLinkWhenFollowable( this.driver, menuItemSelector );
+	}
+}

--- a/lib/pages/wp-admin/wp-admin-snippets-page.js
+++ b/lib/pages/wp-admin/wp-admin-snippets-page.js
@@ -1,0 +1,14 @@
+import { By as by } from 'selenium-webdriver';
+import BaseContainer from '../../base-container';
+import * as driverHelper from '../../driver-helper';
+
+export default class WPAdminSnippetsPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( 'input[value="snippets"]' ) );
+	}
+
+	snippetIsActive( snippetName ) {
+		const selector = by.xpath( `//strong[text()="${snippetName}"]/../..//a[text()="Deactivate"]` );
+		return driverHelper.isElementPresent( this.driver, selector );
+	}
+}

--- a/lib/pages/wp-admin/wp-admin-tb-dialog.js
+++ b/lib/pages/wp-admin/wp-admin-tb-dialog.js
@@ -1,0 +1,19 @@
+import { By as by } from 'selenium-webdriver';
+import BaseContainer from '../../base-container';
+import * as driverHelper from '../../driver-helper';
+
+export default class WPAdminTBDialog extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( '#TB_window' ) );
+	}
+
+	updatedMessageShown() {
+		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, by.css( '#TB_window div.updated' ) );
+	}
+
+	clickOK() {
+		return this.driver.sleep( 3000 ).then( () => {
+			return driverHelper.clickWhenClickable( this.driver, by.css( '#TB_window input[value="OK"]' ) );
+		} );
+	}
+}

--- a/lib/pages/wp-admin/wp-admin-topbar.js
+++ b/lib/pages/wp-admin/wp-admin-topbar.js
@@ -1,0 +1,14 @@
+import { By as by } from 'selenium-webdriver';
+import BaseContainer from '../../base-container';
+import * as driverHelper from '../../driver-helper';
+
+export default class WPAdminTopbar extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( '#wpadminbar' ) );
+	}
+
+	createNewPost() {
+		const newPostSelector = by.css( '#wpadminbar li#wp-admin-bar-new-content a[href$="post-new.php"]' );
+		return driverHelper.clickWhenClickable( this.driver, newPostSelector );
+	}
+}

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -21,7 +21,7 @@ export TESTARGS="-R -p -x"
 if [ "$RUN_SPECIFIED" == "true" ]; then
   TESTARGS=$RUN_ARGS
 elif [[ "$CIRCLE_BRANCH" =~ .*[Jj]etpack.*|.*[Jj][Pp].* ]]; then
-  export JETPACKHOST=BLUEHOST
+  export JETPACKHOST=GODADDY
   TESTARGS="-R -j" # Execute Jetpack tests
 elif [[ "$CIRCLE_BRANCH" =~ .*[Ww][Oo][Oo].* ]]; then
   TESTARGS="-R -W -u https://wpcalypso.wordpress.com" # Execute WooCommerce tests

--- a/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -27,7 +27,7 @@ test.before( function() {
 test.describe( `[${host}] Jetpack Plans: (${screenSize}) @jetpack`, function() {
 	this.timeout( mochaTimeOut );
 
-	test.describe( 'Comparing Plans:', function() {
+	test.xdescribe( 'Comparing Plans:', function() {
 		this.bailSuite( true );
 
 		test.before( function() {
@@ -67,6 +67,23 @@ test.describe( `[${host}] Jetpack Plans: (${screenSize}) @jetpack`, function() {
 					assert( present, `Failed to detect correct plan (${planName})` );
 				} );
 			} );
+		} );
+	} );
+
+	test.describe( 'Purchase Professional Plan:', function() {
+		this.bailSuite( true );
+
+		test.before( function() {
+			return driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		} );
+
+		test.it( 'Can log into WordPress.com', () => {
+			this.loginFlow = new LoginFlow( driver, 'jetpackUser' + host );
+			return this.loginFlow.login();
+		} );
+
+		test.it( 'Can log into site via Jetpack SSO', () => {
+			return this.loginFlow.login( { jetpackSSO: true } );
 		} );
 	} );
 } );

--- a/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
@@ -82,7 +82,7 @@ test.describe( `[${host}] Jetpack Sites on Calypso - Searching Plugins: (${scree
 
 	test.describe( 'Can use the plugins browser to find Automattic plugins', function() {
 		test.it( 'Open the plugins browser and find WP Job Manager by searching for Automattic', function() {
-			const pluginVendor = 'Automattic';
+			const pluginVendor = 'WP Job Manager';
 			const pluginTitle = 'WP Job Manager';
 			this.navbarComponent = new NavbarComponent( driver );
 			this.navbarComponent.clickMySites();

--- a/specs/wp-plan-purchase-spec.js
+++ b/specs/wp-plan-purchase-spec.js
@@ -24,7 +24,7 @@ test.before( function() {
 	driver = driverManager.startBrowser();
 } );
 
-test.describe( `[${host}] Plans: (${screenSize}) @parallel`, function() {
+test.describe( `[${host}] Plans: (${screenSize}) @parallel @jetpack`, function() {
 	this.timeout( mochaTimeOut );
 
 	test.describe( 'Comparing Plans:', function() {
@@ -54,16 +54,25 @@ test.describe( `[${host}] Plans: (${screenSize}) @parallel`, function() {
 
 			test.it( 'Can Compare Plans', function() {
 				this.plansPage = new PlansPage( driver );
-				this.plansPage.openPlansTab();
-				return this.plansPage.waitForComparison();
-			} );
+				if ( host === 'WPCOM' ) {
+					this.plansPage.openPlansTab();
+					return this.plansPage.waitForComparison();
+				}
 
-			test.it( 'Can Verify Current Plan', function() {
-				const planName = 'premium';
-				return this.plansPage.confirmCurrentPlan( planName ).then( function( present ) {
-					assert( present, `Failed to detect correct plan (${planName})` );
+				// Jetpack
+				return this.plansPage.planTypesShown( 'jetpack' ).then( ( displayed ) => {
+					assert( displayed, 'The Jetpack plans are NOT displayed' );
 				} );
 			} );
+
+			if ( host === 'WPCOM' ) {
+				test.it( 'Can Verify Current Plan', function() {
+					const planName = 'premium';
+					return this.plansPage.confirmCurrentPlan( planName ).then( function( present ) {
+						assert( present, `Failed to detect correct plan (${planName})` );
+					} );
+				} );
+			}
 		} );
 
 		//test.describe( 'Can purchase plans', function() {


### PR DESCRIPTION
Fixes #560 

@beaulebens - Can you let me know if this meets what you're expecting for this flow?

1) Log into both WordPress.com and wp-admin (via SSO) to a site on the Free plan
2) Open Jetpack dashboard
3) Click one of the Upgrade buttons (does it matter which one?  From your initial write-up in #560 I was expecting the links to go different places, but every Upgrade button points to `https://jetpack.com/redirect/?source=upgrade&site=SITEURL`, which redirects to `https://jetpack.com/pricing/settings-security-premium`)
4) Click the button at the top of that page to add a Premium plan to your cart and puts you on the payment page.

