### PR TITLE
Fix setting AB test groups for post-publish screen

### DIFF
--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -1,4 +1,5 @@
 import LoginPage from '../pages/login-page.js';
+import EditorPage from '../pages/editor-page';
 import WPAdminLoginPage from '../pages/wp-admin/wp-admin-logon-page';
 import ReaderPage from '../pages/reader-page.js';
 import StatsPage from '../pages/stats-page.js';
@@ -65,9 +66,6 @@ export default class LoginFlow {
 		}
 
 		loginPage = new LoginPage( this.driver, true );
-		this.driver.getCurrentUrl().then( ( urlDisplayed ) => {
-			return loginPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
-		} );
 		return loginPage.login( testUserName, testPassword );
 	}
 
@@ -78,14 +76,26 @@ export default class LoginFlow {
 		readerPage.waitForPage();
 
 		let navbarComponent = new NavbarComponent( this.driver );
-		return navbarComponent.clickCreateNewPost();
+		navbarComponent.clickCreateNewPost();
+
+		this.editorPage = new EditorPage( this.driver );
+
+		this.driver.getCurrentUrl().then( ( urlDisplayed ) => {
+			return this.editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
+		} );
 	}
 
 	loginAndStartNewPage() {
 		this.loginAndSelectMySite();
 
 		let sidebarComponent = new SidebarComponent( this.driver );
-		return sidebarComponent.selectAddNewPage();
+		sidebarComponent.selectAddNewPage();
+
+		this.editorPage = new EditorPage( this.driver );
+
+		this.driver.getCurrentUrl().then( ( urlDisplayed ) => {
+			return this.editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
+		} );
 	}
 
 	loginAndSelectDomains() {

--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -281,6 +281,7 @@ test.describe( `[${host}] Editor: Pages (${screenSize})`, function() {
 				this.editorPage.enterTitle( pageTitle );
 				this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 				this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
+				this.editorPage = new EditorPage( driver );
 				this.editorPage.enterContent( pageQuote );
 				this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
 				this.postEditorToolbarComponent.ensureSaved();

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -458,6 +458,7 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 				this.editorPage.enterTitle( blogPostTitle );
 				this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 				this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
+				this.editorPage = new EditorPage( driver );
 				this.editorPage.enterContent( blogPostQuote );
 				this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
 				this.postEditorToolbarComponent.ensureSaved();

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -768,10 +768,10 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 				return postEditorSidebarComponent.trashPost();
 			} );
 
-			test.it( 'Can then see the Reader page', function() {
-				const readerPage = new ReaderPage( driver );
-				return readerPage.displayed().then( ( displayed ) => {
-					return assert.equal( displayed, true, 'The reader page is not displayed' );
+			test.it( 'Can then see the Posts page (new)', function() {
+				const postsPage = new PostsPage( driver );
+				return postsPage.displayed().then( ( displayed ) => {
+					return assert.equal( displayed, true, 'The posts page is not displayed' );
 				} );
 			} );
 		} );


### PR DESCRIPTION
This sets the AB tests once the editor tests get to the editor page for the first time - the previous attempt was on the logon page and didn't work.

This also makes a change to the trash post test where the posts list is now shown instead of the Reader. I am not sure why this happens now, but since it makes sense I'll leave it in place.
