### PR TITLE
Ignore the showPostPreview ABTest and handle both cases for now

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -74,7 +74,6 @@
 	[ "signupSurveyStep_20170329", "hideSurveyStep" ],
 	[ "readerPostCardTagCount_20170315", "showThree" ],
 	[ "signupProgressIndicator_20170612", "original" ],
-	[ "signupPlansCopyChanges_20170623", "original" ],
-	[ "postPublishPreview_20170627", "noShowPostPublishPreview" ]
+	[ "signupPlansCopyChanges_20170623", "original" ]
   ]
 }

--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -45,10 +45,8 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 
 	waitForSuccessViewPostNotice() {
 		const successNoticeSelector = By.css( '.post-editor__notice.is-success,.post-editor-notice.is-success,.notice.is-success,.post-editor-notice.is-success' );
-		const viewPostSelector = By.css( '.notice__action' );
 
-		driverHelper.waitTillPresentAndDisplayed( this.driver, successNoticeSelector );
-		return driverHelper.waitTillPresentAndDisplayed( this.driver, viewPostSelector );
+		return driverHelper.waitTillPresentAndDisplayed( this.driver, successNoticeSelector );
 	}
 
 	publishAndPreviewPublished() {
@@ -100,11 +98,11 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 			return classNames.includes( 'is-pending' );
 		} );
 	}
-	
+
 	waitForIsDraftStatus() {
 		return driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.editor-status-label.is-draft' ) );
 	}
-	
+
 	statusIsDraft() {
 		return this.driver.findElement( By.css( '.editor-status-label' ) ).getAttribute( 'class' ).then( ( classNames ) => {
 			return classNames.includes( 'is-draft' );

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -65,9 +65,6 @@ export default class LoginFlow {
 		}
 
 		loginPage = new LoginPage( this.driver, true );
-		this.driver.getCurrentUrl().then( ( urlDisplayed ) => {
-			return loginPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
-		} );
 		return loginPage.login( testUserName, testPassword );
 	}
 

--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -102,7 +102,15 @@ test.describe( `[${host}] Editor: Pages (${screenSize})`, function() {
 					} );
 				} );
 
-				test.describe( 'Publish and Preview Published Content', function() {
+				// Just publish instead of preview until the post-Publish preview flow is settled
+				test.describe( 'Publish Content', function() {
+					test.it( 'Can publish content', function() {
+						this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+						this.postEditorToolbarComponent.publishPost();
+					} );
+				} );
+
+				test.xdescribe( 'Publish and Preview Published Content', function() {
 					test.it( 'Can publish and preview published content', function() {
 						this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
 						this.postEditorToolbarComponent.publishAndPreviewPublished();


### PR DESCRIPTION
I ran into timeouts and other issues with the solution I merged in #595.  This PR is half revert, half workaround/fix.  The changes here handle either case of the AB test, whether the post-publish preview is shown or not.  But it got complicated when dealing with the Page publishing flow that publishes and then previews.  So for now I've just skipped that piece of the flow so we can have a functioning set of tests when I leave for the day.

@alisterscott I can work on a real fix for this tomorrow, but if you have time and want to tackle it go right ahead 😄  