### PR TITLE
Move Eyes visdiff code into helper class

### DIFF
--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -1,9 +1,7 @@
 import webdriver from 'selenium-webdriver';
 import config from 'config';
-import * as driverManager from './driver-manager.js';
 import {forEach} from 'lodash';
 import * as SlackNotifier from './slack-notifier.js';
-import * as mediaHelper from './media-helper';
 
 const explicitWaitMS = config.get( 'explicitWaitMS' );
 const by = webdriver.By;
@@ -233,33 +231,6 @@ export function checkForConsoleErrors( driver ) {
 			}
 		} );
 	}
-}
-
-export function eyesScreenshot( driver, eyes, pageName, selector ) {
-	let browserName = global.browserName || 'chrome';
-	console.log( `eyesScreenshot - ${pageName} - [${browserName}][${driverManager.currentScreenSize()}]` );
-
-	if ( process.env.EYESDEBUG ) {
-		return driver.takeScreenshot().then( ( data ) => {
-			mediaHelper.writeScreenshot( data, `EYES-${pageName}-${driverManager.currentScreenSize()}` );
-		} );
-	}
-
-	// Remove focus to avoid blinking cursors in input fields
-	// -- Works in Firefox, but not Chrome, at least on OSX I believe due to a
-	// lack of "raw WebKit events".  It may work on Linux with CircleCI
-	return driver.executeScript( 'document.activeElement.blur()' ).then( function() {
-		if ( selector ) {
-			// If this is a webdriver.By selector
-			if ( selector.using ) {
-				return eyes.checkRegionBy( selector, pageName );
-			}
-
-			return eyes.checkRegionByElement( selector, pageName );
-		}
-
-		return eyes.checkWindow( pageName );
-	} );
 }
 
 export function ensureMobileMenuOpen( driver ) {

--- a/lib/eyes-helper.js
+++ b/lib/eyes-helper.js
@@ -1,0 +1,75 @@
+import assert from 'assert';
+import config from 'config';
+import * as driverManager from './driver-manager.js';
+import * as mediaHelper from './media-helper';
+import * as slackNotifier from '../lib/slack-notifier';
+
+export function eyesOpen( driver, eyes, testEnvironment, testName ) {
+	let screenSize = driverManager.getSizeAsObject();
+	let batchName = '';
+	if ( process.env.CIRCLE_BUILD_NUM ) {
+		batchName = `wp-e2e-tests-visdiff [${global.browserName}] #${process.env.CIRCLE_BUILD_NUM}`
+	}
+
+	if ( batchName !== '' ) {
+		eyes.setBatch( batchName, `wp-e2e-tests-visdiff-${global.browserName}-${process.env.CIRCLE_BUILD_NUM}` );
+	}
+
+	if ( ! process.env.EYESDEBUG ) {
+		eyes.open( driver, testEnvironment, testName, screenSize );
+	}
+}
+
+export function eyesClose( eyes ) {
+	if ( ! process.env.EYESDEBUG ) {
+		try {
+			eyes.close( false ).then( function( testResults ) {
+				let message = '';
+
+				if ( testResults.mismatches ) {
+					message = `<!subteam^S0G7K98MB|flow-patrol-squad-team> Visual diff failed with ${testResults.mismatches} mismatches - ${testResults.appUrls.session}`;
+				} else if ( testResults.missing ) {
+					message = `<!subteam^S0G7K98MB|flow-patrol-squad-team> Visual diff failed with ${testResults.missing} missing steps out of ${testResults.steps} - ${testResults.appUrls.session}`;
+				} else if ( testResults.isNew ) {
+					message = `<!subteam^S0G7K98MB|flow-patrol-squad-team> Visual diff marked as failed because it is a new baseline - ${testResults.appUrls.session}`;
+				}
+
+				if ( message !== '' ) {
+					slackNotifier.warn( message );
+					if ( config.has( 'failVisdiffs' ) && config.get( 'failVisdiffs' ) ) {
+						assert( false, message );
+					}
+				}
+			} );
+		} finally {
+			eyes.abortIfNotClosed();
+		}
+	}
+}
+
+export function eyesScreenshot( driver, eyes, pageName, selector ) {
+	let browserName = global.browserName || 'chrome';
+	console.log( `eyesScreenshot - ${pageName} - [${browserName}][${driverManager.currentScreenSize()}]` );
+
+	if ( process.env.EYESDEBUG ) {
+		return driver.takeScreenshot().then( ( data ) => {
+			mediaHelper.writeScreenshot( data, `EYES-${pageName}-${driverManager.currentScreenSize()}` );
+		} );
+	}
+
+	// Remove focus to avoid blinking cursors in input fields
+	// -- Works in Firefox, but not Chrome, at least on OSX I believe due to a
+	// lack of "raw WebKit events".  It may work on Linux with CircleCI
+	return driver.executeScript( 'document.activeElement.blur()' ).then( function() {
+		if ( selector ) {
+			// If this is a webdriver.By selector
+			if ( selector.using ) {
+				return eyes.checkRegionBy( selector, pageName );
+			}
+
+			return eyes.checkRegionByElement( selector, pageName );
+		}
+
+		return eyes.checkWindow( pageName );
+	} );
+}

--- a/lib/pages/devdocs-page.js
+++ b/lib/pages/devdocs-page.js
@@ -1,5 +1,5 @@
 import webdriver from 'selenium-webdriver';
-import { eyesScreenshot } from '../driver-helper.js'
+import { eyesScreenshot } from '../eyes-helper.js'
 import { warn as slackWarn } from '../slack-notifier';
 import { currentScreenSize } from '../driver-manager';
 import BaseContainer from '../base-container.js';

--- a/specs-visdiff/wp-devdocs-visdiff.js
+++ b/specs-visdiff/wp-devdocs-visdiff.js
@@ -1,9 +1,7 @@
 import test from 'selenium-webdriver/testing';
-import assert from 'assert';
 import config from 'config';
 import * as driverManager from '../lib/driver-manager.js';
-import * as driverHelper from '../lib/driver-helper.js';
-import * as slackNotifier from '../lib/slack-notifier';
+import * as eyesHelper from '../lib/eyes-helper.js';
 
 import LoginFlow from '../lib/flows/login-flow.js';
 
@@ -15,7 +13,7 @@ const by = webdriver.By;
 let mochaDevDocsTimeOut = config.get( 'mochaDevDocsTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 
-let driver, screenSize, screenSizeName;
+let driver, screenSizeName;
 screenSizeName = driverManager.currentScreenSize();
 
 let Eyes = require( 'eyes.selenium' ).Eyes;
@@ -26,7 +24,6 @@ eyes.setForceFullPageScreenshot( true );
 test.before( function() {
 	this.timeout( startBrowserTimeoutMS );
 	driver = driverManager.startBrowser( { useCustomUA: false } );
-	screenSize = driverManager.getSizeAsObject();
 } );
 
 test.describe( `DevDocs Visual Diff (${screenSizeName})`, function() {
@@ -35,19 +32,9 @@ test.describe( `DevDocs Visual Diff (${screenSizeName})`, function() {
 
 	test.before( function() {
 		let testName = `DevDocs [${global.browserName}] [${screenSizeName}]`;
+		let testEnvironment = 'WordPress.com';
 
-		let batchName = '';
-		if ( process.env.CIRCLE_BUILD_NUM ) {
-			batchName = `wp-e2e-tests-visdiff [${global.browserName}] #${process.env.CIRCLE_BUILD_NUM}`
-		}
-
-		if ( batchName !== '' ) {
-			eyes.setBatch( batchName, `wp-e2e-tests-visdiff-${global.browserName}-${process.env.CIRCLE_BUILD_NUM}` );
-		}
-
-		if ( ! process.env.EYESDEBUG ) {
-			eyes.open( driver, 'WordPress.com', testName, screenSize );
-		}
+		eyesHelper.eyesOpen( driver, eyes, testEnvironment, testName );
 
 		let loginFlow = new LoginFlow( driver, 'visualUser' );
 		loginFlow.login();
@@ -67,7 +54,7 @@ test.describe( `DevDocs Visual Diff (${screenSizeName})`, function() {
 		devdocsPage.openTypography().then( function() {
 			devdocsPage.hideMasterbar().then( function() {
 				devdocsPage.hideEnvironmentBadge().then( function() {
-					driverHelper.eyesScreenshot( driver, eyes, 'DevDocs Design (Typography)', by.id( 'primary' ) );
+					eyesHelper.eyesScreenshot( driver, eyes, 'DevDocs Design (Typography)', by.id( 'primary' ) );
 				} );
 			} );
 		} );
@@ -81,33 +68,12 @@ test.describe( `DevDocs Visual Diff (${screenSizeName})`, function() {
 	} );
 
 	test.after( function() {
-		try {
-			eyes.close( false ).then( function( testResults ) {
-				let message = '';
-
-				if ( testResults.mismatches ) {
-					message = `<!subteam^S0G7K98MB|flow-patrol-squad-team> Visual diff failed with ${testResults.mismatches} mismatches - ${testResults.appUrls.session}`;
-				} else if ( testResults.missing ) {
-					message = `<!subteam^S0G7K98MB|flow-patrol-squad-team> Visual diff failed with ${testResults.missing} missing steps out of ${testResults.steps} - ${testResults.appUrls.session}`;
-				} else if ( testResults.isNew ) {
-					message = `<!subteam^S0G7K98MB|flow-patrol-squad-team> Visual diff marked as failed because it is a new baseline - ${testResults.appUrls.session}`;
-				}
-
-				if ( message !== '' ) {
-					slackNotifier.warn( message );
-					if ( config.has( 'failVisdiffs' ) && config.get( 'failVisdiffs' ) ) {
-						assert( false, message );
-					}
-				}
-			} );
-		} finally {
-			if ( ! process.env.EYESDEBUG ) {
-				eyes.abortIfNotClosed();
-			}
-		}
+		eyesHelper.eyesClose( eyes );
 	} );
 } );
 
 test.after( function() {
-	eyes.abortIfNotClosed();
+	if ( ! process.env.EYESDEBUG ) {
+		eyes.abortIfNotClosed();
+	}
 } );


### PR DESCRIPTION
Fixes #3 

This PR moves code specific to the Eyes object into `eyes-helper.js` for easy reuse in future visdiff tests.

It also updates the code used in `after` hooks to fix errors when running the tests locally with the `EYESDEBUG` envvar (not calling `eyes.close()` and `eyes. abortIfNotClosed()` since they are not used for those debug test runs).