### PR TITLE
Adds a domain only signup

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -56,10 +56,11 @@
     }
   },
   "httpsHosts": [ "WPCOM", "PRESSABLE" ],
-  "knownABTestKeys": [ "multiDomainRegistrationV1", "signupSurveyStep", "presaleChatButton", "businessPlanDescriptionAT", "newSiteWithJetpack", "postPublishConfirmation", "readerIntroIllustration", "paymentShowPaypalLogo", "jetpackConnectPlansCopyChanges", "postSignupUpgradeScreen", "skipThemesSelectionModal", "recommendShortestDomain", "checkoutPaymentMethodTabs", "unlimitedThemeNudge" ],
+  "knownABTestKeys": [ "multiDomainRegistrationV1", "signupSurveyStep", "presaleChatButton", "businessPlanDescriptionAT", "newSiteWithJetpack", "postPublishConfirmation", "readerIntroIllustration", "paymentShowPaypalLogo", "jetpackConnectPlansCopyChanges", "postSignupUpgradeScreen", "skipThemesSelectionModal", "recommendShortestDomain", "checkoutPaymentMethodTabs", "unlimitedThemeNudge", "gsuiteUpsell" ],
   "overrideABTests": [
 	[ "signupSurveyStep_20170329", "hideSurveyStep" ],
 	[ "postPublishConfirmation_20170801", "showPublishConfirmation" ],
-	[ "skipThemesSelectionModal_20170830", "show" ]
+	[ "skipThemesSelectionModal_20170830", "show" ],
+	[ "gsuiteUpsell_20171025", "hide" ]
   ]
 }

--- a/lib/components/secure-payment-component.js
+++ b/lib/components/secure-payment-component.js
@@ -28,15 +28,12 @@ export default class SecurePaymentComponent extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, removeItemSelector );
 	}
 
+	waitForCreditCardPaymentProcessing() {
+		return driverHelper.waitTillNotPresent( this.driver, By.css( '.credit-card-payment-box__progress-bar' ), this.explicitWaitMS * 5 );
+	}
+
 	waitForPageToDisappear() {
-		const self = this;
-		return self.driver.wait( function() {
-			return driverHelper.isElementPresent( self.driver, self.expectedElementSelector ).then( function( present ) {
-				return ! present;
-			}, function() {
-				return false;
-			} );
-		}, self.explicitWaitMS * 3, 'The Secure Payment Component is still visible when it shouldn\'t be' );
+		return driverHelper.waitTillNotPresent( this.driver, this.expectedElementSelector, this.explicitWaitMS * 3 );
 	}
 
 	payTotalButton() {

--- a/lib/pages/signup/domain-first-page.js
+++ b/lib/pages/signup/domain-first-page.js
@@ -1,0 +1,13 @@
+import { By } from 'selenium-webdriver';
+import BaseContainer from '../../base-container';
+import * as driverHelper from '../../driver-helper';
+
+export default class DomainFirstPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.site-or-domain__choices' ) );
+	}
+
+	chooseJustBuyTheDomain() {
+		return driverHelper.clickWhenClickable( this.driver, By.css( '.site-or-domain__choice[data-e2e-type="domain"]' ) );
+	}
+}

