### PR TITLE
Use SHA1 hash to identify Jetpack subdomain in CI tests

### DIFF
--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -79,7 +79,7 @@ export function getJetpackSiteName() {
 	const host = this.getJetpackHost();
 
 	if ( host === 'CI' ) {
-		return `${process.env.JP_PREFIX}.wp-e2e-tests.pw`;
+		return `${process.env.CIRCLE_BUILD_NUM}.wp-e2e-tests.pw`;
 	}
 
 	// Other Jetpack site

--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -79,7 +79,7 @@ export function getJetpackSiteName() {
 	const host = this.getJetpackHost();
 
 	if ( host === 'CI' ) {
-		return `${process.env.CIRCLE_BUILD_NUM}.wp-e2e-tests.pw`;
+		return `${process.env.CIRCLE_SHA1}.wp-e2e-tests.pw`;
 	}
 
 	// Other Jetpack site

--- a/scripts/jetpack/wp-serverpilot-init.js
+++ b/scripts/jetpack/wp-serverpilot-init.js
@@ -14,7 +14,7 @@ const userConfig = config.get( 'testAccounts' );
 const username = userConfig.jetpackUserCI[0];
 const password = userConfig.jetpackUserCI[1];
 
-const serverPrefix = process.env.CIRCLE_BUILD_NUM;
+const serverPrefix = process.env.CIRCLE_SHA1;
 
 const serverOptions = {
 	name: `wordpress-${serverPrefix}`,

--- a/scripts/jetpack/wp-serverpilot-init.js
+++ b/scripts/jetpack/wp-serverpilot-init.js
@@ -14,7 +14,7 @@ const userConfig = config.get( 'testAccounts' );
 const username = userConfig.jetpackUserCI[0];
 const password = userConfig.jetpackUserCI[1];
 
-const serverPrefix = process.env.JP_PREFIX;
+const serverPrefix = process.env.CIRCLE_BUILD_NUM;
 
 const serverOptions = {
 	name: `wordpress-${serverPrefix}`,


### PR DESCRIPTION
This should be reliable across Workflow build numbers.