### PR TITLE
Google Adwords Preview tool: Adapt to remote changes

### DIFF
--- a/lib/pages/external/google-ad-preview-tool.js
+++ b/lib/pages/external/google-ad-preview-tool.js
@@ -25,7 +25,7 @@ export default class GoogleAdPreviewTool extends BaseContainer {
 		var locationSearchbox = this.driver.findElement( by.id( 'gwt-debug-geo-search-box' ) );
 		locationSearchbox.sendKeys( location + "\n" );
 
-		selector = by.id( 'gwt-debug-suggestions' );
+		selector = by.id( 'gwt-debug-geo-suggestions-pop-up' );
 		this.driver.wait( until.elementLocated( selector ), this.explicitWaitMS, 'Could not locate the suggestions dropdown' );
 		element = this.driver.findElement( selector );
 		this.driver.wait( until.elementIsVisible( element ), this.explicitWaitMS, 'Could not see suggestions dropdown' );

--- a/lib/pages/external/google-ad-preview-tool.js
+++ b/lib/pages/external/google-ad-preview-tool.js
@@ -1,6 +1,7 @@
 import webdriver, { By as by, until } from 'selenium-webdriver';
 import assert from 'assert';
 import BaseContainer from '../../base-container.js';
+import * as driverHelper from '../../driver-helper';
 
 export default class GoogleAdPreviewTool extends BaseContainer {
 	constructor( driver, language, originating_location ) {
@@ -51,8 +52,7 @@ export default class GoogleAdPreviewTool extends BaseContainer {
 	}
 	search( searchTerm ) {
 		var d = webdriver.promise.defer();
-		var searchBox = this.driver.findElement( by.id( 'gwt-debug-diagnostic-queryv2' ) );
-		searchBox.sendKeys( searchTerm );
+		driverHelper.setWhenSettable( this.driver, by.id( 'gwt-debug-diagnostic-queryv2' ), searchTerm );
 		this.driver.findElement( by.id( 'gwt-debug-preview-ads-buttonv2-content' ) ).click();
 		d.fulfill( true );
 		return d.promise;


### PR DESCRIPTION
This fixes a hang with selecting a city from the dropdown because of an update id.

Also use `setWhenSettable` to update the searchbox as it was sometimes eating characters.