### PR TITLE
Changed plugin search query for wp-calypso/15370

### DIFF
--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -21,7 +21,7 @@ export TESTARGS="-R -p -x"
 if [ "$RUN_SPECIFIED" == "true" ]; then
   TESTARGS=$RUN_ARGS
 elif [[ "$CIRCLE_BRANCH" =~ .*[Jj]etpack.*|.*[Jj][Pp].* ]]; then
-  export JETPACKHOST=BLUEHOST
+  export JETPACKHOST=GODADDY
   TESTARGS="-R -j" # Execute Jetpack tests
 elif [[ "$CIRCLE_BRANCH" =~ .*[Ww][Oo][Oo].* ]]; then
   TESTARGS="-R -W -u https://wpcalypso.wordpress.com" # Execute WooCommerce tests

--- a/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
@@ -82,7 +82,7 @@ test.describe( `[${host}] Jetpack Sites on Calypso - Searching Plugins: (${scree
 
 	test.describe( 'Can use the plugins browser to find Automattic plugins', function() {
 		test.it( 'Open the plugins browser and find WP Job Manager by searching for Automattic', function() {
-			const pluginVendor = 'Automattic';
+			const pluginVendor = 'WP Job Manager';
 			const pluginTitle = 'WP Job Manager';
 			this.navbarComponent = new NavbarComponent( driver );
 			this.navbarComponent.clickMySites();


### PR DESCRIPTION
Workaround for https://github.com/Automattic/wp-calypso/issues/15370, where searching "Automattic" yields an error for some reason.

Also switched the default host from BLUEHOST to GODADDY due to stability issues on BH