### PR TITLE
Rename woo store page to store dashboard & add product test

### DIFF
--- a/lib/components/store-sidebar-component.js
+++ b/lib/components/store-sidebar-component.js
@@ -6,6 +6,18 @@ export default class StoreSidebarComponent extends BaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.store-sidebar__sidebar' ) );
 		this.productsLinkSelector = By.css( 'li.products a' );
+		this.displayComponentIfNecessary();
+	}
+
+	// this is necessary on mobile width screens
+	displayComponentIfNecessary() {
+		const driver = this.driver;
+		const mobileLeftArrowSelector = By.css( '.current-section a' );
+		driver.findElement( mobileLeftArrowSelector ).isDisplayed().then( ( displayed ) => {
+			if ( displayed === true ) {
+				driverHelper.clickWhenClickable( driver, mobileLeftArrowSelector );
+			}
+		} );
 	}
 
 	productsLinkDisplayed() {

--- a/lib/components/store-sidebar-component.js
+++ b/lib/components/store-sidebar-component.js
@@ -1,9 +1,20 @@
 import { By } from 'selenium-webdriver';
-
+import * as driverHelper from '../../lib/driver-helper';
 import BaseContainer from '../base-container.js';
 
 export default class StoreSidebarComponent extends BaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.store-sidebar__sidebar' ) );
+		this.productsLinkSelector = By.css( 'li.products a' );
 	}
+
+	productsLinkDisplayed() {
+		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, this.productsLinkSelector );
+	}
+
+	selectProducts() {
+		return driverHelper.clickWhenClickable( this.driver, this.productsLinkSelector );
+	}
+
 }
+

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -3,6 +3,7 @@ import EditorPage from '../pages/editor-page';
 import WPAdminLoginPage from '../pages/wp-admin/wp-admin-logon-page';
 import ReaderPage from '../pages/reader-page.js';
 import StatsPage from '../pages/stats-page.js';
+import StoreDashboardPage from '../pages/woocommerce/store-dashboard-page';
 
 import config from 'config';
 
@@ -176,4 +177,12 @@ export default class LoginFlow {
 		let loginPage = new LoginPage( this.driver, false );
 		return loginPage.login( testUserName, testPassword );
 	}
+
+	loginAndOpenWooStore() {
+		this.loginAndSelectMySite();
+		this.sideBarComponent = new SidebarComponent( this.driver );
+		this.sideBarComponent.selectStoreOption();
+		return new StoreDashboardPage( this.driver );
+	}
+
 }

--- a/lib/pages/woocommerce/store-dashboard-page.js
+++ b/lib/pages/woocommerce/store-dashboard-page.js
@@ -4,7 +4,7 @@ import BaseContainer from '../../base-container.js';
 
 const by = webdriver.By;
 
