### PR TITLE
Increase sleep time in a couple customizer tests

### DIFF
--- a/lib/pages/customizer-page.js
+++ b/lib/pages/customizer-page.js
@@ -371,7 +371,7 @@ export default class CustomizerPage extends BaseContainer {
 	}
 
 	previewShowsHeader( fileDetails ) {
-		this.driver.sleep( 2000 ); //This is required to show the custom header
+		this.driver.sleep( 3000 ); //This is required to show the custom header
 		this._ensurePreviewViewOnMobile();
 		this._switchToPreviewiFrame();
 		const visible = this.driver.wait( until.elementLocated( by.css( `div.header-image img[src$='${ fileDetails.fileName }']` ) ), this.explicitWaitMS ).then( () => {
@@ -384,7 +384,7 @@ export default class CustomizerPage extends BaseContainer {
 	}
 
 	previewShowsWidget( widgetTitle, widgetContent ) {
-		this.driver.sleep( 2000 ); //This is required to show the custom header
+		this.driver.sleep( 3000 ); //This is required to show the custom header
 		const selector = by.xpath( `//h2[normalize-space(text())="${widgetTitle}"]` );
 		this._ensurePreviewViewOnMobile();
 		this._switchToPreviewiFrame();


### PR DESCRIPTION
For some reason the post-NUX tests were failing.  I bumped up the sleep times for the header image and widget tests and it looks clean now.