### PR TITLE
Temporarily disable setting AB tests on domains page

### DIFF
--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -63,9 +63,10 @@ test.describe( `[${host}] Managing Domains: (${screenSize}) @parallel`, function
 		test.describe( 'Can search for and select a paid domain', function() {
 			test.it( 'Can choose add a domain', () => {
 				const domainsPage = new DomainsPage( driver );
-				driver.getCurrentUrl().then( ( urlDisplayed ) => {
-					domainsPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
-				} );
+				// Temporarily disabled due to https://github.com/Automattic/wp-calypso/issues/19262
+				// driver.getCurrentUrl().then( ( urlDisplayed ) => {
+				// 	domainsPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
+				// } );
 				return domainsPage.clickAddDomain();
 			} );
 


### PR DESCRIPTION
Page won't refresh due to: https://github.com/Automattic/wp-calypso/issues/19262