### PR TITLE
Jetpack connect test using a jurassic.ninja site

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -61,6 +61,7 @@
 	[ "signupSurveyStep_20170329", "hideSurveyStep" ],
 	[ "postPublishConfirmation_20170801", "showPublishConfirmation" ],
 	[ "skipThemesSelectionModal_20170830", "show" ],
-	[ "gsuiteUpsell_20171025", "hide" ]
+	[ "gsuiteUpsell_20171025", "hide" ],
+    [ "newSiteWithJetpack_20170419", "showNewJetpackSite" ]
   ]
 }

--- a/config/default.json
+++ b/config/default.json
@@ -61,7 +61,6 @@
 	[ "signupSurveyStep_20170329", "hideSurveyStep" ],
 	[ "postPublishConfirmation_20170801", "showPublishConfirmation" ],
 	[ "skipThemesSelectionModal_20170830", "show" ],
-	[ "gsuiteUpsell_20171025", "hide" ],
-    [ "newSiteWithJetpack_20170419", "showNewJetpackSite" ]
+	[ "gsuiteUpsell_20171025", "hide" ]
   ]
 }

--- a/lib/base-container.js
+++ b/lib/base-container.js
@@ -8,9 +8,9 @@ import * as slackNotifier from './slack-notifier';
 
 
 export default class BaseContainer {
-	constructor( driver, expectedElementSelector, visit = false, url = null ) {
+	constructor( driver, expectedElementSelector, visit = false, url = null, waitMS = config.get( 'explicitWaitMS' ) ) {
 		this.screenSize = driverManager.currentScreenSize().toUpperCase();
-		this.explicitWaitMS = config.get( 'explicitWaitMS' );
+		this.explicitWaitMS = waitMS;
 		this.driver = driver;
 		this.expectedElementSelector = expectedElementSelector;
 		this.url = url;

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -97,4 +97,8 @@ export default class SidebarComponent extends BaseContainer {
 	selectStoreOption() {
 		return driverHelper.clickWhenClickable( this.driver, this.storeSelector );
 	}
+	addNewSite() {
+		const newSiteSelector = By.css( '.my-sites-sidebar__add-new-site' );
+		return driverHelper.clickWhenClickable( this.driver, newSiteSelector );
+	}
 }

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -101,4 +101,31 @@ export default class SidebarComponent extends BaseContainer {
 		const newSiteSelector = By.css( '.my-sites-sidebar__add-new-site' );
 		return driverHelper.clickWhenClickable( this.driver, newSiteSelector );
 	}
+
+	/**
+     * Selects a jetpack site, if present, from the site switcher.
+	 *
+	 * @return Thenable<bool> true if a jetpack site was selected.
+     */
+	selectJetpackSite() {
+		const siteSwitcherSelector = By.css( '.current-site__switch-sites' );
+		const siteSelector = By.css( '.is-jetpack' );
+
+		return driverHelper.isElementPresent( this.driver, siteSwitcherSelector ).then( foundSwitcher => {
+			if ( ! foundSwitcher ) {
+				// no site switcher, only one site
+				return false;
+			}
+			this.selectSiteSwitcher();
+			return driverHelper.isElementPresent( this.driver, siteSelector ).then( foundSite => {
+				if ( ! foundSite ) {
+					// no jp sites left
+					driverHelper.clickWhenClickable( this.driver, By.css( '.site' ) );
+					return false;
+				}
+				driverHelper.clickWhenClickable( this.driver, siteSelector );
+				return true;
+			} );
+		} );
+	}
 }

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -1,5 +1,6 @@
 import { By, until } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper.js';
+import * as driverManager from '../driver-manager.js';
 
 import BaseContainer from '../base-container.js';
 
@@ -37,7 +38,19 @@ export default class SidebarComponent extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	selectSiteSwitcher() {
+		this.ensureSidebarMenuVisible();
 		return driverHelper.clickWhenClickable( this.driver, By.css( '.current-site__switch-sites' ) );
+	}
+	// Need to click header on mobile to focus the sidebar menu
+	ensureSidebarMenuVisible() {
+		if ( driverManager.currentScreenSize() !== 'mobile' ) {
+			return;
+		}
+		driverHelper.isElementPresent( this.driver, By.css( '.focus-content' ) ).then( focusContent => {
+			if ( focusContent ) {
+				driverHelper.clickWhenClickable( this.driver, By.css( '.current-section a' ) );
+			}
+		} );
 	}
 	searchForSite( searchString ) {
 		const searchSelector = By.css( '.site-selector input[type="search"]' );
@@ -98,6 +111,7 @@ export default class SidebarComponent extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, this.storeSelector );
 	}
 	addNewSite() {
+		this.ensureSidebarMenuVisible();
 		const newSiteSelector = By.css( '.my-sites-sidebar__add-new-site' );
 		return driverHelper.clickWhenClickable( this.driver, newSiteSelector );
 	}
@@ -111,6 +125,7 @@ export default class SidebarComponent extends BaseContainer {
 		const siteSwitcherSelector = By.css( '.current-site__switch-sites' );
 		const siteSelector = By.css( '.is-jetpack' );
 
+		this.ensureSidebarMenuVisible();
 		return driverHelper.isElementPresent( this.driver, siteSwitcherSelector ).then( foundSwitcher => {
 			if ( ! foundSwitcher ) {
 				// no site switcher, only one site

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -103,10 +103,10 @@ export default class SidebarComponent extends BaseContainer {
 	}
 
 	/**
-     * Selects a jetpack site, if present, from the site switcher.
+	 * Selects a jetpack site, if present, from the site switcher.
 	 *
 	 * @return Thenable<bool> true if a jetpack site was selected.
-     */
+	 */
 	selectJetpackSite() {
 		const siteSwitcherSelector = By.css( '.current-site__switch-sites' );
 		const siteSelector = By.css( '.is-jetpack' );

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -76,7 +76,7 @@ export default class SidebarComponent extends BaseContainer {
 			} );
 	}
 	selectSettings() {
-		return this.driver.findElement( By.css( '.sites-navigation .settings a' ) ).click();
+		return driverHelper.clickWhenClickable( this.driver, By.css( '.sites-navigation .settings a' ) );
 	}
 	selectPosts() {
 		const selector = By.css( '.sites-navigation [data-post-type="post"] a:not(.sidebar__button)' );

--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -81,7 +81,7 @@ export function getAccountConfig( account ) {
 		localConfig = JSON.parse( process.env.ACCOUNT_INFO );
 	}
 
-	if ( host !== 'WPCOM' ) {
+	if ( host !== 'WPCOM' && account !== 'jetpackConnectUser' ) {
 		account = 'jetpackUser' + host;
 	}
 

--- a/lib/pages/add-new-site-page.js
+++ b/lib/pages/add-new-site-page.js
@@ -1,19 +1,19 @@
 /** @format */
-import { By as by } from 'selenium-webdriver';
+import { By } from 'selenium-webdriver';
 import BaseContainer from '../base-container';
 
 import * as driverHelper from '../driver-helper';
 
 export default class AddNewSitePage extends BaseContainer {
 	constructor( driver ) {
-		super( driver, by.css( '.jetpack-new-site__header-title' ) );
+		super( driver, By.css( '.jetpack-new-site__header-title' ) );
 	}
 
 	addSiteUrl( url ) {
-		const urlInputSelector = by.css( '.form-text-input' );
+		const urlInputSelector = By.css( '.form-text-input' );
 		driverHelper.setWhenSettable( this.driver, urlInputSelector, url );
 
-		const confirmButtonSelector = by.css( '.jetpack-connect__connect-button' );
+		const confirmButtonSelector = By.css( '.jetpack-connect__connect-button' );
 		return driverHelper.clickWhenClickable(
 			this.driver,
 			confirmButtonSelector,

--- a/lib/pages/add-new-site-page.js
+++ b/lib/pages/add-new-site-page.js
@@ -1,0 +1,23 @@
+/** @format */
+import { By as by } from 'selenium-webdriver';
+import BaseContainer from '../base-container';
+
+import * as driverHelper from '../driver-helper';
+
+export default class AddNewSitePage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( '.jetpack-new-site__header-title' ) );
+	}
+
+	addSiteUrl( url ) {
+		const urlInputSelector = by.css( '.form-text-input' );
+		driverHelper.setWhenSettable( this.driver, urlInputSelector, url );
+
+		const confirmButtonSelector = by.css( '.jetpack-connect__connect-button' );
+		return driverHelper.clickWhenClickable(
+			this.driver,
+			confirmButtonSelector,
+			this.explicitWaitMS
+		);
+	}
+}

--- a/lib/pages/add-new-site-page.js
+++ b/lib/pages/add-new-site-page.js
@@ -3,6 +3,7 @@ import { By } from 'selenium-webdriver';
 import BaseContainer from '../base-container';
 
 import * as driverHelper from '../driver-helper';
+import * as driverManager from '../driver-manager';
 
 export default class AddNewSitePage extends BaseContainer {
 	constructor( driver ) {
@@ -10,10 +11,20 @@ export default class AddNewSitePage extends BaseContainer {
 	}
 
 	addSiteUrl( url ) {
-		const urlInputSelector = By.css( '.form-text-input' );
+		let urlInputSelector = By.css( '.jetpack-new-site__jetpack-site #siteUrl' );
+		let confirmButtonSelector = By.css(
+			'.jetpack-new-site__jetpack-site .jetpack-connect__connect-button'
+		);
+
+		if ( driverManager.currentScreenSize() === 'mobile' ) {
+			urlInputSelector = By.css( '.jetpack-new-site__mobile-jetpack-site #siteUrl' );
+			confirmButtonSelector = By.css(
+				'.jetpack-new-site__mobile-jetpack-site .jetpack-connect__connect-button'
+			);
+		}
+
 		driverHelper.setWhenSettable( this.driver, urlInputSelector, url );
 
-		const confirmButtonSelector = By.css( '.jetpack-connect__connect-button' );
 		return driverHelper.clickWhenClickable(
 			this.driver,
 			confirmButtonSelector,

--- a/lib/pages/signup/pick-a-plan-page.js
+++ b/lib/pages/signup/pick-a-plan-page.js
@@ -30,6 +30,13 @@ export default class PickAPlanPage extends BaseContainer {
 
 		return this._selectPlan( 'free' );
 	}
+	// Explicitly select the free button on jetpack without needing `host` above.
+	selectFreePlanJetpack() {
+		return driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.jetpack-connect__plans-nav-buttons button' )
+		);
+	}
 	selectPersonalPlan() {
 		return this._selectPlan( 'personal' );
 	}

--- a/lib/pages/signup/pick-a-plan-page.js
+++ b/lib/pages/signup/pick-a-plan-page.js
@@ -1,3 +1,4 @@
+import config from 'config';
 import { By, until } from 'selenium-webdriver';
 
 import BaseContainer from '../../base-container.js';
@@ -82,5 +83,12 @@ export default class PickAPlanPage extends BaseContainer {
 		const selector = By.css( 'div.business-bundle div.wpcom-plan-price span' );
 		this.driver.wait( until.elementLocated( selector ), this.explicitWaitMS, 'Could not locate the business plan price element' );
 		return this.driver.findElement( selector ).getText();
+	}
+	static waitForPage( driver ) {
+		driverHelper.waitTillPresentAndDisplayed(
+			driver,
+			By.css( '.plans-features-main__group' ),
+			config.get( 'explicitWaitMS' ) * 2
+		);
 	}
 }

--- a/lib/pages/signup/pick-a-plan-page.js
+++ b/lib/pages/signup/pick-a-plan-page.js
@@ -12,7 +12,13 @@ const screenSize = currentScreenSize();
 
 export default class PickAPlanPage extends BaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.plans-features-main__group' ) );
+		super(
+			driver,
+			By.css( '.plans-features-main__group' ),
+			false,
+			null,
+			config.get( 'explicitWaitMS' ) * 2
+		);
 	}
 	_selectPlan( level ) {
 		let prefix = 'table';
@@ -83,12 +89,5 @@ export default class PickAPlanPage extends BaseContainer {
 		const selector = By.css( 'div.business-bundle div.wpcom-plan-price span' );
 		this.driver.wait( until.elementLocated( selector ), this.explicitWaitMS, 'Could not locate the business plan price element' );
 		return this.driver.findElement( selector ).getText();
-	}
-	static waitForPage( driver ) {
-		driverHelper.waitTillPresentAndDisplayed(
-			driver,
-			By.css( '.plans-features-main__group' ),
-			config.get( 'explicitWaitMS' ) * 2
-		);
 	}
 }

--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -6,6 +6,7 @@ import * as driverHelper from '../driver-helper';
 
 const TEMPLATE_URL = 'http://poopy.life/create?src=weary-duck&key=pVP6jBZR1C6wALZh';
 const PASSWORD_ELEMENT = by.css( '#tdr_password' );
+const URL_ELEMENT = by.css( '#tdr_url' );
 
 export default class WporgCreatorPage extends BaseContainer {
 	constructor( driver ) {
@@ -20,6 +21,11 @@ export default class WporgCreatorPage extends BaseContainer {
 			'Could not locate password element'
 		);
 		return this.driver.findElement( PASSWORD_ELEMENT ).getText();
+	}
+
+	getUrl() {
+		this.driver.wait( until.elementLocated( URL_ELEMENT ) );
+		return this.driver.findElement( URL_ELEMENT ).getText();
 	}
 
 	waitForWpadmin() {

--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -8,10 +8,12 @@ const TEMPLATE_URL = 'http://jurassic.ninja/create';
 const PASSWORD_ELEMENT = By.css( '#jurassic_password' );
 const URL_ELEMENT = By.css( '#jurassic_url' );
 const CONTINUE_LINK = By.linkText( 'The new WP is ready to go, visit it!' );
+const PROGRESS_MESSAGE = By.css( '#progress' );
 
 export default class WporgCreatorPage extends BaseContainer {
 	constructor( driver ) {
-		super( driver, CONTINUE_LINK, /* visit url */ true, TEMPLATE_URL );
+		super( driver, PROGRESS_MESSAGE, /* visit url */ true, TEMPLATE_URL );
+		driverHelper.waitTillPresentAndDisplayed( driver, CONTINUE_LINK, this.explicitWaitMS * 2 );
 		driverHelper.clickWhenClickable( driver, CONTINUE_LINK );
 	}
 

--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -1,0 +1,28 @@
+/** @format */
+import { By as by, until } from 'selenium-webdriver';
+import BaseContainer from '../base-container';
+
+import * as driverHelper from '../driver-helper';
+
+const TEMPLATE_URL = 'http://poopy.life/create?src=weary-duck&key=pVP6jBZR1C6wALZh';
+const PASSWORD_ELEMENT = by.css( '#tdr_password' );
+
+export default class WporgCreatorPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( '.continue-to-install' ), /* visit url */ true, TEMPLATE_URL );
+		driverHelper.clickWhenClickable( driver, by.css( '.continue-to-install' ) );
+	}
+
+	getPassword() {
+		this.driver.wait(
+			until.elementLocated( PASSWORD_ELEMENT ),
+			3000,
+			'Could not locate password element'
+		);
+		return this.driver.findElement( PASSWORD_ELEMENT ).getText();
+	}
+
+	waitForWpadmin() {
+		return driverHelper.waitTillPresentAndDisplayed( this.driver, PASSWORD_ELEMENT );
+	}
+}

--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -1,13 +1,13 @@
 /** @format */
-import { By as by, until } from 'selenium-webdriver';
+import { By, until } from 'selenium-webdriver';
 import BaseContainer from '../base-container';
 
 import * as driverHelper from '../driver-helper';
 
 const TEMPLATE_URL = 'http://jurassic.ninja/create';
-const PASSWORD_ELEMENT = by.css( '#jurassic_password' );
-const URL_ELEMENT = by.css( '#jurassic_url' );
-const CONTINUE_LINK = by.linkText( 'The new WP is ready to go, visit it!' );
+const PASSWORD_ELEMENT = By.css( '#jurassic_password' );
+const URL_ELEMENT = By.css( '#jurassic_url' );
+const CONTINUE_LINK = By.linkText( 'The new WP is ready to go, visit it!' );
 
 export default class WporgCreatorPage extends BaseContainer {
 	constructor( driver ) {

--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -4,22 +4,19 @@ import BaseContainer from '../base-container';
 
 import * as driverHelper from '../driver-helper';
 
-const TEMPLATE_URL = 'http://poopy.life/create?src=weary-duck&key=pVP6jBZR1C6wALZh';
-const PASSWORD_ELEMENT = by.css( '#tdr_password' );
-const URL_ELEMENT = by.css( '#tdr_url' );
+const TEMPLATE_URL = 'http://jurassic.ninja/create';
+const PASSWORD_ELEMENT = by.css( '#jurassic_password' );
+const URL_ELEMENT = by.css( '#jurassic_url' );
+const CONTINUE_LINK = by.linkText( 'The new WP is ready to go, visit it!' );
 
 export default class WporgCreatorPage extends BaseContainer {
 	constructor( driver ) {
-		super( driver, by.css( '.continue-to-install' ), /* visit url */ true, TEMPLATE_URL );
-		driverHelper.clickWhenClickable( driver, by.css( '.continue-to-install' ) );
+		super( driver, CONTINUE_LINK, /* visit url */ true, TEMPLATE_URL );
+		driverHelper.clickWhenClickable( driver, CONTINUE_LINK );
 	}
 
 	getPassword() {
-		this.driver.wait(
-			until.elementLocated( PASSWORD_ELEMENT ),
-			3000,
-			'Could not locate password element'
-		);
+		this.driver.wait( until.elementLocated( PASSWORD_ELEMENT ) );
 		return this.driver.findElement( PASSWORD_ELEMENT ).getText();
 	}
 

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -35,7 +35,7 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 
 		test.it( 'Can create wporg site', () => {
 			this.wporgCreator = new WporgCreatorPage( driver );
-			return this.wporgCreator.waitForWpadmin();
+			this.wporgCreator.waitForWpadmin();
 		} );
 
 		test.it( 'Can get URL', () => {
@@ -71,6 +71,17 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 		test.it( 'Can click the free plan button', () => {
 			this.pickAPlanPage = new PickAPlanPage( driver );
 			return this.pickAPlanPage.selectFreePlanJetpack();
+		} );
+
+		test.it( 'Has site URL in route', done => {
+			const siteSlug = this.url.replace( /^https?:\/\//, '' );
+			console.log( siteSlug );
+			return driver.getCurrentUrl().then( url => {
+				if ( url.includes( this.url ) ) {
+					return done();
+				}
+				done( 'Route does not include site slug ' + url );
+			} );
 		} );
 	} );
 } );

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -82,7 +82,6 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 		} );
 
 		test.it( 'Can click the free plan button', () => {
-			PickAPlanPage.waitForPage( driver );
 			this.pickAPlanPage = new PickAPlanPage( driver );
 			return this.pickAPlanPage.selectFreePlanJetpack();
 		} );

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -7,6 +7,8 @@ import * as driverManager from '../lib/driver-manager';
 import * as dataHelper from '../lib/data-helper';
 
 import WporgCreatorPage from '../lib/pages/wporg-creator-page';
+import LoginFlow from '../lib/flows/login-flow';
+import SidebarComponent from '../lib/components/sidebar-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -40,8 +42,14 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 			} );
 		} );
 
-		test.it( 'Has URL', () => {
-			console.log( 'url', this.url );
+		test.it( 'Can add new site', () => {
+			const loginFlow = new LoginFlow( driver );
+			loginFlow.loginAndSelectMySite();
+
+			const sidebarComponent = new SidebarComponent( driver );
+			sidebarComponent.addNewSite( driver );
+
+			// some A/B test in play here?
 		} );
 	} );
 } );

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -5,9 +5,11 @@ import assert from 'assert';
 
 import * as driverManager from '../lib/driver-manager';
 import * as dataHelper from '../lib/data-helper';
+import { By } from 'selenium-webdriver';
 
 import AddNewSitePage from '../lib/pages/add-new-site-page';
 import PickAPlanPage from '../lib/pages/signup/pick-a-plan-page';
+import SettingsPage from '../lib/pages/settings-page';
 import WporgCreatorPage from '../lib/pages/wporg-creator-page';
 import LoginFlow from '../lib/flows/login-flow';
 import SidebarComponent from '../lib/components/sidebar-component';
@@ -56,12 +58,27 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 			} );
 		} );
 
