### PR TITLE
AB Tests: Add known test jetpackHidePlanIconsOnMobile to default config

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -62,6 +62,7 @@
     "domainsCheckoutLocalizedAddresses",
     "gsuiteUpsell",
     "jetpackConnectPlansCopyChanges",
+    "jetpackHidePlanIconsOnMobile",
     "multiDomainRegistrationV1",
     "newSiteWithJetpack",
     "paymentShowPaypalLogo",

--- a/config/default.json
+++ b/config/default.json
@@ -56,7 +56,24 @@
     }
   },
   "httpsHosts": [ "WPCOM", "PRESSABLE" ],
-  "knownABTestKeys": [ "multiDomainRegistrationV1", "signupSurveyStep", "presaleChatButton", "businessPlanDescriptionAT", "newSiteWithJetpack", "postPublishConfirmation", "readerIntroIllustration", "paymentShowPaypalLogo", "jetpackConnectPlansCopyChanges", "postSignupUpgradeScreen", "skipThemesSelectionModal", "recommendShortestDomain", "checkoutPaymentMethodTabs", "unlimitedThemeNudge", "gsuiteUpsell", "domainsCheckoutLocalizedAddresses" ],
+  "knownABTestKeys": [
+    "businessPlanDescriptionAT",
+    "checkoutPaymentMethodTabs",
+    "domainsCheckoutLocalizedAddresses",
+    "gsuiteUpsell",
+    "jetpackConnectPlansCopyChanges",
+    "multiDomainRegistrationV1",
+    "newSiteWithJetpack",
+    "paymentShowPaypalLogo",
+    "postPublishConfirmation",
+    "postSignupUpgradeScreen",
+    "presaleChatButton",
+    "readerIntroIllustration",
+    "recommendShortestDomain",
+    "signupSurveyStep",
+    "skipThemesSelectionModal",
+    "unlimitedThemeNudge"
+  ],
   "overrideABTests": [
 	[ "signupSurveyStep_20170329", "hideSurveyStep" ],
 	[ "postPublishConfirmation_20170801", "showPublishConfirmation" ],


### PR DESCRIPTION
`jetpackHidePlanIconsOnMobile` was added in https://github.com/Automattic/wp-calypso/pull/19335

This PR adds it to the known tests.

It also formats and alphabetizes the list of known tests to make future additions and deletions less invasive (smaller diffs).