### PR TITLE
dotorg site creator: use `shortlived` param to save resources

### DIFF
--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -4,7 +4,7 @@ import BaseContainer from '../base-container';
 
 import * as driverHelper from '../driver-helper';
 
-const TEMPLATE_URL = 'http://jurassic.ninja/create';
+const TEMPLATE_URL = 'http://jurassic.ninja/create?shortlived';
 const PASSWORD_ELEMENT = By.css( '#jurassic_password' );
 const URL_ELEMENT = By.css( '#jurassic_url' );
 const CONTINUE_LINK = By.linkText( 'The new WP is ready to go, visit it!' );


### PR DESCRIPTION
Creating a jurassic.ninja site using the `shortlived` param will return a site that expires after just one hour instead of one week, meaning we can create many more sites for the same resource usage.