### PR TITLE
Script to launch logged-in browser for manual testing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -55,7 +55,7 @@
 		"quote-props": [ 1, "as-needed" ],
 		"quotes": [ 1, "single", "avoid-escape" ],
 		"semi-spacing": 1,
-		"space-after-keywords": [ 1, "always" ],
+		"keyword-spacing": [ 1, { "after": true } ],
 		"space-before-blocks": [ 1, "always" ],
 		"space-before-function-paren": [ 1, "never" ],
 		// Our array literal index exception violates this rule

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Automated end-to-end acceptance tests for the [wp-calypso](https://github.com/Au
   - [Config Values](#config-values)
   - [Standalone Environment Variables](#standalone-environment-variables)
   - [CircleCI Environment Variables](#circleci-environment-variables)
-- [Ad Blocker](#ad-blocker)
+- [NodeJS Version](#nodejs-version)
+- [Launch Logged-In Window](#launch-logged-in-window)
 
 
 ## Pre-requisites
@@ -220,3 +221,11 @@ These environment variables are intended for use inside CircleCI, to control whi
 
 ### NodeJS Version
 The node version should be defined in the `.nvmrc` file for use with the [nvm](https://github.com/creationix/nvm) project.  When changing the version a new Docker container should be built/pushed to Docker Hub for use on CircleCI 2.0
+
+### Launch Logged-In Window
+To facilitate manual testing, the [launch-wpcom-login.js](/scripts/launch-wpcom-login.js) file in `/scripts` will launch a Chrome browser window to WordPress.com and log in with the account definition given on the command line.  The only config requirement for this is that the `local-${NODE_ENV}.json` file needs to have the `testAccounts` object defined.  If no account is given on the command line, `defaultUser` will be used.
+
+Example:
+```bash
+./node_modules/.bin/babel-node scripts/launch-wpcom-login.js multiSiteUser
+```

--- a/scripts/launch-wpcom-login.js
+++ b/scripts/launch-wpcom-login.js
@@ -1,0 +1,14 @@
+import * as driverManager from '../lib/driver-manager.js';
+
+import LoginFlow from '../lib/flows/login-flow.js';
+
+const driver = driverManager.startBrowser();
+var accountName = 'defaultUser';
+
+// Look for command line arguments
+if ( process.argv.length > 1 ) {
+	accountName = process.argv[2];
+}
+
+let loginFlow = new LoginFlow( driver, accountName );
+loginFlow.login();


### PR DESCRIPTION
To assist in manual testing, this adds a script that launches a browser window logged in to WordPress.com.  Details are in the README.