### PR TITLE
Revert "Temporarily disable setting AB tests on domains page"

### DIFF
--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -63,10 +63,9 @@ test.describe( `[${host}] Managing Domains: (${screenSize}) @parallel`, function
 		test.describe( 'Can search for and select a paid domain', function() {
 			test.it( 'Can choose add a domain', () => {
 				const domainsPage = new DomainsPage( driver );
-				// Temporarily disabled due to https://github.com/Automattic/wp-calypso/issues/19262
-				// driver.getCurrentUrl().then( ( urlDisplayed ) => {
-				// 	domainsPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
-				// } );
+				driver.getCurrentUrl().then( ( urlDisplayed ) => {
+					domainsPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
+				} );
 				return domainsPage.clickAddDomain();
 			} );
 


### PR DESCRIPTION
Reverts Automattic/wp-e2e-tests#761

Fixes #762 