### PR TITLE
Update Free plan selector for Jetpack Connect

### DIFF
--- a/lib/pages/signup/pick-a-plan-page.js
+++ b/lib/pages/signup/pick-a-plan-page.js
@@ -23,6 +23,11 @@ export default class PickAPlanPage extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	selectFreePlan() {
+		// Jetpack connect no longer displays the Free plan, so we have to click the "Skip" button
+		if ( host !== 'WPCOM' ) {
+			return driverHelper.clickWhenClickable( this.driver, By.css( '.jetpack-connect__plans-nav-buttons button' ) );
+		}
+
 		return this._selectPlan( 'free' );
 	}
 	selectPersonalPlan() {


### PR DESCRIPTION
The Jetpack plans page no longer shows the card for the Free plan, instead offering a "Skip" button at the bottom of the page.