### PR TITLE
Updated Dockerfile config to allow for wrapper repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ MAINTAINER Automattic
 
 WORKDIR /wp-e2e-tests
 
+# Create empty directories to also support the wrapper repos
+RUN	mkdir /wp-e2e-tests-canary /wp-e2e-tests-jetpack /wp-e2e-tests-visdiff /wp-e2e-tests-ie11 /wp-e2e-tests-woocommerce
+
 # Version Numbers
 ENV NODE_VERSION 6.10.3
 ENV CHROMEDRIVER_VERSION 2.29
@@ -55,5 +58,5 @@ RUN sed -i.bkp -e \
       's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' \
       /etc/sudoers
 
-RUN	chown -R e2e-tester /wp-e2e-tests
+RUN	chown -R e2e-tester /wp-e2e-tests*
 USER    e2e-tester


### PR DESCRIPTION
Minor Dockerfile update to create empty user-owned directories corresponding to the various wrapper-repos we're using (wp-e2e-tests-jetpack, -canary, etc) in case we transition those to CircleCI 2.0

This has already been pushed to Docker Hub as v0.0.3