### PR TITLE
Cleanup an unnecessary console.log in Jetpack connect spec

### DIFF
--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -88,7 +88,6 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 
 		test.it( 'Has site URL in route', done => {
 			const siteSlug = this.url.replace( /^https?:\/\//, '' );
-			console.log( siteSlug );
 			return driver.getCurrentUrl().then( url => {
 				if ( url.includes( siteSlug ) ) {
 					return done();


### PR DESCRIPTION
This PR cleans up an unnecessary `console.log()` from the Jetpack Connect spec.