### PR TITLE
Check publicize defaults to empty message

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -110,6 +110,10 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 		return this.driver.findElement( this.publicizeMessageSelector ).getAttribute( 'placeholder' );
 	}
 
+	publicizeMessageDisplayed() {
+		return this.driver.findElement( this.publicizeMessageSelector ).getAttribute( 'value' );
+	}
+
 	setPublicizeMessage( message ) {
 		return driverHelper.setWhenSettable( this.driver, this.publicizeMessageSelector, message );
 	}

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -128,8 +128,8 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 
 							test.it( 'Can see the default publicise message', function() {
 								let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
-								postEditorSidebarComponent.publicizeMessagePlaceholder().then( function( placeholderDisplayed ) {
-									assert.equal( placeholderDisplayed, blogPostTitle, 'The placeholder for publicize is not equal to the blog post title. Placeholder: \'' + placeholderDisplayed + '\', Title: \'' + blogPostTitle + '\'' );
+								postEditorSidebarComponent.publicizeMessageDisplayed().then( function( messageDisplayed ) {
+									assert.equal( messageDisplayed, '', 'The publicize message is not defaulting to empty' );
 								} );
 							} );
 


### PR DESCRIPTION
Change introduced here: https://github.com/Automattic/wp-calypso/pull/18028

We won't assert on the content of the placeholder as that is localised (we can't be assured of it being in English)