-		/*
-		test.it( 'Can disconnect existing jetpack sites', () => {
-			this.sideBarComponent.selectSiteSwitcher();
-			this.sideBarComponent.searchForSite( 'ninja' );
-		}
-*/
+		test.it( 'Can disconnect existing jetpack sites', done => {
+			const siteSwitcherSelector = By.css( '.current-site__switch-sites' );
+
+			const removeSites = () => {
+				driver.findElements( siteSwitcherSelector ).then( found => {
+					if ( ! found.length ) {
+						// only one site left
+						return done();
+					}
+					this.sidebarComponent.selectSiteSwitcher();
+					this.sidebarComponent.searchForSite( 'ninja' );
+					this.sidebarComponent.selectSettings();
+					this.settingsPage = new SettingsPage( driver );
+					this.settingsPage.manageConnection();
+					this.settingsPage.disconnectSite().then( removeSites() );
+				} );
+			};
+
+			removeSites();
+		} );
+
 		test.it( 'Can add new site', () => {
 			this.sidebarComponent.addNewSite( driver );
 			const addNewSitePage = new AddNewSitePage( driver );

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -59,37 +59,21 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 			} );
 		} );
 
-		test.it( 'Can disconnect existing jetpack sites', done => {
-			const siteSwitcherSelector = By.css( '.current-site__switch-sites' );
-			const siteSelector = By.css( '.site-selector .site a[aria-label*="ninja"]' );
-
+		test.it( 'Can disconnect existing jetpack sites', () => {
 			const removeSites = () => {
-				driverHelper.isElementPresent( driver, siteSwitcherSelector ).then( foundSwitcher => {
-					if ( ! foundSwitcher ) {
-						// only one site left
-						return done();
+				this.sidebarComponent.selectJetpackSite().then( foundSite => {
+					if ( ! foundSite ) {
+						// Refresh to put the site selector back into a sane state
+						// where it knows there is only one site. Can probably
+						// make the 'add site' stuff below more robust instead.
+						return driver.navigate().refresh();
 					}
-					this.sidebarComponent.selectSiteSwitcher();
-
-					driverHelper.isElementPresent( driver, siteSelector ).then( foundSite => {
-						if ( ! foundSite ) {
-							// no jp sites left
-							driverHelper.clickWhenClickable( driver, By.css( '.site' ) );
-							// Refresh to put the site selector back into a sane state
-							// where it knows there is only one site. Can probably
-							// make the 'add site' stuff below more robust instead.
-							driver.navigate().refresh();
-							return done();
-						}
-
-						this.sidebarComponent.searchForSite( 'ninja' );
-						this.sidebarComponent.selectSettings();
-						const settingsPage = new SettingsPage( driver );
-						settingsPage.manageConnection();
-						settingsPage.disconnectSite();
-						driverHelper.waitTillPresentAndDisplayed( driver, By.css( '.is-success' ) );
-						removeSites();
-					} );
+					this.sidebarComponent.selectSettings();
+					const settingsPage = new SettingsPage( driver );
+					settingsPage.manageConnection();
+					settingsPage.disconnectSite();
+					driverHelper.waitTillPresentAndDisplayed( driver, By.css( '.is-success' ) );
+					removeSites();
 				} );
 			};
 

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -6,6 +6,8 @@ import assert from 'assert';
 import * as driverManager from '../lib/driver-manager';
 import * as dataHelper from '../lib/data-helper';
 
+import AddNewSitePage from '../lib/pages/add-new-site-page';
+import PickAPlanPage from '../lib/pages/signup/pick-a-plan-page';
 import WporgCreatorPage from '../lib/pages/wporg-creator-page';
 import LoginFlow from '../lib/flows/login-flow';
 import SidebarComponent from '../lib/components/sidebar-component';
@@ -42,14 +44,33 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 			} );
 		} );
 
-		test.it( 'Can add new site', () => {
-			const loginFlow = new LoginFlow( driver );
+		test.it( 'Can log in', () => {
+			const loginFlow = new LoginFlow( driver, 'jetpackConnectUser' );
 			loginFlow.loginAndSelectMySite();
 
-			const sidebarComponent = new SidebarComponent( driver );
-			sidebarComponent.addNewSite( driver );
+			this.sidebarComponent = new SidebarComponent( driver );
 
-			// some A/B test in play here?
+			// ensure we are in A/B variant that allows adding jp site from single-site account
+			driver.getCurrentUrl().then( urlDisplayed => {
+				this.sidebarComponent.setABTestControlGroupsInLocalStorage( urlDisplayed );
+			} );
+		} );
+
+		/*
+		test.it( 'Can disconnect existing jetpack sites', () => {
+			this.sideBarComponent.selectSiteSwitcher();
+			this.sideBarComponent.searchForSite( 'ninja' );
+		}
+*/
+		test.it( 'Can add new site', () => {
+			this.sidebarComponent.addNewSite( driver );
+			const addNewSitePage = new AddNewSitePage( driver );
+			addNewSitePage.addSiteUrl( this.url );
+		} );
+
+		test.it( 'Can click the free plan button', () => {
+			this.pickAPlanPage = new PickAPlanPage( driver );
+			return this.pickAPlanPage.selectFreePlanJetpack();
 		} );
 	} );
 } );

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -1,0 +1,47 @@
+/** @format */
+import test from 'selenium-webdriver/testing';
+import config from 'config';
+import assert from 'assert';
+
+import * as driverManager from '../lib/driver-manager';
+import * as dataHelper from '../lib/data-helper';
+
+import WporgCreatorPage from '../lib/pages/wporg-creator-page';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+
+var driver;
+
+test.before( function() {
+	this.timeout( startBrowserTimeoutMS );
+	driver = driverManager.startBrowser();
+} );
+
+test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
+	this.timeout( mochaTimeOut );
+
+	test.describe( 'Connect From Calypso:', function() {
+		this.bailSuite( true );
+
+		test.before( function() {
+			return driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		} );
+
+		test.it( 'Can create wporg site', () => {
+			this.wporgCreator = new WporgCreatorPage( driver );
+			return this.wporgCreator.waitForWpadmin();
+		} );
+
+		test.it( 'Can get password', () => {
+			this.wporgCreator.getPassword().then( password => {
+				this.password = password;
+			} );
+		} );
+
+		test.it( 'Has password', () => {
+			console.log( 'password', this.password );
+		} );
+	} );
+} );

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -34,14 +34,14 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 			return this.wporgCreator.waitForWpadmin();
 		} );
 
