### PR TITLE
Use non-zero return code when usage data is printed

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -58,7 +58,7 @@ usage () {
 -u [baseUrl]	  - Override the calypsoBaseURL config
 -h		  - This help listing
 EOF
-  exit 0
+  exit 1
 }
 
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
When the `run.sh` script prints out the usage data (e.g. when an invalid argument is used), the script now uses a non-zero return code to indicate that the test wasn't actually successful.

This will prevent CI from indicating that a test passed when in fact it failed to run, for example: https://circleci.com/gh/Automattic/wp-e2e-tests-i18n/215

cc @hoverduck 