### PR TITLE
Add pre commit hook validate circle config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Automated end-to-end acceptance tests for the [wp-calypso](https://github.com/Au
   - [CircleCI Environment Variables](#circleci-environment-variables)
   - [Jetpack Tests on CircleCI](#jetpack-tests-on-circleci)
 - [NodeJS Version](#nodejs-version)
+- [Git Pre-Commit Hook](#git-pre-commit-hook)
 - [Launch Logged-In Window](#launch-logged-in-window)
 
 
@@ -225,6 +226,9 @@ The scripts in the `scripts/jetpack` directory are designed to build/configure a
 
 ### NodeJS Version
 The node version should be defined in the `.nvmrc` file for use with the [nvm](https://github.com/creationix/nvm) project.  When changing the version a new Docker container should be built/pushed to Docker Hub for use on CircleCI 2.0
+
+### Git Pre-Commit Hook
+The file `/scripts/git-pre-commit-circleci-validate` will run `circleci validate` against the CircleCI config file prior to every commit.  This prevents the constant back-and-forth when making updates only to find that they fail immediately on CI.  Instructions in the file direct how to install the hook in your local Git environment (it won't run without this).
 
 ### Launch Logged-In Window
 To facilitate manual testing, the [launch-wpcom-login.js](/scripts/launch-wpcom-login.js) file in `/scripts` will launch a Chrome browser window to WordPress.com and log in with the account definition given on the command line.  The only config requirement for this is that the `local-${NODE_ENV}.json` file needs to have the `testAccounts` object defined.  If no account is given on the command line, `defaultUser` will be used.

--- a/scripts/git-pre-commit-circleci-validate
+++ b/scripts/git-pre-commit-circleci-validate
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# This is a pre-commit hook to validate the CircleCI config file prior to committing changes
+#  -- To enable:
+#    - 1) Download the CircleCI CLI - https://circleci.com/docs/2.0/local-jobs/#installing-the-cli-locally
+#    - 2) Symlink the file into .git/hooks/pre-commit
+# Inspired by (i.e stolen from) https://circleci.com/blog/circleci-hacks-validate-circleci-config-on-every-commit-with-a-git-hook/
+
+# The following line is needed by the CircleCI Local Build Tool (due to Docker interactivity)
+exec < /dev/tty
+
+# If validation fails, tell Git to stop and provide error message. Otherwise, continue.
+if ! eMSG=$(circleci config validate -c .circleci/config.yml); then
+	echo "CircleCI Configuration Failed Validation."
+	echo $eMSG
+	exit 1
+fi


### PR DESCRIPTION
This idea came out of this post on the CircleCI blog - https://circleci.com/blog/circleci-hacks-validate-circleci-config-on-every-commit-with-a-git-hook/

Any time I'm making updates to the CircleCI config I always have a bunch of ridiculous commits to get the config file syntax right, forgetting to validate it ahead of time.  This PR adds a script that can be linked in to run pre-commit to validate the config file.