### PR TITLE
Fix editor visibility selector

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -124,7 +124,7 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 		let visibilitySelector;
 		const driver = this.driver;
 		this._expandOrCollapseSection( 'status', true );
-		visibilitySelector = By.css( '.editor-visibility button' );
+		visibilitySelector = By.css( '.editor-drawer .editor-visibility button' );
 		driverHelper.clickWhenClickable( driver, visibilitySelector );
 		driverHelper.clickWhenClickable( driver, By.css( 'input[value=private]' ) );
 		return driverHelper.clickWhenClickable( driver, By.css( '.dialog button.is-primary' ) ); //Click Yes to publish

--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -60,7 +60,7 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 		return driver.wait( function() {
 			return driverHelper.isElementPresent( driver, saveCategoryButtonSelector ).then( function( present ) {
 				return ! present;
-			}, function( error ) {
+			}, function() {
 				return false;
 			} );
 		}, this.explicitWaitMS, 'The add category save button is still present when it should have disappeared' );
@@ -134,7 +134,7 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 		let visibilitySelector;
 		const driver = this.driver;
 		this._expandOrCollapseSection( 'status', true );
-		visibilitySelector = By.css( '.editor-visibility button' );
+		visibilitySelector = By.css( '.editor-drawer .editor-visibility button' );
 		driverHelper.clickWhenClickable( driver, visibilitySelector );
 		driverHelper.clickWhenClickable( driver, By.css( 'input[value=password]' ) );
 		return driverHelper.setWhenSettable( driver, By.css( 'div.editor-visibility__dialog input[type=text]' ), password, { secureValue: true } );


### PR DESCRIPTION
These Calypso PRs changed the editor sidebar post visibility button slightly, which required us to use a more specific selector

https://github.com/Automattic/wp-calypso/pull/15755
https://github.com/Automattic/wp-calypso/pull/15803