### PR TITLE
Fix theme switch for CI-based jetpack sites

### DIFF
--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -138,8 +138,15 @@ export default class LoginFlow {
 
 	loginAndSelectThemes() {
 		this.loginAndSelectMySite();
-
 		let sideBarComponent = new SidebarComponent( this.driver );
+
+		if ( host === 'CI' ) {
+			const siteURL = dataHelper.getJetpackSiteName();
+
+			sideBarComponent.selectSiteSwitcher();
+			sideBarComponent.searchForSite( siteURL );
+		}
+
 		return sideBarComponent.selectThemes();
 	}
 

--- a/specs/wp-theme-switch-spec.js
+++ b/specs/wp-theme-switch-spec.js
@@ -6,13 +6,11 @@ import * as driverManager from '../lib/driver-manager.js';
 
 import LoginFlow from '../lib/flows/login-flow.js';
 
-import ReaderPage from '../lib/pages/reader-page';
 import ThemesPage from '../lib/pages/themes-page.js';
 import ThemePreviewPage from '../lib/pages/theme-preview-page.js';
 import ThemeDetailPage from '../lib/pages/theme-detail-page.js';
 import ViewSitePage from '../lib/pages/view-site-page';
 import ThemeDialogComponent from '../lib/components/theme-dialog-component.js';
-import NavbarComponent from '../lib/components/navbar-component';
 import SidebarComponent from '../lib/components/sidebar-component';
 import * as dataHelper from '../lib/data-helper';
 
@@ -74,7 +72,7 @@ test.describe( `[${host}] Switching Themes: (${screenSize})`, function() {
 test.describe( `[${host}] Activating Themes: (${screenSize}) @parallel @jetpack`, function() {
 	this.timeout( mochaTimeOut );
 	this.bailSuite( true );
-	let siteAddress;
+	let siteAddress, sidebarComponent;
 
 	test.describe( 'Activating Themes:', function() {
 		// Ensure logged out
@@ -82,16 +80,20 @@ test.describe( `[${host}] Activating Themes: (${screenSize}) @parallel @jetpack`
 			driverManager.clearCookiesAndDeleteLocalStorage( driver );
 		} );
 
-		test.it( 'Login and select Themes', function() {
+		test.it( 'Login', function() {
 			let loginFlow = new LoginFlow( driver );
-			return loginFlow.loginAndSelectThemes();
+			return loginFlow.loginAndSelectMySite();
 		} );
 
 		test.it( 'Can capture the site\'s address from the sidebar', function() {
-			let sidebarComponent = new SidebarComponent( driver );
+			sidebarComponent = new SidebarComponent( driver );
 			return sidebarComponent.getCurrentSiteDomain().then( ( domain ) => {
 				siteAddress = domain;
 			} );
+		} );
+
+		test.it( 'Can open Themes menu', function() {
+			return sidebarComponent.selectThemes();
 		} );
 
 		test.describe( 'Can switch free themes', function() {

--- a/specs/wp-theme-switch-spec.js
+++ b/specs/wp-theme-switch-spec.js
@@ -77,26 +77,21 @@ test.describe( `[${host}] Activating Themes: (${screenSize}) @parallel @jetpack`
 	let siteAddress;
 
 	test.describe( 'Activating Themes:', function() {
-		test.it( 'Delete Cookies and Login', function() {
+		// Ensure logged out
+		test.before( function() {
 			driverManager.clearCookiesAndDeleteLocalStorage( driver );
-			let loginFlow = new LoginFlow( driver );
-			loginFlow.login();
-			let readerPage = new ReaderPage( this.driver, true );
-			return readerPage.waitForPage();
 		} );
 
-		test.it( 'Can capture the site\'s address from the sidebar and select themes', function() {
-			let navbarComponent = new NavbarComponent( this.driver );
-			navbarComponent.clickMySites();
+		test.it( 'Login and select Themes', function() {
+			let loginFlow = new LoginFlow( driver );
+			return loginFlow.loginAndSelectThemes();
+		} );
+
+		test.it( 'Can capture the site\'s address from the sidebar', function() {
 			let sidebarComponent = new SidebarComponent( driver );
 			return sidebarComponent.getCurrentSiteDomain().then( ( domain ) => {
 				siteAddress = domain;
 			} );
-		} );
-
-		test.it( 'Can select themes', function() {
-			let sidebarComponent = new SidebarComponent( driver );
-			return sidebarComponent.selectThemes();
 		} );
 
 		test.describe( 'Can switch free themes', function() {


### PR DESCRIPTION
I'm not sure why it suddenly stopped working (I _guess_ it's a complication from #774), but the theme switch spec was failing for the dynamically-created Jetpack sites.  It was actually switching the theme on the main wpcom site, rather than the connected Jetpack site.