-export default class StorePage extends BaseContainer {
+export default class StoreDashboardPage extends BaseContainer {
 	constructor( driver, visit = false ) {
 		const url = config.get( 'calypsoBaseURL' ) + '/store/' + config.get( 'wooCommerceSite' );
 		super( driver, by.css( '.woocommerce.dashboard.main' ), visit, url );

--- a/lib/pages/woocommerce/store-products-page.js
+++ b/lib/pages/woocommerce/store-products-page.js
@@ -1,12 +1,17 @@
 import webdriver from 'selenium-webdriver';
 import config from 'config';
 import BaseContainer from '../../base-container.js';
+import * as driverHelper from '../../../lib/driver-helper';
 
 const by = webdriver.By;
 
 export default class StoreProductsPage extends BaseContainer {
 	constructor( driver, visit = false ) {
 		const url = config.get( 'calypsoBaseURL' ) + '/store/products/' + config.get( 'wooCommerceSite' );
-		super( driver, by.css( '.woocommerce.dashboard.main' ), visit, url );
+		super( driver, by.css( '.products__list' ), visit, url );
+	}
+
+	atLeastOneProductDisplayed() {
+		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, by.css( '.products__list-wrapper tr.has-action' ) );
 	}
 }

--- a/specs-woocommerce/wp-woocommerce-spec.js
+++ b/specs-woocommerce/wp-woocommerce-spec.js
@@ -7,7 +7,7 @@ import * as driverManager from '../lib/driver-manager';
 import NavBarComponent from '../lib/components/navbar-component';
 import SidebarComponent from '../lib/components/sidebar-component';
 import StoreSidebarComponent from '../lib/components/store-sidebar-component';
-import StorePage from '../lib/pages/woocommerce/store-page';
+import StoreDashboardPage from '../lib/pages/woocommerce/store-dashboard-page';
 import StoreSettingsPage from '../lib/pages/woocommerce/store-settings-page';
 import StoreOrdersPage from '../lib/pages/woocommerce/store-orders-page';
 import StoreOrdersAddPage from '../lib/pages/woocommerce/store-orders-add-page';
@@ -47,17 +47,17 @@ test.describe( `Can see WooCommerce Store option in Calypso '${ screenSize }' @p
 		this.navBarComponent.clickMySites();
 	} );
 
-	test.it( 'Can see \'Store (BETA)\' option in main Calypso menu for a WooCommerce site', function() {
+	test.it( 'Can see \'Store (BETA)\' option in main Calypso menu for an AT WooCommerce site set to the US', function() {
 		this.sideBarComponent = new SidebarComponent( driver );
 		this.sideBarComponent.storeOptionDisplayed().then( ( displayed ) => {
-			assert( displayed, 'The Store menu option is not displayed for the WooCommerce site' );
+			assert( displayed, 'The Store menu option is not displayed for the AT WooCommerce site set to the US' );
 		} );
 	} );
 
-	test.it( 'The \'Store (BETA)\' option opens the store management page with its own sidebar', function() {
+	test.it( 'The \'Store (BETA)\' option opens the store dashboard with its own sidebar', function() {
 		this.sideBarComponent = new SidebarComponent( driver );
 		this.sideBarComponent.selectStoreOption();
-		this.storePage = new StorePage( driver );
+		this.storeDashboardPage = new StoreDashboardPage( driver );
 		this.storeSidebarComponent = new StoreSidebarComponent( driver );
 		this.storeSidebarComponent.displayed().then( ( d ) => {
 			assert( d, 'The store sidebar is not displayed' );
@@ -80,9 +80,9 @@ test.xdescribe( `WooCommerce on Calypso /store/{storeslug}: '${ screenSize }' @p
 	} );
 
 	test.it( 'Can see store placeholder page when visiting /store/{storeSlug}', function() {
-		this.storePage = new StorePage( driver, true );
-		this.storePage.displayed().then( ( shown ) => {
-			assert( shown, 'Could not see the WooCommerce store page after visiting /store' );
+		this.storeDashboardPage = new StoreDashboardPage( driver, true );
+		this.storeDashboardPage.displayed().then( (shown ) => {
+			assert( shown, 'Could not see the WooCommerce store dashboard page after visiting /store' );
 		} );
 	} );
 } );

--- a/specs-woocommerce/wp-woocommerce-spec.js
+++ b/specs-woocommerce/wp-woocommerce-spec.js
@@ -65,6 +65,39 @@ test.describe( `Can see WooCommerce Store option in Calypso '${ screenSize }' @p
 	} );
 } );
 
+test.describe( `Can manage WooCommerce products option in Calypso '${ screenSize }' @parallel`, function() {
+	this.timeout( mochaTimeOut );
+	this.bailSuite( true );
+
+	test.before( function() {
+		driverManager.clearCookiesAndDeleteLocalStorage( driver );
+	} );
+
+	// Login as WooCommerce store user and open the woo store
+	test.before( function() {
+		this.loginFlow = new LoginFlow( driver, 'wooCommerceUser' );
+		return this.loginFlow.loginAndOpenWooStore();
+	} );
+
+	test.it( 'Can see \'Products\' option in the Woo store sidebar', function() {
+		this.storeDashboardPage = new StoreDashboardPage( driver );
+		this.storeSidebarComponent = new StoreSidebarComponent( driver );
+		this.storeSidebarComponent.productsLinkDisplayed().then( ( d ) => {
+			assert( d, 'The store sidebar products link is not displayed' );
+		} );
+	} );
+
+	test.it( 'Can see the products page with at least one product when selecting the products option in the Woo store sidebar', function() {
+		this.storeDashboardPage = new StoreDashboardPage( driver );
+		this.storeSidebarComponent = new StoreSidebarComponent( driver );
+		this.storeSidebarComponent.selectProducts();
+		this.storeProductsPage = new StoreProductsPage( driver );
+		this.storeProductsPage.atLeastOneProductDisplayed().then( ( displayed ) => {
+			assert( displayed, 'No Woo products are displayed on the product page' );
+		} );
+	} );
+} );
+
 test.xdescribe( `WooCommerce on Calypso /store/{storeslug}: '${ screenSize }' @parallel`, function() {
 	this.timeout( mochaTimeOut );
 	this.bailSuite( true );


### PR DESCRIPTION
- Renames the store page to store dashboard
- Adds the first test around selecting products from the sidebar