### PR TITLE
New selector for editor sidebar

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -4,7 +4,7 @@ import BaseContainer from '../base-container.js';
 
 export default class PostEditorSidebarComponent extends BaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.post-editor__sidebar' ) );
+		super( driver, By.css( '.editor-sidebar' ) );
 		this.publicizeMessageSelector = By.css( 'div.editor-sharing__message-input textarea' );
 		this.displayComponentIfNecessary();
 	}


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/16022 Updated the CSS class name on the editor sidebar, which broke most of the editor tests.  This PR brings them back in sync.

h/t: @rachelmcr for the quick identification of the problem