### PR TITLE
Experiment with creating a poopy.life site for jp connect tests

### DIFF
--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -6,6 +6,7 @@ import * as driverHelper from '../driver-helper';
 
 const TEMPLATE_URL = 'http://poopy.life/create?src=weary-duck&key=pVP6jBZR1C6wALZh';
 const PASSWORD_ELEMENT = by.css( '#tdr_password' );
+const URL_ELEMENT = by.css( '#tdr_url' );
 
 export default class WporgCreatorPage extends BaseContainer {
 	constructor( driver ) {
@@ -20,6 +21,11 @@ export default class WporgCreatorPage extends BaseContainer {
 			'Could not locate password element'
 		);
 		return this.driver.findElement( PASSWORD_ELEMENT ).getText();
+	}
+
+	getUrl() {
+		this.driver.wait( until.elementLocated( URL_ELEMENT ) );
+		return this.driver.findElement( URL_ELEMENT ).getText();
 	}
 
 	waitForWpadmin() {

--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -1,0 +1,28 @@
+/** @format */
+import { By as by, until } from 'selenium-webdriver';
+import BaseContainer from '../base-container';
+
+import * as driverHelper from '../driver-helper';
+
+const TEMPLATE_URL = 'http://poopy.life/create?src=weary-duck&key=pVP6jBZR1C6wALZh';
+const PASSWORD_ELEMENT = by.css( '#tdr_password' );
+
+export default class WporgCreatorPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( '.continue-to-install' ), /* visit url */ true, TEMPLATE_URL );
+		driverHelper.clickWhenClickable( driver, by.css( '.continue-to-install' ) );
+	}
+
+	getPassword() {
+		this.driver.wait(
+			until.elementLocated( PASSWORD_ELEMENT ),
+			3000,
+			'Could not locate password element'
+		);
+		return this.driver.findElement( PASSWORD_ELEMENT ).getText();
+	}
+
+	waitForWpadmin() {
+		return driverHelper.waitTillPresentAndDisplayed( this.driver, PASSWORD_ELEMENT );
+	}
+}

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -1,0 +1,47 @@
+/** @format */
+import test from 'selenium-webdriver/testing';
+import config from 'config';
+import assert from 'assert';
+
+import * as driverManager from '../lib/driver-manager';
+import * as dataHelper from '../lib/data-helper';
+
+import WporgCreatorPage from '../lib/pages/wporg-creator-page';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+
+var driver;
+
+test.before( function() {
+	this.timeout( startBrowserTimeoutMS );
+	driver = driverManager.startBrowser();
+} );
+
+test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
+	this.timeout( mochaTimeOut );
+
+	test.describe( 'Connect From Calypso:', function() {
+		this.bailSuite( true );
+
+		test.before( function() {
+			return driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		} );
+
+		test.it( 'Can create wporg site', () => {
+			this.wporgCreator = new WporgCreatorPage( driver );
+			return this.wporgCreator.waitForWpadmin();
+		} );
+
+		test.it( 'Can get password', () => {
+			this.wporgCreator.getPassword().then( password => {
+				this.password = password;
+			} );
+		} );
+
+		test.it( 'Has password', () => {
+			console.log( 'password', this.password );
+		} );
+	} );
+} );

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -34,14 +34,14 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 			return this.wporgCreator.waitForWpadmin();
 		} );
 
-		test.it( 'Can get password', () => {
-			this.wporgCreator.getPassword().then( password => {
-				this.password = password;
+		test.it( 'Can get URL', () => {
+			this.wporgCreator.getUrl().then( url => {
+				this.url = url;
 			} );
 		} );
 
-		test.it( 'Has password', () => {
-			console.log( 'password', this.password );
+		test.it( 'Has URL', () => {
+			console.log( 'url', this.url );
 		} );
 	} );
 } );


### PR DESCRIPTION
Rough experiment with creating a new poopy.life wporg site for every test, allowing parallel tests and multiple jetpack connects and disconnects.

Will also have a look at using the existing server pilot scripts for multiple sites, in a separate PR.