-		test.it( 'Can get password', () => {
-			this.wporgCreator.getPassword().then( password => {
-				this.password = password;
+		test.it( 'Can get URL', () => {
+			this.wporgCreator.getUrl().then( url => {
+				this.url = url;
 			} );
 		} );
 
-		test.it( 'Has password', () => {
-			console.log( 'password', this.password );
+		test.it( 'Has URL', () => {
+			console.log( 'url', this.url );
 		} );
 	} );
 } );

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -50,16 +50,11 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 		test.it( 'Can log in', () => {
 			const loginFlow = new LoginFlow( driver, 'jetpackConnectUser' );
 			loginFlow.loginAndSelectMySite();
-
-			this.sidebarComponent = new SidebarComponent( driver );
-
-			// ensure we are in A/B variant that allows adding jp site from single-site account
-			driver.getCurrentUrl().then( urlDisplayed => {
-				this.sidebarComponent.setABTestControlGroupsInLocalStorage( urlDisplayed );
-			} );
 		} );
 
 		test.it( 'Can disconnect existing jetpack sites', () => {
+			this.sidebarComponent = new SidebarComponent( driver );
+
 			const removeSites = () => {
 				this.sidebarComponent.selectJetpackSite().then( foundSite => {
 					if ( ! foundSite ) {

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -70,9 +70,9 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 					this.sidebarComponent.selectSiteSwitcher();
 					this.sidebarComponent.searchForSite( 'ninja' );
 					this.sidebarComponent.selectSettings();
-					this.settingsPage = new SettingsPage( driver );
-					this.settingsPage.manageConnection();
-					this.settingsPage.disconnectSite().then( removeSites() );
+					const settingsPage = new SettingsPage( driver );
+					settingsPage.manageConnection();
+					settingsPage.disconnectSite().then( removeSites() );
 				} );
 			};
 
@@ -94,10 +94,10 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 			const siteSlug = this.url.replace( /^https?:\/\//, '' );
 			console.log( siteSlug );
 			return driver.getCurrentUrl().then( url => {
-				if ( url.includes( this.url ) ) {
+				if ( url.includes( siteSlug ) ) {
 					return done();
 				}
-				done( 'Route does not include site slug ' + url );
+				done( `Route ${ url } does not include site slug ${ siteSlug }` );
 			} );
 		} );
 	} );

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -82,6 +82,7 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 		} );
 
 		test.it( 'Can click the free plan button', () => {
+			PickAPlanPage.waitForPage( driver );
 			this.pickAPlanPage = new PickAPlanPage( driver );
 			return this.pickAPlanPage.selectFreePlanJetpack();
 		} );


### PR DESCRIPTION
A test for connecting a .org site running jetpack, starting from Calypso. Adds a library module `wporg-creator-page` that spins up a new .org site with jetpack installed per-test. This uses the `jurassic.ninja` service, an internal poopy.life clone.

Running a new .org site per test allows using a different set of features to the other jetpack tests (for example SSO turned off), and connecting/disconnecting without affecting the other tests.

These tests require a longer timeout, I'm running with 40 seconds, due to the time to create a .org site and the time to authorize the jetpack connection.

Also requires user `e2eflowtestingjetpackconnect`.


/cc @oskosk @sirreal 

