### PR TITLE
Allow mp3 upload to Jetpack sites

### DIFF
--- a/specs/wp-media-upload-spec.js
+++ b/specs/wp-media-upload-spec.js
@@ -89,33 +89,30 @@ test.describe( `[${host}] Editor: Media Upload (${screenSize}) @parallel @jetpac
 				} );
 			} );
 
-			// Skip this test on Jetpack sites due to https://github.com/Automattic/jetpack/issues/7159
-			if ( host === 'WPCOM' ) {
-				test.describe( 'Can upload an mp3', function() {
-					let fileDetails;
+			test.describe( 'Can upload an mp3', function() {
+				let fileDetails;
 
-					test.it( 'Create mp3 for upload', function() {
-						mediaHelper.getMP3FileWithFilename( 'new.mp3' ).then( function( details ) {
-							fileDetails = details;
-						} );
-					} );
-
-					test.it( 'Can upload an mp3', function() {
-						editorPage.uploadMedia( fileDetails );
-					} );
-
-					test.it( 'Can delete mp3', function() {
-						editorPage.deleteMedia();
-					} );
-
-					test.after( function() {
-						editorPage.dismissMediaModal();
-						if ( fileDetails ) {
-							mediaHelper.deleteFile( fileDetails ).then( function() {} );
-						}
+				test.it( 'Create mp3 for upload', function() {
+					mediaHelper.getMP3FileWithFilename( 'new.mp3' ).then( function( details ) {
+						fileDetails = details;
 					} );
 				} );
-			}
+
+				test.it( 'Can upload an mp3', function() {
+					editorPage.uploadMedia( fileDetails );
+				} );
+
+				test.it( 'Can delete mp3', function() {
+					editorPage.deleteMedia();
+				} );
+
+				test.after( function() {
+					editorPage.dismissMediaModal();
+					if ( fileDetails ) {
+						mediaHelper.deleteFile( fileDetails ).then( function() {} );
+					}
+				} );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
With https://github.com/Automattic/wp-calypso/pull/16099 we can now upload mp3 files to Jetpack sites.