### PR TITLE
Update the editor sidebar accordion selectors to utilise data attributes

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -24,27 +24,27 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 	}
 
 	expandCategoriesAndTags() {
-		return this._expandOrCollapseSection( 'categories-tags__accordion', true );
+		return this._expandOrCollapseSection( 'categories-tags', true );
 	}
 
 	closeCategoriesAndTags() {
-		return this._expandOrCollapseSection( 'categories-tags__accordion', false );
+		return this._expandOrCollapseSection( 'categories-tags', false );
 	}
 
 	expandSharingSection() {
-		return this._expandOrCollapseSection( 'sharing__accordion', true );
+		return this._expandOrCollapseSection( 'sharing', true );
 	}
 
 	closeSharingSection() {
-		return this._expandOrCollapseSection( 'sharing__accordion', false );
+		return this._expandOrCollapseSection( 'sharing', false );
 	}
 
 	expandMoreOptions() {
-		return this._expandOrCollapseSection( 'drawer__more-options', true );
+		return this._expandOrCollapseSection( 'more-options', true );
 	}
 
 	closeMoreOptions() {
-		return this._expandOrCollapseSection( 'drawer__more-options', false );
+		return this._expandOrCollapseSection( 'more-options', false );
 	}
 
 	expandFeaturedImage() {
@@ -175,28 +175,17 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 	}
 
 	_expandOrCollapseSection( sectionName, expand = true ) {
-		let headerSelector;
-		let toggleSelector;
-		if ( sectionName === 'status' ) {
-			headerSelector = By.css( 'div.accordion' );
-			toggleSelector = By.css( 'div.accordion button.accordion__toggle' );
-		} else if ( sectionName === 'featured-image' ) {
-			headerSelector = By.css( `div[data-e2e-title="${sectionName}"]` );
-			toggleSelector = By.css( `div[data-e2e-title="${sectionName}"] button.accordion__toggle` );
-		} else {
-			headerSelector = By.css( `div.editor-${sectionName}` );
-			toggleSelector = By.css( `div.editor-${sectionName} button.accordion__toggle` );
-		}
-		const explicitWaitMS = this.explicitWaitMS;
+		const headerSelector = By.css( `div[data-e2e-title="${sectionName}"]` );
+		const toggleSelector = By.css( `div[data-e2e-title="${sectionName}"] button.accordion__toggle` );
 		const driver = this.driver;
 
-		driver.wait( until.elementLocated( headerSelector ), explicitWaitMS, `Could not locate the toggle to open/close: '${sectionName}'` );
+		driverHelper.waitTillPresentAndDisplayed( driver, headerSelector );
 		return driver.findElement( headerSelector ).getAttribute( 'class' ).then( function( c ) {
 			if ( expand && c.indexOf( 'is-expanded' ) < 0 ) {
-				return driverHelper.clickWhenClickable( driver, toggleSelector, explicitWaitMS );
+				return driverHelper.clickWhenClickable( driver, toggleSelector );
 			}
 			if ( !expand && c.indexOf( 'is-expanded' ) > -1 ) {
-				return driverHelper.clickWhenClickable( driver, toggleSelector, explicitWaitMS );
+				return driverHelper.clickWhenClickable( driver, toggleSelector );
 			}
 		} );
 	}


### PR DESCRIPTION
This utilises the data attributes I recently added in https://github.com/Automattic/wp-calypso/pull/18065