### PR TITLE
New selector for removing featured image

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -169,7 +169,7 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 	}
 
 	removeFeaturedImage() {
-		const removeButtonSelector = By.css( '[data-e2e-title="featured-image"] .editor-drawer-well__remove' );
+		const removeButtonSelector = By.css( '[data-e2e-title="featured-image"] button.remove-button' );
 		driverHelper.waitTillPresentAndDisplayed( this.driver, removeButtonSelector );
 		return driverHelper.clickWhenClickable( this.driver, removeButtonSelector );
 	}


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/18064 changed the 'remove featured image' button