### PR TITLE
Update the selectors for inserting media and contact forms to use newly added data-e2e- attributes

### DIFF
--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -51,7 +51,7 @@ export default class EditorPage extends BaseContainer {
 
 	_chooseInsertMediaOption() {
 		driverHelper.clickWhenClickable( this.driver, by.css( '.mce-wpcom-insert-menu button.mce-open' ) );
-		return driverHelper.clickWhenClickable( this.driver, by.css( '.mce-menu .gridicons-add-image' ) );
+		return driverHelper.clickWhenClickable( this.driver, by.css( 'span[data-e2e-insert-type="media"]' ) );
 	}
 
 	uploadMedia( fileDetails ) {
@@ -68,7 +68,7 @@ export default class EditorPage extends BaseContainer {
 
 	insertContactForm() {
 		driverHelper.clickWhenClickable( this.driver, by.css( '.mce-wpcom-insert-menu button.mce-open' ) );
-		driverHelper.clickWhenClickable( this.driver, by.css( '.mce-menu .gridicons-mention' ) );
+		driverHelper.clickWhenClickable( this.driver, by.css( 'span[data-e2e-insert-type="contact-form"]' ) );
 		return driverHelper.clickWhenClickable( this.driver, by.css( 'button[data-e2e-button="save"]' ) );
 	}
 


### PR DESCRIPTION
Requires https://github.com/Automattic/wp-calypso/pull/15894 to be merged