### PR TITLE
Updates to Jetpack config scripts, magellan config

### DIFF
--- a/magellan-jetpack.json
+++ b/magellan-jetpack.json
@@ -5,7 +5,7 @@
   ],
   "mocha_opts": "test/mocha.opts",
   "mocha_args": "-R spec-xunit-reporter",
-  "max_test_attempts": 2,
+  "max_test_attempts": 3,
   "max_workers": 3,
   "suiteTag": "jetpack",
   "sauce": false,

--- a/scripts/jetpack/git-jetpack.sh
+++ b/scripts/jetpack/git-jetpack.sh
@@ -3,18 +3,18 @@ export APP_NAME=$1
 if [ "$APP_NAME" == "" ]; then
   echo "Please supply app directory name!"
   exit 1
-elif [ ! -d apps/$APP_NAME ]; then
+elif [ ! -d apps/$APP_NAME/public/wp-content/plugins ]; then
   # Wait up to 30 seconds for app to be created
-  echo "App directory apps/$APP_NAME does not exist, waiting..."
+  echo "App directory apps/$APP_NAME/public/wp-content/plugins does not exist, waiting..."
   sleep 10
-  if [ ! -d apps/$APP_NAME ]; then
-    echo "App directory apps/$APP_NAME does not exist, waiting..."
+  if [ ! -d apps/$APP_NAME/public/wp-content/plugins ]; then
+    echo "App directory apps/$APP_NAME/public/wp-content/plugins does not exist, waiting..."
     sleep 10
     if [ ! -d apps/$APP_NAME ]; then
-      echo "App directory apps/$APP_NAME does not exist, waiting..."
+      echo "App directory apps/$APP_NAME/public/wp-content/plugins does not exist, waiting..."
       sleep 10
       if [ ! -d apps/$APP_NAME ]; then
-        echo "App directory apps/$APP_NAME does not exist after 30s, quitting!"
+        echo "App directory apps/$APP_NAME/public/wp-content/plugins does not exist after 30s, quitting!"
         exit 1
       fi
     fi
@@ -23,7 +23,6 @@ fi
 echo "App directory apps/$APP_NAME found!  Installing Jetpack..."
 
 # Refresh jetpack in home directory and copy it into the site
-mkdir -p apps/$APP_NAME/public/wp-content/plugins
 cp -a jetpack apps/$APP_NAME/public/wp-content/plugins
 cd apps/$APP_NAME/public/wp-content/plugins/jetpack
 git checkout master && git pull


### PR DESCRIPTION
1) Update the directory path that we're checking for when installing Jetpack on DO via ServerPilot, hopefully that eliminates what I suspect was a timing race causing initialization failures
2) Increase the magellan attempts for Jetpack tests to 3 to combat general flakiness in other hosting providers.