### PR TITLE
Ensure logged out as commenter before logging in to view comment

### DIFF
--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -177,7 +177,7 @@ export function clearCookiesAndDeleteLocalStorage( driver ) {
 }
 
 export function deleteLocalStorage( driver ) {
-	driver.getCurrentUrl().then( ( url ) => {
+	return driver.getCurrentUrl().then( ( url ) => {
 		if ( url.startsWith( 'data:' ) === false && url !== 'about:blank' ) {
 			return driver.executeScript( 'window.localStorage.clear();' );
 		}

--- a/specs/wp-reader-spec.js
+++ b/specs/wp-reader-spec.js
@@ -57,7 +57,9 @@ test.describe( 'Reader: (' + screenSize + ') @parallel', function() {
 
 			test.describe( 'Delete the new comment', function() {
 				test.before( function() {
-					driverManager.clearCookiesAndDeleteLocalStorage( driver );
+					driverManager.clearCookiesAndDeleteLocalStorage( driver ).then( () => {
+						driver.get( config.get( 'calypsoBaseURL' ) );
+					} );
 				} );
 
 				test.it( 'Can log in as test site owner', function() {


### PR DESCRIPTION
The Reader commenting spec was consistently failing when running against calypso.localhost due to a timing issue in the way we were logging out and then back in.

@rachelmcr / @alisterscott were you seeing this problem, or just me?  Could be just me.