### PR TITLE
Enable site preview test for Pressable (https)

### DIFF
--- a/specs/wp-view-site-spec.js
+++ b/specs/wp-view-site-spec.js
@@ -16,57 +16,59 @@ const host = dataHelper.getJetpackHost();
 
 var driver;
 
-test.before( function() {
-	this.timeout( startBrowserTimeoutMS );
-	driver = driverManager.startBrowser();
-} );
+if ( host === 'WPCOM' || host === 'PRESSABLE' ) {
+	test.before( function() {
+		this.timeout( startBrowserTimeoutMS );
+		driver = driverManager.startBrowser();
+	} );
 
-test.describe( `[${host}] View site from sidebar: (${screenSize}) @parallel`, function() {
-	this.timeout( mochaTimeOut );
-	this.bailSuite( true );
+	test.describe( `[${host}] View site from sidebar: (${screenSize}) @parallel @jetpack`, function() {
+		this.timeout( mochaTimeOut );
+		this.bailSuite( true );
 
-	test.describe( 'View site and close:', function() {
-		test.before( function() {
-			driverManager.clearCookiesAndDeleteLocalStorage( driver );
-		} );
-
-		test.it( 'Can Log In and go to My Sites', function() {
-			const loginFlow = new LoginFlow( driver );
-			return loginFlow.loginAndSelectMySite();
-		} );
-
-		test.it( 'Can view the default site from sidebar', function() {
-			this.sidebarComponent = new SidebarComponent( driver );
-			return this.sidebarComponent.selectViewThisSite();
-		} );
-
-		test.it( 'Can see the web preview button', function() {
-			this.siteViewComponent = new SiteViewComponent( driver );
-			return this.siteViewComponent.isWebPreviewPresent().then( ( present ) => {
-				assert.equal( present, true, 'The web preview button was not displayed' );
+		test.describe( 'View site and close:', function() {
+			test.before( function() {
+				driverManager.clearCookiesAndDeleteLocalStorage( driver );
 			} );
-		} );
 
-		test.it( 'Can see the web preview "open in new window" button', function() {
-			return this.siteViewComponent.isOpenInNewWindowButtonPresent().then( ( present ) => {
-				assert.equal( present, true, 'The web preview "open in new window" button was not displayed' );
+			test.it( 'Can Log In and go to My Sites', function() {
+				const loginFlow = new LoginFlow( driver );
+				return loginFlow.loginAndSelectMySite();
 			} );
-		} );
 
-		test.it( 'Can see the site preview', function() {
-			return this.siteViewComponent.isSitePresent().then( ( present ) => {
-				assert.equal( present, true, 'The web site preview was not displayed' );
+			test.it( 'Can view the default site from sidebar', function() {
+				this.sidebarComponent = new SidebarComponent( driver );
+				return this.sidebarComponent.selectViewThisSite();
 			} );
-		} );
 
-		test.it( 'Can close site view', function() {
-			return this.siteViewComponent.close( driver );
-		} );
+			test.it( 'Can see the web preview button', function() {
+				this.siteViewComponent = new SiteViewComponent( driver );
+				return this.siteViewComponent.isWebPreviewPresent().then( ( present ) => {
+					assert.equal( present, true, 'The web preview button was not displayed' );
+				} );
+			} );
 
-		test.it( 'Can see sidebar again', function() {
-			return this.sidebarComponent.displayed().then( ( displayed ) => {
-				assert( displayed, 'The sidebar was not displayed' );
+			test.it( 'Can see the web preview "open in new window" button', function() {
+				return this.siteViewComponent.isOpenInNewWindowButtonPresent().then( ( present ) => {
+					assert.equal( present, true, 'The web preview "open in new window" button was not displayed' );
+				} );
+			} );
+
+			test.it( 'Can see the site preview', function() {
+				return this.siteViewComponent.isSitePresent().then( ( present ) => {
+					assert.equal( present, true, 'The web site preview was not displayed' );
+				} );
+			} );
+
+			test.it( 'Can close site view', function() {
+				return this.siteViewComponent.close( driver );
+			} );
+
+			test.it( 'Can see sidebar again', function() {
+				return this.sidebarComponent.displayed().then( ( displayed ) => {
+					assert( displayed, 'The sidebar was not displayed' );
+				} );
 			} );
 		} );
 	} );
-} );
+}


### PR DESCRIPTION
Working on #618 made me realize I could turn this test on for Pressable as well, since it has https configured.