--- a/lib/pages/signup/start-page.js
+++ b/lib/pages/signup/start-page.js
@@ -5,13 +5,19 @@ import BaseContainer from '../../base-container';
 import * as dataHelper from '../../data-helper';
 
 export default class StartPage extends BaseContainer {
-	constructor( driver, { visit = true, culture = 'en', personalPlanSetting = 'hide', flow = '' } = {} ) {
+	constructor( driver, { visit = true, culture = 'en', flow = '', domainFirst = false, domainFirstDomain = '' } = {} ) {
 		let url;
 		if ( visit === true ) {
+			let queryStrings = '';
 			url = config.get( 'calypsoBaseURL' ) + '/start';
 
 			if ( flow !== '' ) {
 				url += '/' + flow;
+			}
+
+			if ( domainFirst === true ) {
+				url += '/domain-first/site-or-domain';
+				queryStrings = StartPage.appendQueryString( queryStrings, `new=${ domainFirstDomain }` );
 			}
 
 			if ( culture !== 'en' ) {
@@ -19,8 +25,9 @@ export default class StartPage extends BaseContainer {
 			}
 
 			if ( dataHelper.isRunningOnLiveBranch() ) {
-				url = url + '?branch=' + config.get( 'branchName' );
+				queryStrings = StartPage.appendQueryString( queryStrings, `branch=${ config.get( 'branchName' ) }` );
 			}
+			url += queryStrings;
 		} else {
 			url = driver.getCurrentUrl().then( ( urlDisplayed ) => {
 				return urlDisplayed;
@@ -32,5 +39,12 @@ export default class StartPage extends BaseContainer {
 		super( driver, By.css( '.step-wrapper' ), visit, url );
 		this.checkForUnknownABTestKeys();
 		this.setABTestControlGroupsInLocalStorage( url, culture, ABTestControlFlow );
+	}
+
+	static appendQueryString( existingQueryString, queryStringPair ) {
+		if ( existingQueryString === '' ) {
+			return `?${ queryStringPair }`;
+		}
+		return `${ existingQueryString }&${ queryStringPair }`;
 	}
 }

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -622,12 +622,12 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 		} );
 	} );
 
-	test.describe( 'Partially sign up for a site on a business paid plan w/ domain name coming in via /create as business flow @parallel @canary', function() {
+	test.describe( 'Sign up for a site on a business paid plan w/ domain name coming in via /create as business flow @parallel @canary', function() {
 		this.bailSuite( true );
 		let stepNum = 1;
 
 		const siteName = dataHelper.getNewBlogName();
-		const expectedDomainName = `${siteName}.com`;
+		const expectedDomainName = `${siteName}.live`;
 		const emailAddress = dataHelper.getEmailAddress( siteName, signupInboxId );
 		const password = config.get( 'passwordForNewTestSignUps' );
 		const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
@@ -691,7 +691,7 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 					} );
 
 					test.it( 'Can search for a blog name, can see and select a paid .com address in results', function() {
-						this.findADomainComponent.searchForBlogNameAndWaitForResults( siteName );
+						this.findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
 						return this.findADomainComponent.selectDotComAddress( expectedDomainName );
 					} );
 
@@ -767,7 +767,21 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 
 								test.it( 'Can enter and submit test payment details', function() {
 									this.securePaymentComponent = new SecurePaymentComponent( driver );
-									return this.securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
+									this.securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
+									this.securePaymentComponent.submitPaymentDetails();
+									this.securePaymentComponent.waitForCreditCardPaymentProcessing();
+									return this.securePaymentComponent.waitForPageToDisappear();
+								} );
+
+								test.describe( `Step ${stepNum}: Checkout Thank You Page`, function() {
+									stepNum++;
+
+									test.it( 'Can see the secure check out thank you page', function() {
+										this.CheckOutThankyouPage = new CheckOutThankyouPage( driver );
+										return this.CheckOutThankyouPage.displayed().then( ( displayed ) => {
+											return assert.equal( displayed, true, 'The checkout thank you page is not displayed' );
+										} );
+									} );
 								} );
 							} );
 						} );

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -602,6 +602,7 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 						test.it( 'Can enter and submit test payment details', function() {
 							this.securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 							this.securePaymentComponent.submitPaymentDetails();
+							this.securePaymentComponent.waitForCreditCardPaymentProcessing();
 							return this.securePaymentComponent.waitForPageToDisappear();
 						} );
 


### PR DESCRIPTION
Fixes #759

Depends upon data attributes in https://github.com/Automattic/wp-calypso/pull/19264

This adds a domain only signup scenario using a .live domain sandbox method

Also, this completes the business plan scenario using the same .live domain sandbox method

Should we add some tasks to the end of sign up to ensure calypso shows a domain only site? This would fix this issue: #732