### PR TITLE
Update DevDocs typography URL

### DIFF
--- a/lib/pages/devdocs-page.js
+++ b/lib/pages/devdocs-page.js
@@ -29,7 +29,7 @@ export default class DevdocsPage extends BaseContainer {
 	}
 
 	openTypography() {
-		var url = this.baseURL + '/design/typography?debug=true';
+		var url = this.baseURL + '/typography?debug=true';
 
 		return this.driver.get( url );
 	}


### PR DESCRIPTION
This PR updates the URL for the Typography section of the DevDocs for our visdiff tests. The URL changed in https://github.com/Automattic/wp-calypso/pull/17942.

The visdiff tests will now screenshot the new URL: https://wpcalypso.wordpress.com/devdocs/typography?debug=true