### PR TITLE
Revert "Remove support for DISABLE_EMAIL flag"

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ These environment variables are intended for use inside CircleCI, to control whi
 
 | Name | Description | Default | Required |
 | ---- | ----------- | ------- | -------- |
+| DISABLE_EMAIL | Setting this to `true` will cause the Invite and Signup tests to be skipped | false | No |
 | SKIP_TEST_REGEX | The value of this variable will be used in the `-i -g *****` parameter, to skip any tests that match the given RegEx.  List multiple keywords separated by a `|` (i.e. `Invite|Domain|Theme`) | `Empty String` | No |
 
 ### Jetpack Tests on CircleCI

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -16,6 +16,9 @@ if [ "$CIRCLE_NODE_INDEX" == "0" ]; then
   if [ "$SKIP_TEST_REGEX" != "" ]; then
     ./node_modules/.bin/babel-node --presets es2015 lib/slack-ping-cli.js "Attention! Tests are being skipped with pattern [$SKIP_TEST_REGEX]"
   fi
+  if [ "$DISABLE_EMAIL" == "true" ]; then
+    ./node_modules/.bin/babel-node --presets es2015 lib/slack-ping-cli.js "WARNING::: Any test that uses email is currently disabled as DISABLE_EMAIL is set to true"
+  fi
 fi
 
 if [ "$NODE_ENV_OVERRIDE" != "" ]; then

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -40,7 +40,13 @@ test.before( function() {
 	driver = driverManager.startBrowser();
 } );
 
-test.describe( `[${host}] Invites:  (${screenSize})`, function() {
+// Faked out test.describe function to enable dynamic skipping of e-mail tests
+let testDescribe = test.describe;
+if ( process.env.DISABLE_EMAIL === 'true' ) {
+	testDescribe = test.xdescribe;
+}
+
+testDescribe( `[${host}] Invites:  (${screenSize})`, function() {
 	this.timeout( mochaTimeOut );
 	const usePublishConfirmation = config.get( 'usePublishConfirmation' );
 

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -39,8 +39,13 @@ test.before( function() {
 	driver = driverManager.startBrowser();
 } );
 
+// Faked out test.describe function to enable dynamic skipping of e-mail tests
+let testDescribe = test.describe;
+if ( process.env.DISABLE_EMAIL === 'true' ) {
+	testDescribe = test.xdescribe;
+}
 
-test.describe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
+testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 	this.timeout( mochaTimeOut );
 
 	test.describe( 'Sign up for a free site @parallel @canary', function() {


### PR DESCRIPTION
Reverts Automattic/wp-e2e-tests#682

@alisterscott / @rachelmcr we can't remove this flag yet because SKIP_TEST_REGEX doesn't work with Magellan.

See #506