### PR TITLE
Switch privacy protection from checkbox to radio button

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -56,11 +56,10 @@
     }
   },
   "httpsHosts": [ "WPCOM", "PRESSABLE" ],
-  "knownABTestKeys": [ "multiDomainRegistrationV1", "signupSurveyStep", "presaleChatButton", "businessPlanDescriptionAT", "newSiteWithJetpack", "postPublishConfirmation", "readerIntroIllustration", "paymentShowPaypalLogo", "jetpackConnectPlansCopyChanges", "postSignupUpgradeScreen", "privacyNoPopup", "skipThemesSelectionModal" ],
+  "knownABTestKeys": [ "multiDomainRegistrationV1", "signupSurveyStep", "presaleChatButton", "businessPlanDescriptionAT", "newSiteWithJetpack", "postPublishConfirmation", "readerIntroIllustration", "paymentShowPaypalLogo", "jetpackConnectPlansCopyChanges", "postSignupUpgradeScreen", "skipThemesSelectionModal" ],
   "overrideABTests": [
 	[ "signupSurveyStep_20170329", "hideSurveyStep" ],
 	[ "postPublishConfirmation_20170801", "showPublishConfirmation" ],
-	[ "privacyNoPopup_20170830", "original" ],
 	[ "skipThemesSelectionModal_20170830", "show" ]
   ]
 }

--- a/lib/pages/signup/checkout-page.js
+++ b/lib/pages/signup/checkout-page.js
@@ -14,7 +14,7 @@ export default class CheckOutPage extends BaseContainer {
 		driverHelper.setWhenSettable( this.driver, By.id( 'last-name' ), lastName );
 		driverHelper.setWhenSettable( this.driver, By.id( 'email' ), domainEmailAddress );
 
-		driverHelper.clickWhenClickable( this.driver, By.css( `select.phone-input__country-select option[value="${countryCode}"]` ));
+		driverHelper.clickWhenClickable( this.driver, By.css( `select.phone-input__country-select option[value="${countryCode}"]` ) );
 
 		driverHelper.setWhenSettable( this.driver, By.css( 'input[name="phone"]' ), phoneNumber );
 
@@ -29,7 +29,8 @@ export default class CheckOutPage extends BaseContainer {
 	}
 
 	selectAddPrivacyProtectionCheckbox() {
-		const selector = By.css( 'input#privacyProtectionCheckbox' );
+		// The radio button _should_ be selected by default, but let's click it anyway :)
+		const selector = By.css( 'input#registrantType[value="private"]' );
 		return driverHelper.setCheckbox( this.driver, selector );
 	}
 


### PR DESCRIPTION
PR https://github.com/Automattic/wp-calypso/pull/18254 removed the AB test `privacyNoPopup`, leading to a new UI on the domain checkout page with radio buttons instead of a checkbox.