### PR TITLE
Adds a test to open the store option for a WooCommerce store

### DIFF
--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -6,6 +6,7 @@ import BaseContainer from '../base-container.js';
 export default class SidebarComponent extends BaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.sidebar' ) );
+		this.storeSelector = By.css( '.sites-navigation li a[href*=store]' );
 	}
 	selectDomains() {
 		let selector = By.css( '.sites-navigation .domains a' );
@@ -65,7 +66,9 @@ export default class SidebarComponent extends BaseContainer {
 		return this.driver.findElement( selector ).getText();
 	}
 	storeOptionDisplayed() {
-		const selector = By.css( '.sites-navigation li a[href*=store]' );
-		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, selector );
+		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, this.storeSelector );
+	}
+	selectStoreOption() {
+		return driverHelper.clickWhenClickable( this.driver, this.storeSelector );
 	}
 }

--- a/lib/components/store-sidebar-component.js
+++ b/lib/components/store-sidebar-component.js
@@ -1,0 +1,9 @@
+import { By } from 'selenium-webdriver';
+
+import BaseContainer from '../base-container.js';
+
+export default class StoreSidebarComponent extends BaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.store-sidebar__sidebar' ) );
+	}
+}

--- a/specs-woocommerce/wp-woocommerce-spec.js
+++ b/specs-woocommerce/wp-woocommerce-spec.js
@@ -6,6 +6,7 @@ import * as driverManager from '../lib/driver-manager';
 
 import NavBarComponent from '../lib/components/navbar-component';
 import SidebarComponent from '../lib/components/sidebar-component';
+import StoreSidebarComponent from '../lib/components/store-sidebar-component';
 import StorePage from '../lib/pages/woocommerce/store-page';
 import StoreSettingsPage from '../lib/pages/woocommerce/store-settings-page';
 import StoreOrdersPage from '../lib/pages/woocommerce/store-orders-page';
@@ -38,18 +39,28 @@ test.describe( `Can see WooCommerce Store option in Calypso '${ screenSize }' @p
 		driverManager.clearCookiesAndDeleteLocalStorage( driver );
 	} );
 
-	// Login as WooCommerce store user
+	// Login as WooCommerce store user and open the sidebar
 	test.before( function() {
 		this.loginFlow = new LoginFlow( driver, 'wooCommerceUser' );
 		this.loginFlow.login();
+		this.navBarComponent = new NavBarComponent( driver );
+		this.navBarComponent.clickMySites();
 	} );
 
 	test.it( 'Can see \'Store (BETA)\' option in main Calypso menu for a WooCommerce site', function() {
-		this.navBarComponent = new NavBarComponent( driver );
-		this.navBarComponent.clickMySites();
 		this.sideBarComponent = new SidebarComponent( driver );
 		this.sideBarComponent.storeOptionDisplayed().then( ( displayed ) => {
 			assert( displayed, 'The Store menu option is not displayed for the WooCommerce site' );
+		} );
+	} );
+
+	test.it( 'The \'Store (BETA)\' option opens the store management page with its own sidebar', function() {
+		this.sideBarComponent = new SidebarComponent( driver );
+		this.sideBarComponent.selectStoreOption();
+		this.storePage = new StorePage( driver );
+		this.storeSidebarComponent = new StoreSidebarComponent( driver );
+		this.storeSidebarComponent.displayed().then( ( d ) => {
+			assert( d, 'The store sidebar is not displayed' );
 		} );
 	} );
 } );


### PR DESCRIPTION
This actually uses the store option in the Calypso sidebar and checks that the store page and store sidebar are then displayed.