### PR TITLE
Handle post-post preview on Jetpack sites

### DIFF
--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -48,10 +48,7 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 
 	waitForSuccessViewPostNotice() {
 		const successNoticeSelector = By.css( '.post-editor__notice.is-success,.post-editor-notice.is-success,.notice.is-success,.post-editor-notice.is-success' );
-		let viewPostSelector = By.css( '.notice.is-success' );
-		if ( host !== 'WPCOM' ) {
-			viewPostSelector = By.css( '.notice__action' );
-		}
+		const viewPostSelector = By.css( '.notice.is-success' );
 
 		driverHelper.waitTillPresentAndDisplayed( this.driver, successNoticeSelector );
 		return driverHelper.waitTillPresentAndDisplayed( this.driver, viewPostSelector );

--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -1,8 +1,10 @@
 import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper.js';
+import * as dataHelper from '../lib/data-helper';
 
 import BaseContainer from '../base-container.js';
 import PostPreviewComponent from './post-preview-component.js';
+const host = dataHelper.getJetpackHost();
 
 export default class PostEditorToolbarComponent extends BaseContainer {
 	constructor( driver ) {
@@ -46,7 +48,10 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 
 	waitForSuccessViewPostNotice() {
 		const successNoticeSelector = By.css( '.post-editor__notice.is-success,.post-editor-notice.is-success,.notice.is-success,.post-editor-notice.is-success' );
-		const viewPostSelector = By.css( '.notice.is-success' );
+		let viewPostSelector = By.css( '.notice.is-success' );
+		if ( host !== 'WPCOM' ) {
+			viewPostSelector = By.css( '.notice__action' );
+		}
 
 		driverHelper.waitTillPresentAndDisplayed( this.driver, successNoticeSelector );
 		return driverHelper.waitTillPresentAndDisplayed( this.driver, viewPostSelector );
@@ -60,8 +65,12 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 
 	publishAndViewContent( { reloadPageTwice = false } = {} ) {
 		this.publishPost();
-		let previewComponent = new PostPreviewComponent( this.driver );
-		previewComponent.edit();
+		if ( host === 'WPCOM' ) {
+			let previewComponent = new PostPreviewComponent( this.driver );
+			previewComponent.edit();
+		} else {
+			this.waitForSuccessViewPostNotice();
+		}
 		return this.viewPublishedPostOrPage( { reloadPageTwice: reloadPageTwice } );
 	}
 

--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -62,7 +62,7 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 
 	publishAndViewContent( { reloadPageTwice = false } = {} ) {
 		this.publishPost();
-		if ( host === 'WPCOM' ) {
+		if ( host === 'WPCOM' || host === 'PRESSABLE' ) {
 			let previewComponent = new PostPreviewComponent( this.driver );
 			previewComponent.edit();
 		} else {

--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -1,6 +1,6 @@
 import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper.js';
-import * as dataHelper from '../lib/data-helper';
+import * as dataHelper from '../data-helper';
 
 import BaseContainer from '../base-container.js';
 import PostPreviewComponent from './post-preview-component.js';

--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -70,7 +70,7 @@ test.describe( `[${host}] Editor: Pages (${screenSize})`, function() {
 				postEditorSidebarComponent.closeSharingSection();
 			} );
 
-			if ( host === 'WPCOM' ) {
+			if ( host === 'WPCOM' || host === 'PRESSABLE' ) {
 				test.describe( 'Preview', function() {
 					test.it( 'Can launch page preview', function() {
 						let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
@@ -105,7 +105,7 @@ test.describe( `[${host}] Editor: Pages (${screenSize})`, function() {
 				test.describe( 'Publish and Preview Published Content', function() {
 					test.it( 'Can publish and preview published content', function() {
 						this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
-						if ( host === 'WPCOM' ) {
+						if ( host === 'WPCOM' || host === 'PRESSABLE' ) {
 							this.postEditorToolbarComponent.publishPost();
 						} else {
 							this.postEditorToolbarComponent.publishAndPreviewPublished();
@@ -132,7 +132,7 @@ test.describe( `[${host}] Editor: Pages (${screenSize})`, function() {
 					} );
 
 					test.it( 'Can close page preview', function() {
-						if ( host === 'WPCOM' ) {
+						if ( host === 'WPCOM' || host === 'PRESSABLE' ) {
 							return this.pagePreviewComponent.edit();
 						}
 

--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -105,7 +105,11 @@ test.describe( `[${host}] Editor: Pages (${screenSize})`, function() {
 				test.describe( 'Publish and Preview Published Content', function() {
 					test.it( 'Can publish and preview published content', function() {
 						this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
-						this.postEditorToolbarComponent.publishPost();
+						if ( host === 'WPCOM' ) {
+							this.postEditorToolbarComponent.publishPost();
+						} else {
+							this.postEditorToolbarComponent.publishAndPreviewPublished();
+						}
 						return this.pagePreviewComponent = new PagePreviewComponent( driver );
 					} );
 
@@ -128,7 +132,12 @@ test.describe( `[${host}] Editor: Pages (${screenSize})`, function() {
 					} );
 
 					test.it( 'Can close page preview', function() {
-						return this.pagePreviewComponent.edit();
+						if ( host === 'WPCOM' ) {
+							return this.pagePreviewComponent.edit();
+						}
+
+						// else Jetpack
+						return this.pagePreviewComponent.close();
 					} );
 				} );
 			} else { // Jetpack tests

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -186,7 +186,11 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 								test.describe( 'Publish and Preview Published Content', function() {
 									test.it( 'Can publish and view content', function() {
 										let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
-										postEditorToolbarComponent.publishPost();
+										if ( host === 'WPCOM' ) {
+											postEditorToolbarComponent.publishPost();
+										} else {
+											postEditorToolbarComponent.publishAndPreviewPublished();
+										}
 										this.postPreviewComponent = new PostPreviewComponent( driver );
 									} );
 
@@ -221,7 +225,12 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 									} );
 
 									test.it( 'Can close post preview', function() {
-										this.postPreviewComponent.edit();
+										if ( host === 'WPCOM' ) {
+											return this.postPreviewComponent.edit();
+										}
+
+										// else Jetpack
+										return this.postPreviewComponent.close();
 									} );
 								} );
 							} else { // Jetpack tests
@@ -942,11 +951,16 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 			test.it( 'Can publish the post', function() {
 				this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
 				this.postEditorToolbarComponent.ensureSaved();
-				this.postEditorToolbarComponent.publishPost();
-				this.postEditorToolbarComponent.waitForSuccessViewPostNotice();
-				let postPreviewComponent = new PostPreviewComponent( driver );
+				if ( host === 'WPCOM' ) {
+					this.postEditorToolbarComponent.publishPost();
+					this.postEditorToolbarComponent.waitForSuccessViewPostNotice();
+					let postPreviewComponent = new PostPreviewComponent( driver );
 
-				return postPreviewComponent.edit();
+					return postPreviewComponent.edit();
+				}
+
+				// else Jetpack
+				return this.postEditorToolbarComponent.waitForSuccessViewPostNotice();
 			} );
 		} );
 

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -140,8 +140,8 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 							postEditorSidebarComponent.closeSharingSection();
 						} );
 
-						test.describe( 'Preview (WPCOM only)', function() {
-							if ( host === 'WPCOM' ) {
+						test.describe( 'Preview (WPCOM/PRESSABLE only)', function() {
+							if ( host === 'WPCOM' || host === 'PRESSABLE' ) {
 								test.it( 'Can launch post preview', function() {
 									this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
 									this.postEditorToolbarComponent.ensureSaved();
@@ -186,7 +186,7 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 								test.describe( 'Publish and Preview Published Content', function() {
 									test.it( 'Can publish and view content', function() {
 										let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
-										if ( host === 'WPCOM' ) {
+										if ( host === 'WPCOM' || host === 'PRESSABLE' ) {
 											postEditorToolbarComponent.publishPost();
 										} else {
 											postEditorToolbarComponent.publishAndPreviewPublished();
@@ -225,7 +225,7 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 									} );
 
 									test.it( 'Can close post preview', function() {
-										if ( host === 'WPCOM' ) {
+										if ( host === 'WPCOM' || host === 'PRESSABLE' ) {
 											return this.postPreviewComponent.edit();
 										}
 
@@ -951,8 +951,9 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 			test.it( 'Can publish the post', function() {
 				this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
 				this.postEditorToolbarComponent.ensureSaved();
-				if ( host === 'WPCOM' ) {
-					this.postEditorToolbarComponent.publishPost();
+				this.postEditorToolbarComponent.publishPost();
+
+				if ( host === 'WPCOM' || host === 'PRESSABLE' ) {
 					this.postEditorToolbarComponent.waitForSuccessViewPostNotice();
 					let postPreviewComponent = new PostPreviewComponent( driver );
 


### PR DESCRIPTION
Jetpack sites without https enabled do not support the new post-post preview publish flow, which was enabled in #617.  This PR wraps those steps in conditionals so it's only enabled on WPCOM and PRESSABLE (our other pre-build Jetpack sites do not have https at the moment)