### PR TITLE
The signup specs run against calypso.localhost again

### DIFF
--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -186,6 +186,8 @@ export function deleteLocalStorage( driver ) {
 
 export function ensureNotLoggedIn( driver ) {
 	// This makes sure neither auth domain or local domain has any cookies or local storage
+	driver.get( 'https://wordpress.com' );
+	this.clearCookiesAndDeleteLocalStorage( driver );
 	driver.get( config.get( 'calypsoBaseURL' ) );
 	return this.clearCookiesAndDeleteLocalStorage( driver );
 }

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -186,9 +186,13 @@ export function deleteLocalStorage( driver ) {
 
 export function ensureNotLoggedIn( driver ) {
 	// This makes sure neither auth domain or local domain has any cookies or local storage
-	driver.get( 'https://wordpress.com' );
-	this.clearCookiesAndDeleteLocalStorage( driver );
-	driver.get( config.get( 'calypsoBaseURL' ) );
+	const calypsoURL = config.get( 'calypsoBaseURL' );
+	const wordPressDotComURL = 'https://wordpress.com';
+	if ( calypsoURL !== wordPressDotComURL ) {
+		driver.get( wordPressDotComURL );
+		this.clearCookiesAndDeleteLocalStorage( driver );
+	}
+	driver.get( calypsoURL );
 	return this.clearCookiesAndDeleteLocalStorage( driver );
 }
 


### PR DESCRIPTION
We weren't clearing cookies for WordPress.com which meant subsquent scenarios would remain logged in