### PR TITLE
Match http or https when working with Jetpack sites

### DIFF
--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -97,7 +97,7 @@ export function getJetpackSiteName() {
 
 	// Other Jetpack site
 	let siteName = this.getAccountConfig( 'jetpackUser' + host )[2];
-	return siteName.replace( /https?:\/\//, '' ).replace( /\/wp-admin/, '' );
+	return siteName.replace( /^https?:\/\//, '' ).replace( /\/wp-admin/, '' );
 }
 
 export function getTestCreditCardDetails() {

--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -97,7 +97,7 @@ export function getJetpackSiteName() {
 
 	// Other Jetpack site
 	let siteName = this.getAccountConfig( 'jetpackUser' + host )[2];
-	return siteName.replace( /https:\/\//, '' ).replace( /\/wp-admin/, '' );
+	return siteName.replace( /https?:\/\//, '' ).replace( /\/wp-admin/, '' );
 }
 
 export function getTestCreditCardDetails() {


### PR DESCRIPTION
This PR updates the regex which trims the scheme from a Jetpack sitename to match `http` as well as `https` at the start of the string.

This is useful when working with "disposable" sites, such as those provided by http://poopy.life