### PR TITLE
Enable Publish Confirmation as Default Behaviour

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -61,7 +61,7 @@
   "overrideABTests": [
 	[ "signupSurveyStep_20170329", "hideSurveyStep" ],
 	[ "postPublishConfirmation_20170801", "showPublishConfirmation" ],
-	[ "privacyNoPopup_20170829", "original" ]
+	[ "privacyNoPopup_20170830", "original" ],
 	[ "skipThemesSelectionModal_20170830", "show" ]
   ]
 }

--- a/config/default.json
+++ b/config/default.json
@@ -15,7 +15,7 @@
   "checkForConsoleErrors": false,
   "reportWarningsToSlack": false,
   "closeBrowserOnComplete": true,
-  "usePublishConfirmation": false,
+  "usePublishConfirmation": true,
   "sauceConfigurations": {
     "osx-chrome": {
         "browserName": "chrome",
@@ -60,7 +60,7 @@
   "knownABTestKeys": [ "multiDomainRegistrationV1", "signupSurveyStep", "presaleChatButton", "businessPlanDescriptionAT", "newSiteWithJetpack", "postPublishConfirmation", "readerIntroIllustration", "paymentShowPaypalLogo", "jetpackConnectPlansCopyChanges", "postSignupUpgradeScreen", "privacyNoPopup" ],
   "overrideABTests": [
 	[ "signupSurveyStep_20170329", "hideSurveyStep" ],
-	[ "postPublishConfirmation_20170801", "noPublishConfirmation" ],
+	[ "postPublishConfirmation_20170801", "showPublishConfirmation" ],
 	[ "privacyNoPopup_20170829", "original" ]
   ]
 }


### PR DESCRIPTION
Sets the flag and AB test override to use the publish confirmation step as default - this will soon be the default for all users

See: https://github.com/Automattic/wp-calypso/pull/17655