### PR TITLE
Add test for Jetpack plan upgrade logged-out

### DIFF
--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -81,7 +81,7 @@ export function getAccountConfig( account ) {
 		localConfig = JSON.parse( process.env.ACCOUNT_INFO );
 	}
 
-	if ( host !== 'WPCOM' ) {
+	if ( host !== 'WPCOM' && host.match( /DIRECT$/ ) ) {
 		account = 'jetpackUser' + host;
 	}
 

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -167,7 +167,7 @@ export default class LoginFlow {
 	loginUsingExistingForm() {
 		let testUserName, testPassword;
 
-		const accountInfo = LoginFlow.getAccountConfig( this.account );
+		const accountInfo = dataHelper.getAccountConfig( this.account );
 
 		if ( accountInfo !== undefined ) {
 			testUserName = accountInfo[0];

--- a/lib/pages/jetpack-authorize-page.js
+++ b/lib/pages/jetpack-authorize-page.js
@@ -5,10 +5,10 @@ import * as driverHelper from '../driver-helper';
 
 export default class JetpackAuthorizePage extends BaseContainer {
 	constructor( driver ) {
-		super( driver, by.css( '.is-section-jetpackConnect' ) );
-		driver.getCurrentUrl().then( ( urlDisplayed ) => {
-			this.setABTestControlGroupsInLocalStorage( urlDisplayed );
-		} );
+		super( driver, by.css( '.jetpack-connect__authorize-form' ) );
+//		driver.getCurrentUrl().then( ( urlDisplayed ) => {
+//			this.setABTestControlGroupsInLocalStorage( urlDisplayed );
+//		} );
 	}
 
 	chooseSignIn() {

--- a/lib/pages/login-page.js
+++ b/lib/pages/login-page.js
@@ -14,6 +14,7 @@ export default class LoginPage extends BaseContainer {
 		if ( typeof overrideURL === 'string' ) {
 			loginURL = overrideURL;
 		}
+
 		super( driver, By.css( '#loginform, .wp-login__container' ), visit, loginURL );
 	}
 

--- a/lib/pages/login-page.js
+++ b/lib/pages/login-page.js
@@ -14,7 +14,6 @@ export default class LoginPage extends BaseContainer {
 		if ( typeof overrideURL === 'string' ) {
 			loginURL = overrideURL;
 		}
-
 		super( driver, By.css( '#loginform, .wp-login__container' ), visit, loginURL );
 	}
 

--- a/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -12,6 +12,7 @@ import PickAPlanPage from '../lib/pages/signup/pick-a-plan-page';
 import StatsPage from '../lib/pages/stats-page';
 import WPAdminJetpackPage from '../lib/pages/wp-admin/wp-admin-jetpack-page';
 import JetpackPlanSalesPage from '../lib/pages/jetpack-plans-sales-page';
+import JetpackAuthorizePage from '../lib/pages/jetpack-authorize-page';
 
 import ReaderPage from '../lib/pages/reader-page.js';
 import SecurePaymentComponent from '../lib/components/secure-payment-component.js';
@@ -81,6 +82,76 @@ test.describe( `[${host}] Jetpack Plans: (${screenSize}) @jetpack`, function() {
 		test.it( 'Can then see secure payment component', () => {
 			const securePaymentComponent = new SecurePaymentComponent( driver );
 			securePaymentComponent.displayed().then( ( displayed ) => {
+				assert.equal( displayed, true, 'Could not see the secure payment component' );
+			} );
+		} );
+
+		// Remove all items from basket for clean up
+		test.after( () => {
+			this.readerPage = new ReaderPage( driver, true );
+
+			this.navbarComponent = new NavbarComponent( driver );
+			this.navbarComponent.clickMySites();
+
+			this.statsPage = new StatsPage( driver, true );
+
+			this.sideBarComponent = new SidebarComponent( driver );
+			this.sideBarComponent.selectPlan();
+
+			this.domainsPage = new PlansPage( driver );
+			this.shoppingCartWidgetComponent = new ShoppingCartWidgetComponent( driver );
+			this.shoppingCartWidgetComponent.empty();
+		} );
+	} );
+
+	test.describe( 'Purchase Premium Plan Logged Out:', function() {
+		this.bailSuite( true );
+
+		test.before( function() {
+			return driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		} );
+
+		test.it( 'Can log into site', () => {
+			const loginFlow = new LoginFlow( driver, 'jetpackUser' + 'DIRECT' );
+			return loginFlow.login( { jetpackDIRECT: true } );
+		} );
+
+		test.it( 'Can open Jetpack dashboard', () => {
+			this.wpAdminSidebar = new WPAdminSidebar( driver );
+			return this.wpAdminSidebar.selectJetpack();
+		} );
+
+		test.it( 'Can find and click Upgrade nudge button', () => {
+			this.jetpackDashboard = new WPAdminJetpackPage( driver );
+			// The nudge buttons are loaded after the page, and there's no good loaded status indicator to key off of
+			return driver.sleep( 3000 ).then( () => {
+				return this.jetpackDashboard.clickUpgradeNudge();
+			} );
+		} );
+
+		test.it( 'Can click the Proceed button', () => {
+			this.jetpackPlanSalesPage = new JetpackPlanSalesPage( driver );
+			// The upgrade buttons are loaded after the page, and there's no good loaded status indicator to key off of
+			return driver.sleep( 3000 ).then( () => {
+				return this.jetpackPlanSalesPage.clickPurchaseButton();
+			} );
+		} );
+
+		test.it( 'Can click the purchase premium button', () => {
+			this.pickAPlanPage = new PickAPlanPage( driver );
+			return this.pickAPlanPage.selectPremiumPlan();
+		} );
+
+		test.it( 'Can log in to WordPress.com', () => {
+			this.jetpackAuthorizePage = new JetpackAuthorizePage( driver );
+			this.jetpackAuthorizePage.chooseSignIn;
+			const loginFlow = new LoginFlow( driver, 'jetpackUser' + host );
+			return loginFlow.loginUsingExistingForm();
+		} );
+
+		test.it( 'Can then see secure payment component', () => {
+			const securePaymentComponent = new SecurePaymentComponent( driver );
+			securePaymentComponent.displayed().then( displayed => {
 				assert.equal( displayed, true, 'Could not see the secure payment component' );
 			} );
 		} );

--- a/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -1,3 +1,4 @@
+
 import test from 'selenium-webdriver/testing';
 import config from 'config';
 import assert from 'assert';
@@ -142,9 +143,15 @@ test.describe( `[${host}] Jetpack Plans: (${screenSize}) @jetpack`, function() {
 			return this.pickAPlanPage.selectPremiumPlan();
 		} );
 
+		test.it( 'Can see the authorize page', () => {
+			return this.jetpackAuthorizePage = new JetpackAuthorizePage( driver );
+			this.jetpackAuthorizePage.displayed().then( displayed => {
+				assert.equal( displayed, true, 'Could not see the authorize page' );
+			} );
+		} );
+
 		test.it( 'Can log in to WordPress.com', () => {
-			this.jetpackAuthorizePage = new JetpackAuthorizePage( driver );
-			this.jetpackAuthorizePage.chooseSignIn;
+			this.jetpackAuthorizePage.chooseSignIn();
 			const loginFlow = new LoginFlow( driver, 'jetpackUser' + host );
 			return loginFlow.loginUsingExistingForm();
 		} );


### PR DESCRIPTION
Rough work-in-progress

* Needs a config entry: `jetpackUserDIRECT` with the creds to log into the .org site
* Needs single-sign-on turned off in the jetpack settings (simplifies the login to the .org site)

Note that this test is failing as expected because of https://github.com/Automattic/wp-calypso/issues/16081

/cc @sirreal 


