### PR TITLE
Add checking for error messages on all pages

### DIFF
--- a/lib/base-container.js
+++ b/lib/base-container.js
@@ -9,7 +9,7 @@ import * as slackNotifier from './slack-notifier';
 
 
 export default class BaseContainer {
-	constructor( driver, expectedElementSelector, visit = false, url = null, checkErrorsWarnings = true ) {
+	constructor( driver, expectedElementSelector, visit = false, url = null, checkErrors = true, checkWarnings = true ) {
 		this.screenSize = driverManager.currentScreenSize().toUpperCase();
 		this.explicitWaitMS = config.get( 'explicitWaitMS' );
 		this.driver = driver;
@@ -21,8 +21,8 @@ export default class BaseContainer {
 		this.waitForPage();
 		this.checkForUnknownABTestKeys();
 		this.checkForConsoleErrors();
-		this.checkForGlobalErrors( { reportErrors: checkErrorsWarnings } );
-		this.checkForGlobalWarnings( { reportWarnings: checkErrorsWarnings } );
+		this.checkForGlobalErrors( { reportErrors: checkErrors } );
+		this.checkForGlobalWarnings( { reportWarnings: checkWarnings } );
 	}
 
 	takeScreenShot( screenName = '' ) {

--- a/lib/base-container.js
+++ b/lib/base-container.js
@@ -1,5 +1,6 @@
 import config from 'config';
 import assert from 'assert';
+import { By as by } from 'selenium-webdriver';
 
 import * as driverManager from './driver-manager';
 import * as driverHelper from './driver-helper';
@@ -8,7 +9,7 @@ import * as slackNotifier from './slack-notifier';
 
 
 export default class BaseContainer {
-	constructor( driver, expectedElementSelector, visit = false, url = null ) {
+	constructor( driver, expectedElementSelector, visit = false, url = null, checkErrorsWarnings = true ) {
 		this.screenSize = driverManager.currentScreenSize().toUpperCase();
 		this.explicitWaitMS = config.get( 'explicitWaitMS' );
 		this.driver = driver;
@@ -20,6 +21,8 @@ export default class BaseContainer {
 		this.waitForPage();
 		this.checkForUnknownABTestKeys();
 		this.checkForConsoleErrors();
+		this.checkForGlobalErrors( { reportErrors: checkErrorsWarnings } );
+		this.checkForGlobalWarnings( { reportWarnings: checkErrorsWarnings } );
 	}
 
 	takeScreenShot( screenName = '' ) {
@@ -93,5 +96,43 @@ export default class BaseContainer {
 		} );
 
 		return this.waitForPage();
+	}
+
+	checkForGlobalErrors( { reportErrors = true } = {} ) {
+		const errorSelector = by.css( '.notice.is-error' );
+		const self = this;
+		if ( reportErrors === true ) {
+			driverHelper.isElementPresent( self.driver, errorSelector ).then( ( present ) => {
+				if ( present === true ) {
+					self.driver.findElement( errorSelector ).getText().then( ( errorText ) => {
+						self.driver.getCurrentUrl().then( ( url ) => {
+							slackNotifier.warn( `Found an error message '${ errorText }' on page: ${ url }` );
+						} );
+						return errorText
+					} );
+				}
+				return '';
+			} );
+		}
+		return '';
+	}
+
+	checkForGlobalWarnings( { reportWarnings = true } = {} ) {
+		const errorSelector = by.css( '.notice.is-warning' );
+		const self = this;
+		if ( reportWarnings === true ) {
+			driverHelper.isElementPresent( self.driver, errorSelector ).then( ( present ) => {
+				if ( present === true ) {
+					self.driver.findElement( errorSelector ).getText().then( ( errorText ) => {
+						self.driver.getCurrentUrl().then( ( url ) => {
+							slackNotifier.warn( `Found a warning message '${ errorText }' on page: ${ url }` );
+						} );
+						return errorText
+					} );
+				}
+				return '';
+			} );
+		}
+		return '';
 	}
 }

--- a/lib/pages/devdocs/devdocs-notices-page.js
+++ b/lib/pages/devdocs/devdocs-notices-page.js
@@ -1,0 +1,10 @@
+import webdriver from 'selenium-webdriver';
+import BaseContainer from '../../base-container.js';
+
+const by = webdriver.By;
+
+export default class DevdocsPage extends BaseContainer {
+	constructor( driver, visit ) {
+		super( driver, by.css( '.notice' ), visit, 'https://wpcalypso.wordpress.com/devdocs/design/notices', false );
+	}
+}

--- a/lib/pages/devdocs/devdocs-notices-page.js
+++ b/lib/pages/devdocs/devdocs-notices-page.js
@@ -5,6 +5,6 @@ const by = webdriver.By;
 
 export default class DevdocsPage extends BaseContainer {
 	constructor( driver, visit ) {
-		super( driver, by.css( '.notice' ), visit, 'https://wpcalypso.wordpress.com/devdocs/design/notices', false );
+		super( driver, by.css( '.notice' ), visit, 'https://wpcalypso.wordpress.com/devdocs/design/notices', false, false );
 	}
 }

--- a/lib/pages/signup/checkout-thankyou-page.js
+++ b/lib/pages/signup/checkout-thankyou-page.js
@@ -6,7 +6,7 @@ import * as driverHelper from '../../driver-helper.js';
 
 export default class CheckOutThankyouPage extends BaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.checkout-thank-you' ) );
+		super( driver, By.css( '.checkout-thank-you' ), false, null, true, false );
 	}
 	clickMySite() {
 		return driverHelper.clickWhenClickable( this.driver, By.css( '.my-sites a' ) );

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -676,7 +676,7 @@ testDescribe( `[${host}] Invites:  (${screenSize})`, function() {
 									this.navbarComponent.dismissGuidedTours();
 									this.navbarComponent.clickCreateNewPost();
 									this.editorPage = new EditorPage( driver );
-									this.driver.getCurrentUrl().then( ( urlDisplayed ) => {
+									driver.getCurrentUrl().then( ( urlDisplayed ) => {
 										return this.editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
 									} );
 									this.editorPage.enterTitle( reviewPostTitle );

--- a/specs/wp-log-in-out-spec.js
+++ b/specs/wp-log-in-out-spec.js
@@ -8,6 +8,7 @@ import * as dataHelper from '../lib/data-helper';
 import ReaderPage from '../lib/pages/reader-page';
 import ProfilePage from '../lib/pages/profile-page';
 import WPHomePage from '../lib/pages/wp-home-page';
+import DevDocsNoticesPage from '../lib/pages/devdocs/devdocs-notices-page';
 
 import NavbarComponent from '../lib/components/navbar-component.js';
 import LoggedOutMasterbarComponent from '../lib/components/logged-out-masterbar-component'
@@ -98,5 +99,26 @@ test.describe( `[${host}] User Agent: (${screenSize}) @parallel @jetpack`, funct
 		driver.executeScript( 'return navigator.userAgent;' ).then( ( userAgent ) => {
 			assert( userAgent.match( 'wp-e2e-tests' ), `User Agent does not contain 'wp-e2e-tests'.  [${userAgent}]` );
 		} );
+	} );
+} );
+
+test.describe( `[${host}] Can check for errors and warnings on every page: (${screenSize}) @parallel`, function() {
+	this.timeout( mochaTimeOut );
+	this.bailSuite( true );
+
+	test.before( function() {
+		driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		const loginFlow = new LoginFlow( driver );
+		return loginFlow.login();
+	} );
+
+	test.it( 'Login and check dev docs for error message', function() {
+		const devDocsNoticesPage = new DevDocsNoticesPage( driver, true );
+		return devDocsNoticesPage.checkForGlobalErrors( { reportErrors: false } );
+	} );
+
+	test.it( 'Login and check dev docs for warning message', function() {
+		const devDocsNoticesPage = new DevDocsNoticesPage( driver, true );
+		return devDocsNoticesPage.checkForGlobalWarnings( { reportWarnings: false } );
 	} );
 } );


### PR DESCRIPTION
This adds a check to every page to make sure that neither an error nor a warning appears:

<img width="406" alt="screen shot 2017-09-13 at 1 18 52 pm" src="https://user-images.githubusercontent.com/128826/30358149-1eb1a9f6-9886-11e7-8e5e-1ac0f776e20d.png">

If it does, it gives us a Slack warning.

The problem is this seems to double to execution time in CircleCI.

@hoverduck @rachelmcr is this worth it for slowing things down drastically?

See #711 for some context (which ended up being a false alert)