### PR TITLE
Add override for upcoming privacy no pop-up AB test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -57,10 +57,11 @@
     }
   },
   "httpsHosts": [ "WPCOM", "PRESSABLE" ],
-  "knownABTestKeys": [ "multiDomainRegistrationV1", "signupSurveyStep", "presaleChatButton", "businessPlanDescriptionAT", "newSiteWithJetpack", "signupPlansCopyChanges", "postPublishConfirmation", "readerIntroIllustration", "paymentShowPaypalLogo", "jetpackConnectPlansCopyChanges", "postSignupUpgradeScreen" ],
+  "knownABTestKeys": [ "multiDomainRegistrationV1", "signupSurveyStep", "presaleChatButton", "businessPlanDescriptionAT", "newSiteWithJetpack", "signupPlansCopyChanges", "postPublishConfirmation", "readerIntroIllustration", "paymentShowPaypalLogo", "jetpackConnectPlansCopyChanges", "postSignupUpgradeScreen", "privacyNoPopup" ],
   "overrideABTests": [
 	[ "signupSurveyStep_20170329", "hideSurveyStep" ],
 	[ "signupPlansCopyChanges_20170623", "modified" ],
-	[ "postPublishConfirmation_20170801", "noPublishConfirmation" ]
+	[ "postPublishConfirmation_20170801", "noPublishConfirmation" ],
+	[ "privacyNoPopup_20170829", "original" ]
   ]
 }


### PR DESCRIPTION
Sets the e2e tests to use the original privacy group (checkbox with pop-up)

See: https://github.com/Automattic/wp-calypso/pull/17559/