### PR TITLE
Switch canaries from free sign up to two paid sign ups

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -53,7 +53,7 @@ if ( process.env.DISABLE_EMAIL === 'true' ) {
 testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 	this.timeout( mochaTimeOut );
 
-	test.describe( 'Sign up for a free site @parallel @canary', function() {
+	test.describe( 'Sign up for a free site @parallel', function() {
 		this.bailSuite( true );
 		let stepNum = 1;
 
@@ -198,7 +198,7 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 		} );
 	} );
 
-	test.describe( 'Sign up for a site on a premium paid plan through main flow @parallel', function() {
+	test.describe( 'Sign up for a site on a premium paid plan through main flow @parallel @canary', function() {
 		this.bailSuite( true );
 		let stepNum = 1;
 
@@ -491,7 +491,7 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 		} );
 	} );
 
-	test.describe( 'Partially sign up for a site on a business paid plan w/ domain name coming in via /create as business flow @parallel', function() {
+	test.describe( 'Partially sign up for a site on a business paid plan w/ domain name coming in via /create as business flow @parallel @canary', function() {
 		this.bailSuite( true );
 		let stepNum = 1;
 


### PR DESCRIPTION
The paid sign up tests seem to be working fine on wpcalypso now - I'm not sure why though

cc @rachelmcr and @hoverduck  in case we need to revert this and have the free sign ups running as canary tests instead