### PR TITLE
Enables Post-post-preview flow by default

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -60,6 +60,6 @@
   "overrideABTests": [
 	[ "signupSurveyStep_20170329", "hideSurveyStep" ],
 	[ "signupPlansCopyChanges_20170623", "original" ],
-	[ "postPublishPreview_20170627", "noShowPostPublishPreview" ]
+	[ "postPublishPreview_20170627", "showPostPublishPreview" ]
   ]
 }

--- a/lib/components/page-preview-component.js
+++ b/lib/components/page-preview-component.js
@@ -36,6 +36,11 @@ export default class PagePreviewComponent extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, By.css( 'button.web-preview__close' ) );
 	}
 
+	edit() {
+		this.driver.switchTo().defaultContent();
+		return driverHelper.clickWhenClickable( this.driver, By.css( '.button.web-preview__edit' ) );
+	}
+
 	static switchToIFrame( driver ) {
 		const iFrameSelector = By.css( '.web-preview__frame' );
 		const explicitWaitMS = config.get( 'explicitWaitMS' );

--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -2,6 +2,7 @@ import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper.js';
 
 import BaseContainer from '../base-container.js';
+import PostPreviewComponent from './post-preview-component.js';
 
 export default class PostEditorToolbarComponent extends BaseContainer {
 	constructor( driver ) {
@@ -45,7 +46,7 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 
 	waitForSuccessViewPostNotice() {
 		const successNoticeSelector = By.css( '.post-editor__notice.is-success,.post-editor-notice.is-success,.notice.is-success,.post-editor-notice.is-success' );
-		const viewPostSelector = By.css( '.notice__action' );
+		const viewPostSelector = By.css( '.notice.is-success' );
 
 		driverHelper.waitTillPresentAndDisplayed( this.driver, successNoticeSelector );
 		return driverHelper.waitTillPresentAndDisplayed( this.driver, viewPostSelector );
@@ -59,7 +60,8 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 
 	publishAndViewContent( { reloadPageTwice = false } = {} ) {
 		this.publishPost();
-		this.waitForSuccessViewPostNotice();
+		let previewComponent = new PostPreviewComponent( this.driver );
+		previewComponent.edit();
 		return this.viewPublishedPostOrPage( { reloadPageTwice: reloadPageTwice } );
 	}
 
@@ -100,11 +102,11 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 			return classNames.includes( 'is-pending' );
 		} );
 	}
-	
+
 	waitForIsDraftStatus() {
 		return driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.editor-status-label.is-draft' ) );
 	}
-	
+
 	statusIsDraft() {
 		return this.driver.findElement( By.css( '.editor-status-label' ) ).getAttribute( 'class' ).then( ( classNames ) => {
 			return classNames.includes( 'is-draft' );

--- a/lib/components/post-preview-component.js
+++ b/lib/components/post-preview-component.js
@@ -43,6 +43,11 @@ export default class PostPreviewComponent extends BaseContainer {
 		return this.viewPostPage.imageDisplayed( fileDetails );
 	}
 
+	edit() {
+		this.driver.switchTo().defaultContent();
+		return driverHelper.clickWhenClickable( this.driver, By.css( '.button.web-preview__edit' ) );
+	}
+
 	close() {
 		this.driver.switchTo().defaultContent();
 		return driverHelper.clickWhenClickable( this.driver, By.css( 'button.web-preview__close' ) );

--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -105,7 +105,7 @@ test.describe( `[${host}] Editor: Pages (${screenSize})`, function() {
 				test.describe( 'Publish and Preview Published Content', function() {
 					test.it( 'Can publish and preview published content', function() {
 						this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
-						this.postEditorToolbarComponent.publishAndPreviewPublished();
+						this.postEditorToolbarComponent.publishPost();
 						return this.pagePreviewComponent = new PagePreviewComponent( driver );
 					} );
 

--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -128,7 +128,7 @@ test.describe( `[${host}] Editor: Pages (${screenSize})`, function() {
 					} );
 
 					test.it( 'Can close page preview', function() {
-						this.pagePreviewComponent.close();
+						return this.pagePreviewComponent.edit();
 					} );
 				} );
 			} else { // Jetpack tests

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -221,7 +221,7 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 									} );
 
 									test.it( 'Can close post preview', function() {
-										this.postPreviewComponent.close();
+										this.postPreviewComponent.edit();
 									} );
 								} );
 							} else { // Jetpack tests

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -8,7 +8,6 @@ import EditorPage from '../lib/pages/editor-page.js';
 import TwitterFeedPage from '../lib/pages/twitter-feed-page.js';
 import ViewPostPage from '../lib/pages/view-post-page.js';
 import NotFoundPage from '../lib/pages/not-found-page.js';
-import ReaderPage from '../lib/pages/reader-page.js';
 import PostsPage from '../lib/pages/posts-page.js';
 
 import SidebarComponent from '../lib/components/sidebar-component.js';
@@ -187,7 +186,7 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 								test.describe( 'Publish and Preview Published Content', function() {
 									test.it( 'Can publish and view content', function() {
 										let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
-										postEditorToolbarComponent.publishAndPreviewPublished();
+										postEditorToolbarComponent.publishPost();
 										this.postPreviewComponent = new PostPreviewComponent( driver );
 									} );
 
@@ -944,7 +943,10 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 				this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
 				this.postEditorToolbarComponent.ensureSaved();
 				this.postEditorToolbarComponent.publishPost();
-				return this.postEditorToolbarComponent.waitForSuccessViewPostNotice();
+				this.postEditorToolbarComponent.waitForSuccessViewPostNotice();
+				let postPreviewComponent = new PostPreviewComponent( driver );
+
+				return postPreviewComponent.edit();
 			} );
 		} );
 


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/15886 will disable the post-preview AB test.  This PR enables that flow by default in the e2e tests.