### PR TITLE
Revert "Update canary tests to include paid sign up again"

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -48,7 +48,7 @@ if ( process.env.DISABLE_EMAIL === 'true' ) {
 testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 	this.timeout( mochaTimeOut );
 
-	test.describe( 'Sign up for a free site @parallel', function() {
+	test.describe( 'Sign up for a free site @parallel @canary', function() {
 		this.bailSuite( true );
 
 		const blogName = dataHelper.getNewBlogName();
@@ -188,7 +188,7 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 		} );
 	} );
 
-	test.describe( 'Sign up for a site on a premium paid plan through main flow @canary @parallel', function() {
+	test.describe( 'Sign up for a site on a premium paid plan through main flow @parallel', function() {
 		this.bailSuite( true );
 
 		const blogName = dataHelper.getNewBlogName();
@@ -459,7 +459,7 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 		} );
 	} );
 
-	test.describe( 'Partially sign up for a site on a business paid plan w/ domain name coming in via /create as business flow @canary @parallel', function() {
+	test.describe( 'Partially sign up for a site on a business paid plan w/ domain name coming in via /create as business flow @parallel', function() {
 		this.bailSuite( true );
 
 		const siteName = dataHelper.getNewBlogName();


### PR DESCRIPTION
Reverts Automattic/wp-e2e-tests#653

We're still seeing the login failures on Canary...