### PR TITLE
Mailosaur API version bump, minor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ A full list of config values are:
 | startAppTimeoutMS | This is the maximum total time in milliseconds that the app can take to start for mobile testing - this is different from test time as we want it to fail fast | 240000 | Yes (for app testing only)| Yes |
 | afterHookTimeoutMS | This is the maximum total time in milliseconds that an after test hook can take including capturing the screenshots | 20000 | Yes | Yes |
 | browser | The browser to use: either <code>firefox</code> or <code>chrome</code> | <code>chrome</code> | Yes |  Yes |
-| proxy | The type of proxy to use: either <code>system</code> to use whatever your system is configured to use, or <code>direct</code> to use no proxy. | <code>direct</code> | Yes |  Yes |
+| proxy | The type of proxy to use: either <code>system</code> to use whatever your system is configured to use, or <code>direct</code> to use no proxy. Also supports <code>charles</code> to send web traffic through the [Charles Proxy](https://www.charlesproxy.com/) app for troubleshooting.| <code>direct</code> | Yes |  Yes |
 | saveAllScreenshots | Whether screenshots should be saved for all steps, including those that pass | <code>false</code> | Yes |  Yes |
 | neverSaveScreenshots | Overrides the screenshot function so nothing is captured.  This is intended for use with the Applitools visual diff specs, since the screenshots are handled via their utilities instead. | <code>false</code> | Yes |  Yes |
 | checkForConsoleErrors | Automatically report on console errors in the browser | <code>true</code> | Yes |  Yes |

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -42,8 +42,10 @@ export function getProxyType() {
 			return proxy.direct();
 		case 'system':
 			return proxy.system();
+		case 'charles':
+			return proxy.manual( {http: 'localhost:8888', https: 'localhost:8888'} );
 		default:
-			throw new Error( `Unknown proxy type specified of: '${proxyType}'. Supported values are 'direct' or 'system'` );
+			throw new Error( `Unknown proxy type specified of: '${proxyType}'. Supported values are 'direct', 'system', or 'charles'` );
 	}
 }
 

--- a/lib/email-client.js
+++ b/lib/email-client.js
@@ -50,7 +50,7 @@ export default class EmailClient {
 		var self = this;
 		var interval;
 		var d = webdriver.promise.defer();
-		const intervalMS = 500;
+		const intervalMS = 1500;
 		let retries = emailWaitMS / intervalMS;
 
 		interval = setInterval( function() {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fs-extra": "0.22.1",
     "junit-viewer": "4.9.6",
     "lodash": "^4.13.1",
-    "mailosaur": "^3.0.0",
+    "mailosaur": "4.0.0",
     "mocha": "hoverduck/mocha#57b51e8",
     "node-slack-upload": "1.2.1",
     "random-qoutes-generator": "0.0.1",


### PR DESCRIPTION
Bump up the version of the Mailosaur API that using from 3.0.0 to 4.0.0

Also adding support to connect to the [Charles Proxy](https://www.charlesproxy.com/) app for troubleshooting web traffic as well as increasing the timeout for the Mailosaur query retries, as they were stepping on each other too much.