### PR TITLE
Just write to console when alert is being dismissed rather than do a Slack warning

### DIFF
--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -196,7 +196,7 @@ export function dismissAllAlerts( driver ) {
 	times( 3, () => {
 		return driver.get( 'data:,' ).then( () => {}, ( err ) => {
 			return driver.sleep( 2000 ).then( () => {
-				slackNotifier.warn( `Accepting an open alert: '${err}'` );
+				console.log( `Accepting an open alert: '${err}'` );
 				return driver.switchTo().alert().then( function( alert ) {
 					return alert.accept();
 				}, () => { } );


### PR DESCRIPTION
This is unnecessary noise in Slack