### PR TITLE
New attempt at canary signup workaround

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -296,10 +296,10 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 
 								test.it( 'Verify login screen not present', () => {
 									return driver.getCurrentUrl().then( ( url ) => {
-										if ( url.match( /wp-login.php|log-in/ ) ) {
-											SlackNotifier.warn( 'WARNING: Signup process sent me to the login screen!' );
+										if ( ! url.match( /checkout/ ) ) {
 											let baseURL = config.get( 'calypsoBaseURL' );
 											let newUrl = `${baseURL}/checkout/${selectedBlogAddress}`;
+											SlackNotifier.warn( `WARNING: Signup process sent me to ${url} instead of ${newUrl}` );
 											return driver.get( decodeURIComponent( newUrl ) );
 										}
 
@@ -557,10 +557,10 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 
 							test.it( 'Verify login screen not present', () => {
 								return driver.getCurrentUrl().then( ( url ) => {
-									if ( url.match( /wp-login.php|log-in/ ) ) {
-										SlackNotifier.warn( 'WARNING: Signup process sent me to the login screen!' );
+									if ( ! url.match( /checkout/ ) ) {
 										let baseURL = config.get( 'calypsoBaseURL' );
 										let newUrl = `${baseURL}/checkout/${expectedDomainName}/business`;
+										SlackNotifier.warn( `WARNING: Signup process sent me to ${url} instead of ${newUrl}!` );
 										return driver.get( decodeURIComponent( newUrl ) );
 									}
 


### PR DESCRIPTION
Now instead of matching `/wp-login.php|log-in/` I'm just checking for `! /checkout/`.  My theory is maybe the login page hasn't actually loaded in the time it takes for the URL check, so we're passing the test too early.

This new method may lead to unnecessary redirects, but that _should_ be inconsequential to the test results themselves, but something to monitor.

I'm having problems recreating the issue in manual CircleCI runs, so I'll probably just merge this and let it run its course for a while.