### PR TITLE
Update the save selector for editor

### DIFF
--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -16,7 +16,7 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 	}
 
 	ensureSaved( { clickSave = true } = {} ) {
-		const saveSelector = By.css( 'button.editor-ground-control__save' );
+		const saveSelector = By.css( '.editor-ground-control__status button.editor-ground-control__save' );
 		const savedSelector = By.css( 'span.editor-ground-control__save-status[data-e2e-status="Saved"]' );
 		const driver = this.driver;
 


### PR DESCRIPTION
When running locally (calypso.localhost) and revision history is enabled the old selector doesn't work as expected