### PR TITLE
Add i18n screenshot upload script

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The `run.sh` script takes the following parameters, which can be combined to exe
 -m [browsers]	  - Execute the multi-browser visual-diff tests with the given list of browsers via grunt.  Specify browsers in comma-separated list or 'all'
 -f		  - Tell visdiffs to fail the tests rather than just send an alert
 -i		  - Execute i18n screenshot tests, not compatible with -g flag
+-U		  - Execute the i18n screenshot upload script in scripts/
 -v		  - Execute the visdiff tests in specs-visdiff/
 -x		  - Execute the tests from the context of xvfb-run
 -u [baseUrl]	  - Override the calypsoBaseURL config
@@ -198,6 +199,7 @@ A full list of config values are:
 | emailPrefix | A string to stick on the beginning of the e-mail addresses used for invites and signups | username | No | **NO** |
 | testAccounts | A JSON object with username/password pairs assigned to keynames for easy retrieval.  The necessary accounts can be found in the config/local.example.json file.  | {"defaultUser": ["username1","password1"], "multiSiteUser": ["username2","password2"] } | No | **NO** |
 | highlightElements | Boolean to indicate whether to visually highlight elements being interacted with on the page | true | No | Yes |
+| restApiApplication | A JSON object with your [WordPress REST API app](https://developer.wordpress.com/apps/) client ID, redirect URI, and client secret | {"client_id": "YOUR_CLIENT_ID", "redirect_uri": "YOUR_REDIRECT_URI", "client_secret": "YOUR CLIENT_SECRET"} | Yes (for REST API scripts only) | **NO** |
 
 ### Standalone Environment Variables
 

--- a/config/api.json
+++ b/config/api.json
@@ -1,0 +1,106 @@
+{
+  "wp": {
+    "oauth2": {
+      "authorize": {
+        "schema": "https",
+        "method": ["GET"]
+      },
+      "token-info": {
+        "schema": "https",
+        "method": ["GET"]
+      },
+      "token": {
+        "schema": "https",
+        "method": ["POST"]
+      }
+    },
+    "insights": {
+      "schema": "https",
+      "method": ["GET"]
+    },
+    "batch": {
+      "schema": "https",
+      "method": ["GET"]
+    },
+    "me": {
+      "schema": "https",
+      "method": ["GET"],
+      "sites": {
+        "schema": "https",
+        "method": ["GET"]
+      },
+      "settings": {
+        "schema": "https",
+        "method": ["GET", "POST"]
+      },
+      "billing-history": {
+        "schema": "https",
+        "method": ["GET"]
+      },
+      "two-step": {
+        "schema": "https",
+        "method": ["GET"]
+      },
+      "likes": {
+        "schema": "https",
+        "method": ["GET"]
+      },
+      "posts": {
+        "schema": "https",
+        "method": ["GET"]
+      }
+    },
+    "sites": {
+      "${site}": {
+        "schema": "https",
+        "method": ["GET"],
+        "users": {
+          "schema": "https",
+          "method": ["GET"]
+        },
+        "comments": {
+          "schema": "https",
+          "method": ["GET"]
+        },
+        "tags": {
+          "schema": "https",
+          "method": ["GET"]
+        },
+        "categories": {
+          "schema": "https",
+          "method": ["GET"]
+        },
+        "follows": {
+          "schema": "https",
+          "method": ["GET"]
+        },
+        "sharing-buttons": {
+          "schema": "https",
+          "method": ["GET"]
+        },
+        "posts": {
+          "schema": "https",
+          "method": ["GET"],
+          "new": {
+            "schema": "https",
+            "method": ["POST"]
+          },
+          "${post_ID}": {
+            "delete": {
+              "schema": "https",
+              "method": ["POST"]
+            }
+          }
+        },
+        "media": {
+          "schema": "https",
+          "method": ["GET"],
+          "new": {
+            "schema": "https",
+            "method": ["POST"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/config/local.example.json
+++ b/config/local.example.json
@@ -100,6 +100,16 @@
 		"postNUXUser": [
 			"username",
 			"password"
+		],
+		"i18nScreenshotUser": [
+			"username",
+			"password",
+			"site address or ID"
 		]
-	}
+	},
+	"restApiApplication": {
+		"client_id": "YOUR_CLIENT_ID",
+		"redirect_uri": "YOUR_REDIRECT_URI",
+		"client_secret": "YOUR_CLIENT_SECRET"
+    }
 }

--- a/lib/wpcom-api/media.js
+++ b/lib/wpcom-api/media.js
@@ -1,0 +1,44 @@
+const fs = require( 'fs' );
+
+function uploadMedia( service, siteID, formData ) {
+	var r = service.sites['${site}'].media.new.POST( {
+		params: { site: siteID },
+		formData: formData
+	} );
+
+	return r;
+}
+
+function prepareUpload( locales, flows, imageFolder ) {
+	var imageFormData;
+	var imageFormDataCollection = {};
+
+	// Prepare the images to upload for each locale
+	for ( const locale of locales ) {
+		imageFormDataCollection[locale] = {};
+
+		// Prepare the images to upload for each flow in the current locale
+		for ( const flow of flows ) {
+			const imageFiles = fs.readdirSync( imageFolder );
+			const filter = new RegExp( `^${locale}-(DESKTOP|MOBILE)--${flow}` );
+
+			// Prepare the formData for each image in the current locale and flow
+			imageFormData = [];
+			for ( const image of imageFiles ) {
+				if ( filter.test( image ) ) {
+					imageFormData.push( {
+						'media[0]': fs.createReadStream( imageFolder + image )
+					} );
+				}
+			}
+
+			// Collect the formData for this locale & flow
+			imageFormDataCollection[locale][flow] = imageFormData;
+		}
+	}
+
+	return imageFormDataCollection;
+}
+
+module.exports.upload = uploadMedia;
+module.exports.prepareUpload = prepareUpload;

--- a/lib/wpcom-api/oauth.js
+++ b/lib/wpcom-api/oauth.js
@@ -1,0 +1,100 @@
+// WordPress.com REST API oauth flows
+// See https://developer.wordpress.com/docs/oauth2/
+
+const expect = require( 'chai' ).expect;
+const config = require( 'config' );
+
+function login( wp, account ) {
+	var r;
+	var options = {};
+	options.server = 'https://public-api.wordpress.com';
+	options.login = 'https://wordpress.com/wp-login.php';
+	options.proxy = null;
+	options.clientId = config.restApiApplication.client_id;
+	options.redirectUri = config.restApiApplication.redirect_uri;
+	options.clientSecret = config.restApiApplication.client_secret;
+	options.responseType = 'code';
+	options.scope = 'global';
+	options.action = 'oauth2-login';
+	options.redirectTo = `https://public-api.wordpress.com/oauth2/authorize/?client_id=${options.clientId}&redirect_uri=${options.redirectUri}&response_type=code&scope=global&jetpack-code&jetpack-user-id=0&action=oauth2-login`;
+	options.account = account;
+
+	const loginForm = {
+		redirect_to: options.redirectTo,
+		log: options.account[0],
+		pwd: options.account[1]
+	};
+
+	// Simulate wp login to get _wpnonce
+	r = wp.rawRequest( {
+		method: 'POST',
+		uri: options.login,
+		proxy: options.proxy,
+		followRedirect: true,
+		followAllRedirects: true,
+		form: loginForm,
+	} );
+	expect( r.data.statusCode ).to.equal( 200 );
+	const wpnonce = r.data.body.match( /_wpnonce=([a-zA-Z0-9_]+)/ )[1];
+
+	// Get access code
+	const loginQuery = {
+		blog_id: 0,
+		client_id: options.clientId,
+		redirect_uri: options.redirectUri,
+		response_type: options.responseType,
+		scope: options.scope,
+		action: options.action,
+		redirect_to: options.redirectTo,
+		_wpnonce: wpnonce
+	};
+
+	r = wp.rawRequest( {
+		method: 'GET',
+		uri: options.server + '/oauth2/login/',
+		qs: loginQuery,
+		proxy: options.proxy,
+		followRedirect: false,
+	} );
+	expect( r.data.statusCode ).to.equal( 302 );
+	const accessCode = r.data.headers.location.match( /code=(.+)&state/i )[1];
+
+	// Get access token
+	r = wp.rawRequest( {
+		method: 'POST',
+		uri: options.server + '/oauth2/token',
+		proxy: options.proxy,
+		form: {
+			client_id: options.clientId,
+			client_secret: options.clientSecret,
+			redirect_uri: options.redirectUri,
+			code: accessCode,
+			grant_type: 'authorization_code'
+		}
+	} );
+	expect( r.data.statusCode ).to.equal( 200 );
+	const accessToken = JSON.parse( r.data.body ).access_token;
+	expect( accessToken ).to.be.a( 'String' );
+
+	// Validate access token
+	r = wp.oauth2['token-info'].GET( {
+		query: {
+			client_id: options.clientId,
+			token: accessToken
+		}
+	} );
+	expect( r.data.statusCode ).to.equal( 200 );
+	expect( r.data.body.scope ).to.equal( options.scope );
+
+	// set access token header for all the coming API calls
+	wp.setHeaders( {
+		Authorization: 'Bearer ' + accessToken
+	} );
+
+	return {
+		response: r,
+		accessToken: accessToken
+	};
+};
+
+module.exports.login = login;

--- a/lib/wpcom-api/posts.js
+++ b/lib/wpcom-api/posts.js
@@ -1,0 +1,10 @@
+function publishPost( service, siteID, formData ) {
+	var r = service.sites['${site}'].posts.new.POST( {
+		params: { site: siteID },
+		formData: formData
+	} );
+
+	return r;
+}
+
+module.exports.publish = publishPost;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "asana-phrase": "0.0.8",
     "babel-runtime": "^6.3.19",
+    "bluecat": "^1.1.6",
     "chai": "^3.4.1",
     "config": "1.16.0",
     "creditcard-generator": "0.0.7",

--- a/run.sh
+++ b/run.sh
@@ -191,7 +191,7 @@ else # Not using multiple CircleCI containers, just queue up the tests in sequen
   if [ "$CI" != "true" ] || [ $CIRCLE_NODE_INDEX == 0 ]; then
     if [ $UPLOAD == 1 ]; then
       # Clear out screenshots-i18n/ directory
-      rm -f screenshots-i18n/*
+      rm -f ${SCREENSHOTDIR}/*
     fi
     IFS=, read -r -a SCREENSIZE_ARRAY <<< "$SCREENSIZES"
     IFS=, read -r -a LOCALE_ARRAY <<< "$LOCALES"
@@ -212,7 +212,7 @@ fi
 
 if [ $UPLOAD == 1 ]; then
   echo "Uploading i18n tests screenshots:"
-  CMD="node ./scripts/i18nscreenshots.js $LOCALES"
+  CMD="node ./scripts/i18n-screenshots-upload.js $LOCALES"
 
   eval $CMD
   RETURN+=$?

--- a/run.sh
+++ b/run.sh
@@ -189,6 +189,10 @@ if [ $PARALLEL == 1 ]; then
   fi
 else # Not using multiple CircleCI containers, just queue up the tests in sequence
   if [ "$CI" != "true" ] || [ $CIRCLE_NODE_INDEX == 0 ]; then
+    if [ $UPLOAD == 1 ]; then
+      # Clear out screenshots-i18n/ directory
+      rm -f screenshots-i18n/*
+    fi
     IFS=, read -r -a SCREENSIZE_ARRAY <<< "$SCREENSIZES"
     IFS=, read -r -a LOCALE_ARRAY <<< "$LOCALES"
     for size in ${SCREENSIZE_ARRAY[@]}; do

--- a/run.sh
+++ b/run.sh
@@ -13,6 +13,7 @@ BRANCH=""
 RETURN=0
 CLEAN=0
 GREP=""
+UPLOAD=0
 
 # Function to join arrays into a string
 function joinStr { local IFS="$1"; shift; echo "$*"; }
@@ -40,6 +41,7 @@ usage () {
 -m [browsers]	  - Execute the multi-browser visual-diff tests with the given list of browsers via grunt.  Specify browsers in comma-separated list or 'all'
 -f		  - Tell visdiffs to fail the tests rather than just send an alert
 -i		  - Execute i18n screenshot tests, not compatible with -g flag
+-U      - Execute the i18n screenshot upload script in scripts/
 -v		  - Execute the visdiff tests in specs-visdiff/
 -x		  - Execute the tests from the context of xvfb-run
 -u [baseUrl]	  - Override the calypsoBaseURL config
@@ -52,7 +54,7 @@ if [ $# -eq 0 ]; then
   usage
 fi
 
-while getopts ":a:Rpb:s:gjWCH:wl:cm:fivxu:h" opt; do
+while getopts ":a:Rpb:s:gjWCH:wl:cm:fiUvxu:h" opt; do
   case $opt in
     a)
       WORKERS=$OPTARG
@@ -86,6 +88,9 @@ while getopts ":a:Rpb:s:gjWCH:wl:cm:fivxu:h" opt; do
       LOCALES="en,pt-BR,es,ja,fr,he"
       export SCREENSHOTDIR="screenshots-i18n"
       MAGELLAN_CONFIG="magellan-i18n.json"
+      ;;
+    U)
+      UPLOAD=1
       ;;
     w)
       NODE_CONFIG_ARGS+=$IE11_CONFIG
@@ -199,6 +204,14 @@ else # Not using multiple CircleCI containers, just queue up the tests in sequen
       done
     done
   fi
+fi
+
+if [ $UPLOAD == 1 ]; then
+  echo "Uploading i18n tests screenshots:"
+  CMD="node ./scripts/i18nscreenshots.js $LOCALES"
+
+  eval $CMD
+  RETURN+=$?
 fi
 
 if [ $CLEAN == 1 ]; then

--- a/scripts/i18n-screenshots-upload.js
+++ b/scripts/i18n-screenshots-upload.js
@@ -38,6 +38,7 @@ service.run( function() {
 	var postFormData;
 	var postContent;
 	var r;
+	var postLink;
 
 	// Oauth login
 	oauth.login( service, account );
@@ -61,6 +62,7 @@ service.run( function() {
 		}
 
 		// Prepare post content with one gallery per flow
+		const dateString = new Date().toDateString();
 		postContent = '';
 		for ( const flowID in imageIDs ) {
 			if ( imageIDs.hasOwnProperty( flowID ) ) {
@@ -70,7 +72,8 @@ service.run( function() {
 		}
 
 		postFormData = {
-			title: `${locale} Signup Screenshots`,
+			title: `${locale} Signup Screenshots (${dateString})`,
+			slug: `${locale}-signup-screenshots`,
 			content: postContent,
 			categories: 'Signup',
 			tags: locale
@@ -79,7 +82,8 @@ service.run( function() {
 		// Publish post
 		r = posts.publish( service, account[2], postFormData );
 		expect( r.data.statusCode ).to.equal( 200 );
+		postLink = r.data.body.URL;
 
-		console.log( ` - Successfully published ${locale} post` );
+		console.log( ` - Successfully published ${locale} post: ${postLink}` );
 	}
 } );

--- a/scripts/i18nscreenshots.js
+++ b/scripts/i18nscreenshots.js
@@ -1,0 +1,85 @@
+const config = require( 'config' );
+const bluecat = require( 'bluecat' );
+const path = require( 'path' );
+const expect = require( 'chai' ).expect;
+
+const oauth = require( '../lib/wpcom-api/oauth.js' );
+const posts = require( '../lib/wpcom-api/posts.js' );
+const media = require( '../lib/wpcom-api/media.js' );
+
+const api = bluecat.Api( 'wp' );
+api.oauth2.host = 'https://public-api.wordpress.com';
+const service = new bluecat.ServiceSync( api, 'public-api.wordpress.com/rest/v1.1' );
+
+// Test account for the upload
+const account = config.testAccounts.i18nScreenshotUser;
+
+// Locales to include in upload
+const locales = process.argv[2].toUpperCase().split( ',' );
+
+// e2e flows to include in upload
+// identified by the flow name as it appears in the screenshot filename
+const e2eFlows = [
+	'sign-up-for-a-site-on-a-premium-paid-plan-through-main-flow',
+	'partially-sign-up-for-a-site-on-a-business-paid-plan-w--domain-name-coming-in-via--create-as-business-flow'
+];
+
+// Directory where screenshots are saved
+const imageFolder = path.join( __dirname, '/../screenshots-i18n/' );
+
+// Prepare the images for upload, grouping them by locale & flow
+const imageFormDataCollection = media.prepareUpload( locales, e2eFlows, imageFolder );
+
+// Start the API calls
+service.run( function() {
+	var imageIDs;
+	var imageFormData;
+	var niceFlowID;
+	var postFormData;
+	var postContent;
+	var r;
+
+	// Oauth login
+	oauth.login( service, account );
+
+	// Publish a post for each locale
+	for ( const locale of locales ) {
+		console.log( `- Uploading ${locale} screenshots` );
+
+		// Upload the media for all flows in the locale and capture their media IDs
+		imageIDs = {};
+		for ( const flow of e2eFlows ) {
+			imageFormData = imageFormDataCollection[ locale ][ flow ];
+			imageIDs[ flow ] = [];
+
+			for ( const formData of imageFormData ) {
+				r = media.upload( service, account[2], formData );
+				expect( r.data.statusCode ).to.equal( 200 );
+
+				imageIDs[ flow ].push( r.data.body.media[0].ID );
+			}
+		}
+
+		// Prepare post content with one gallery per flow
+		postContent = '';
+		for ( const flowID in imageIDs ) {
+			if ( imageIDs.hasOwnProperty( flowID ) ) {
+				niceFlowID = flowID.charAt( 0 ).toUpperCase() + flowID.slice( 1 ).replace( /-/g, ' ' );
+				postContent += `<h2>${niceFlowID}</h2><p>[gallery ids="${imageIDs[ flowID ]}"]</p>`;
+			}
+		}
+
+		postFormData = {
+			title: `${locale} Signup Screenshots`,
+			content: postContent,
+			categories: 'Signup',
+			tags: locale
+		};
+
+		// Publish post
+		r = posts.publish( service, account[2], postFormData );
+		expect( r.data.statusCode ).to.equal( 200 );
+
+		console.log( ` - Successfully published ${locale} post` );
+	}
+} );


### PR DESCRIPTION
This PR is the third step for #494. It adds a script (called from `./run.sh`) to upload i18n screenshots to a WordPress.com blog using the WordPress.com REST API.

## To Test

You will need to create a [REST API app](https://developer.wordpress.com/apps/) and add the follow to your local config:

```
"restApiApplication": {
    "client_id": "YOUR_CLIENT_ID",
    "redirect_uri": "YOUR_REDIRECT_URI",
    "client_secret": "YOUR_CLIENT_SECRET"
  }
```

You will also need to specify a user `i18nScreenshotUser` in your local config, with the site address or ID where you want to upload the screenshots, as follows:

```
"testAccounts": {
	"i18nScreenshotUser": [
	  "USERNAME",
	  "PASSWORD",
	  "SITE_ADDRESS_OR_ID"
	]
}
```

You can then run `./run.sh -i -U` to first generate the i18n screenshots and then upload them to the specified site.