### PR TITLE
Wait for serverpilot action instead of sleeping when launching new WordPress

### DIFF
--- a/scripts/jetpack/git-jetpack.sh
+++ b/scripts/jetpack/git-jetpack.sh
@@ -4,21 +4,8 @@ if [ "$APP_NAME" == "" ]; then
   echo "Please supply app directory name!"
   exit 1
 elif [ ! -d apps/$APP_NAME/public/wp-content/plugins ]; then
-  # Wait up to 30 seconds for app to be created
-  echo "App directory apps/$APP_NAME/public/wp-content/plugins does not exist, waiting..."
-  sleep 10
-  if [ ! -d apps/$APP_NAME/public/wp-content/plugins ]; then
-    echo "App directory apps/$APP_NAME/public/wp-content/plugins does not exist, waiting..."
-    sleep 10
-    if [ ! -d apps/$APP_NAME ]; then
-      echo "App directory apps/$APP_NAME/public/wp-content/plugins does not exist, waiting..."
-      sleep 10
-      if [ ! -d apps/$APP_NAME ]; then
-        echo "App directory apps/$APP_NAME/public/wp-content/plugins does not exist after 30s, quitting!"
-        exit 1
-      fi
-    fi
-  fi
+  echo "App directory apps/$APP_NAME/public/wp-content/plugins does not exist."
+  exit 1
 fi
 echo "App directory apps/$APP_NAME found!  Installing Jetpack..."
 

--- a/scripts/jetpack/wp-serverpilot-init.js
+++ b/scripts/jetpack/wp-serverpilot-init.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 const config = require( 'config' );
-const fs = require( 'fs-extra' );
 const ServerPilot = require( 'serverpilot' );
 
 const spConfig = config.get( 'spConfig' );
@@ -34,9 +33,9 @@ sp.createApp( serverOptions, function( err, data ) {
 		console.log( err );
 		throw err;
 	}
-	waitForServerPilotAction( data.actionid, function( err ) {
+	waitForServerPilotAction( data.actionid, function( actionErr ) {
 		if ( err !== null ) {
-			console.log( err );
+			console.log( actionErr );
 			throw err;
 		}
 		console.log( `Site created - http://${serverPrefix}.wp-e2e-tests.pw - ID ${data.data.id}` );

--- a/scripts/jetpack/wp-serverpilot-init.js
+++ b/scripts/jetpack/wp-serverpilot-init.js
@@ -15,6 +15,7 @@ const username = userConfig.jetpackUserCI[0];
 const password = userConfig.jetpackUserCI[1];
 
 const serverPrefix = process.env.CIRCLE_SHA1.substr( 0, 20 );
+const actionWaitTimeout = 2000;
 
 const serverOptions = {
 	name: `wordpress-${serverPrefix}`,
@@ -33,6 +34,34 @@ sp.createApp( serverOptions, function( err, data ) {
 		console.log( err );
 		throw err;
 	}
-
-	console.log( `Site created - http://${serverPrefix}.wp-e2e-tests.pw - ID ${data.data.id}` );
+	waitForServerPilotAction( data.actionid, function( err ) {
+		if ( err !== null ) {
+			console.log( err );
+			throw err;
+		}
+		console.log( `Site created - http://${serverPrefix}.wp-e2e-tests.pw - ID ${data.data.id}` );
+	} );
 } );
+
+/**
+ * Waits for ServerPilot to finish an action
+ * @param  {String}   actionId The ServerPilot action Id as returned by the create app endpoint
+ * @param  {Function} cb       What to do after the action finishes or errors
+ */
+function waitForServerPilotAction( actionId, cb ) {
+	setTimeout( function() {
+		sp.getActionStatus( actionId, function( err, response ) {
+			if ( err ) {
+				return cb( err );
+			}
+			if ( response.data.status === 'error' ) {
+				return cb( new Error( 'ServerPilot app creation has completed but there were errors.' ) );
+			}
+			// If ServerPilot is still provisioning the app, recur
+			if ( response.data.status === 'open' ) {
+				return waitForServerPilotAction( actionId, cb );
+			}
+			cb();
+		} );
+	}, actionWaitTimeout );
+}


### PR DESCRIPTION
**ServerPilot's API** offers [a way to check the status of an action](https://github.com/ServerPilot/API#check-the-status-of-an-action). For instance, when an app is created, the API returns its data even before it's fully provisioned. That data contains an action identifier that can be used to check the status of the action via the `/actions/:id` endpoint.


**serverpilot-node** also offers [a wrapper for this endpoint](https://github.com/jplhomer/serverpilot-node#actions). 

Changes here should make the tests start earlier most of the times, as we won't enter in big sleep times before running them because we will be polling for the status instead.


#### Changes introduced by this Pull Request

* Updates `scripts/jetpack/wp-serverpilot-init.js` to exit only when ServerPilot's action has completed, or errored.
* Updates `scripts/jetpack/git-jetpack.sh` to not `sleep` as it will be run now only when the app has been created and provisioned with WordPress already. 

#### Testing instructions

1. Check this branch
2. Run the following command or an equivalent, to confirm that after the script finishes, the instance is fully created:

```
CIRCLE_SHA1='mycustomtestmycustomtestmycustomtest' node scripts/jetpack/wp-serverpilot-init.js && curl -v http://${CIRCLE_SHA1:0:20}.wp-e2e-tests.pw/wp-content/plugins/akismet/akismet.php 
```

3. Confirm that you get a valid response (maybe a 403 status code coming from nginx). 
4. If the same concatenation of commands is done in master, you should get a response like `Empty reply from server` instead when the `curl` command runs.
5. Using ServerPilot's Manager, delete by hand the newly created app