### PR TITLE
Add i18n support to all tests in signup spec

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -71,7 +71,7 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 			stepNum++;
 
 			test.it( 'Can see the design type choice page', function() {
-				this.startPage = new StartPage( driver, { visit: true } );
+				this.startPage = new StartPage( driver, { visit: true, culture: locale } );
 				this.designTypeChoicePage = new DesignTypeChoicePage( driver );
 				return this.designTypeChoicePage.displayed().then( ( displayed ) => {
 					return assert.equal( displayed, true, 'The design type choice page is not displayed' );
@@ -182,11 +182,13 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 										} );
 									} );
 
-									test.it( 'Can see the correct blog title displayed', function() {
-										return this.viewBlogPage.title().then( ( title ) => {
-											return assert.equal( title, 'Site Title', 'The expected blog title is not displaying correctly' );
+									if ( locale === 'en' ) {
+										test.it( 'Can see the correct blog title displayed', function() {
+											return this.viewBlogPage.title().then( ( title ) => {
+												return assert.equal( title, 'Site Title', 'The expected blog title is not displaying correctly' );
+											} );
 										} );
-									} )
+									}
 								} );
 							} );
 						} );
@@ -374,7 +376,7 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 		} );
 
 		test.it( 'We can set the sandbox cookie for payments', function() {
-			this.WPHomePage = new WPHomePage( driver, { visit: true } );
+			this.WPHomePage = new WPHomePage( driver, { visit: true, culture: locale } );
 			return this.WPHomePage.setSandboxModeForPayments( sandboxCookieValue );
 		} );
 
@@ -382,7 +384,7 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 			stepNum++;
 
 			test.it( 'Can see the design type choice page', function() {
-				this.startPage = new StartPage( driver, { visit: true, flow: 'premium' } );
+				this.startPage = new StartPage( driver, { visit: true, culture: locale, flow: 'premium' } );
 				this.designTypeChoicePage = new DesignTypeChoicePage( driver );
 				return this.designTypeChoicePage.displayed().then( ( displayed ) => {
 					return assert.equal( displayed, true, 'The design type choice page is not displayed' );
@@ -663,7 +665,7 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 			stepNum++;
 
 			test.it( 'When we visit the start URL we see the survey page', function() {
-				this.startPage = new StartPage( driver, { visit: true, flow: 'surveystep' } );
+				this.startPage = new StartPage( driver, { visit: true, culture: locale, flow: 'surveystep' } );
 				this.surveyPage = new SurveyPage( driver );
 				return this.surveyPage.displayed().then( ( displayed ) => {
 					return assert.equal( displayed, true, 'The survey starting page is not displayed' );
@@ -788,11 +790,13 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 											} );
 										} );
 
-										test.it( 'Can see the correct blog title displayed', function() {
-											return this.viewBlogPage.title().then( ( title ) => {
-												return assert.equal( title, 'Site Title', 'The expected blog title is not displaying correctly' );
+										if ( locale === 'en' ) {
+											test.it( 'Can see the correct blog title displayed', function() {
+												return this.viewBlogPage.title().then( ( title ) => {
+													return assert.equal( title, 'Site Title', 'The expected blog title is not displaying correctly' );
+												} );
 											} );
-										} );
+										}
 
 										test.describe( `Step ${stepNum}: Can not publish until email is confirmed`, function() {
 											stepNum++;


### PR DESCRIPTION
Fixes #673

This PR adds i18n support to all the tests in the signup spec. Since the i18n screenshot tests run on the signup canary tests, this ensures those tests will run as expected even when we switch which signup tests are used as canaries.

## To Test:

1. Run the i18n screenshot tests with `./run.sh -i` and confirm they pass.
2. Set your browser locale to a non-English language, e.g. with `export BROWSERLOCALE='es'`.
3. Run the full signup spec with `./node_modules/.bin/mocha specs/wp-signup-spec.js` and confirm all signup tests pass in a non-English locale.