### PR TITLE
Handle upgrade nudge notice when testing plugins page

### DIFF
--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -60,8 +60,20 @@ export default class SidebarComponent extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, By.css( '.preview a' ) );
 	}
 	selectPlugins() {
-		this.driver.findElement( By.css( '.sites-navigation .plugins a' ) ).click();
-		return this.driver.wait( until.elementLocated( By.css( '.plugins-browser-list' ) ) );
+		let selector = By.css( '.sites-navigation .plugins a' );
+		let dismissNoticeSelector = By.css( '.notice.is-dismissable .notice__dismiss' );
+		const driver = this.driver;
+
+		return driverHelper.clickWhenClickable( driver, selector ).then(
+			function success() {},
+			function fail() {
+				// Dismiss any visible notice (i.e upgrade nudge) and try again
+				return driverHelper.clickIfPresent( driver, dismissNoticeSelector ).then( () => {
+					return driverHelper.clickWhenClickable( driver, selector );
+				} );
+			} ).then( () => {
+				return driver.wait( until.elementLocated( By.css( '.plugins-browser-list' ) ) )
+			} );
 	}
 	selectSettings() {
 		return this.driver.findElement( By.css( '.sites-navigation .settings a' ) ).click();

--- a/lib/pages/plugin-details-page.js
+++ b/lib/pages/plugin-details-page.js
@@ -8,7 +8,7 @@ const until = webdriver.until;
 export default class PluginDetailsPage extends BaseContainer {
 	constructor( driver ) {
 		super( driver, by.css( '.plugin__page' ) );
-		this.successNoticeSelector = by.css( '.notice.is-success' );
+		this.successNoticeSelector = by.css( '.notice.is-success.is-dismissable' );
 		this.activatePluginSelector = by.css( '.plugin-activate-toggle .form-toggle__switch' );
 	}
 


### PR DESCRIPTION
We were seeing some issues with the Jetpack plugins page on Calypso related to a new plan upgrade nudge.  This PR just updates a selector and applies some retry logic.