### PR TITLE
Move the fs.rename operations in the Magellan reporter

### DIFF
--- a/lib/reporter/magellan-reporter.js
+++ b/lib/reporter/magellan-reporter.js
@@ -103,6 +103,21 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 									fields: fieldsObj,
 									username: 'e2e Test Runner'
 								} );
+
+								// Move to /reports for CircleCI artifacts
+								try {
+									fs.rename( `${reportDir}/${reportPath}`, `./reports/${testRun.guid}_${reportPath}`, function( moveErr ) {
+										if ( moveErr ) {
+											slackClient.send( {
+												icon_emoji: ':a8c:',
+												text: `Build <https://circleci.com/gh/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}/${process.env.CIRCLE_BUILD_NUM}|#${process.env.CIRCLE_BUILD_NUM}> Moving file to /reports failed: '${moveErr}'`,
+												username: 'e2e Test Runner'
+											} );
+										}
+									} );
+								} catch ( e ) {
+									console.log( `Error moving file, likely just timing race: ${e.message}` );
+								}
 							} );
 						} catch ( e ) {
 							console.log( `Error reading report file, likely just timing race: ${e.message}` );
@@ -144,12 +159,27 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 								console.log( `Error reading screenshot file, likely just timing race: ${e.message}` );
 							}
 						}
+
+						// Move to /screenshots for CircleCI artifacts
+						try {
+							fs.rename( `${screenshotDir}/${screenshotPath}`, `./screenshots/${screenshotPath}`, function( moveErr ) {
+								if ( moveErr ) {
+									slackClient.send( {
+										icon_emoji: ':a8c:',
+										text: `Build <https://circleci.com/gh/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}/${process.env.CIRCLE_BUILD_NUM}|#${process.env.CIRCLE_BUILD_NUM}> Moving file to /screenshots failed: '${moveErr}'`,
+										username: 'e2e Test Runner'
+									} );
+								}
+							} );
+						} catch ( e ) {
+							console.log( `Error moving file, likely just timing race: ${e.message}` );
+						}
 					} );
 				} );
 			}
 
-			// Pass or fail, if this was the last run move the logs and screenshots to CI artifact directories
-			if ( passCondition || failCondition ) {
+			// Also move the report/screenshots files if the test passed
+			if ( passCondition ) {
 				// Reports
 				fs.readdir( reportDir, function( dirErr, reportFiles ) {
 					if ( dirErr ) {


### PR DESCRIPTION
I've noticed more frequent file operation errors in the Magellan reporter than I'd like.  I think it's due to async execution and the fs calls happening in multiple different scopes.  This PR _should_ resolve that.