### PR TITLE
Introduce a test for Jetpack Connect starting from wp-admin

### DIFF
--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -174,7 +174,7 @@ export default class LoginFlow {
 	loginUsingExistingForm() {
 		let testUserName, testPassword;
 
-		const accountInfo = LoginFlow.getAccountConfig( this.account );
+		const accountInfo = dataHelper.getAccountConfig( this.account );
 
 		if ( accountInfo !== undefined ) {
 			testUserName = accountInfo[0];

--- a/lib/pages/signup/create-your-account-page.js
+++ b/lib/pages/signup/create-your-account-page.js
@@ -23,4 +23,9 @@ export default class CreateYourAccountPage extends BaseContainer {
 		const errorElement = this.driver.findElement( errorSelector );
 		return this.driver.wait( until.elementIsVisible( errorElement ), this.explicitWaitMS, 'Could not see validation errors displayed' );
 	}
+
+	clickLoginLink() {
+		const selector = By.css( 'a.logged-out-form__link-item[href*="log-in"]' );
+		return driverHelper.clickWhenClickable( this.driver, selector, this.explicitWaitMS );
+	}
 }

--- a/lib/pages/wp-admin/wp-admin-jetpack-page.js
+++ b/lib/pages/wp-admin/wp-admin-jetpack-page.js
@@ -20,6 +20,10 @@ export default class WPAdminJetpackPage extends BaseContainer {
 		return driverHelper.isElementPresent( this.driver, by.css( '.jp-at-a-glance' ) );
 	}
 
+	jumpstartDisplayed() {
+		return driverHelper.isElementPresent( this.driver, by.css( '.jp-jumpstart' ) );
+	}
+
 	openPlansTab() {
 		const selector = by.css( '.dops-section-nav__panel li.dops-section-nav-tab:nth-child(2) a' );
 		return driverHelper.clickWhenClickable( this.driver, selector );

--- a/lib/pages/wp-admin/wp-admin-sidebar.js
+++ b/lib/pages/wp-admin/wp-admin-sidebar.js
@@ -24,7 +24,7 @@ export default class WPAdminSidebar extends BaseContainer {
 
 	selectJetpack() {
 		const jetpackMenuSelector = by.css( '#toplevel_page_jetpack' );
-		const menuItemSelector = by.css( '#toplevel_page_jetpack li a[href$="jetpack#/dashboard"]' );
+		const menuItemSelector = by.css( '#toplevel_page_jetpack a[href$="jetpack#/dashboard"], #toplevel_page_jetpack a[href$="jetpack"]' );
 
 		return this._selectMenuItem( jetpackMenuSelector, menuItemSelector );
 	}

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -1,11 +1,9 @@
 /** @format */
 import test from 'selenium-webdriver/testing';
 import config from 'config';
-import assert from 'assert';
 
 import * as driverManager from '../lib/driver-manager';
 import * as driverHelper from '../lib/driver-helper';
-import * as dataHelper from '../lib/data-helper';
 import { By } from 'selenium-webdriver';
 
 import AddNewSitePage from '../lib/pages/add-new-site-page';

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -9,9 +9,13 @@ import * as dataHelper from '../lib/data-helper';
 import { By } from 'selenium-webdriver';
 
 import AddNewSitePage from '../lib/pages/add-new-site-page';
+import CreateYourAccountPage from '../lib/pages/signup/create-your-account-page.js';
+import JetpackAuthorizePage from '../lib/pages/jetpack-authorize-page';
 import PickAPlanPage from '../lib/pages/signup/pick-a-plan-page';
 import SettingsPage from '../lib/pages/settings-page';
 import WporgCreatorPage from '../lib/pages/wporg-creator-page';
+import WPAdminJetpackPage from '../lib/pages/wp-admin/wp-admin-jetpack-page.js';
+import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar.js';
 import LoginFlow from '../lib/flows/login-flow';
 import SidebarComponent from '../lib/components/sidebar-component';
 
@@ -94,6 +98,59 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 				}
 				done( `Route ${ url } does not include site slug ${ siteSlug }` );
 			} );
+		} );
+	} );
+
+	test.describe.only( 'Connect From wp-admin:', function() {
+		this.bailSuite( true );
+
+		test.before( function() {
+			return driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		} );
+
+		test.it( 'Can create a WP.org site', () => {
+			this.wporgCreator = new WporgCreatorPage( driver );
+			this.wporgCreator.waitForWpadmin();
+		} );
+
+		test.it( 'Can get URL of WP.org site', () => {
+			this.wporgCreator.getUrl().then( url => {
+				this.url = url;
+			} );
+		} );
+
+		test.it( 'Can navigate to the Jetpack dashboard', () => {
+			this.wpAdminSidebar = new WPAdminSidebar( driver );
+			return this.wpAdminSidebar.selectJetpack();
+		} );
+
+		test.it( 'Can click the Connect Jetpack button', () => {
+			this.wpAdminJetpack = new WPAdminJetpackPage( driver );
+			return this.wpAdminJetpack.connectWordPressCom();
+		} );
+
+		test.it( 'Can click the login link in the account creation page', () => {
+			this.createAccountPage = new CreateYourAccountPage( driver )
+			return this.createAccountPage.clickLoginLink();
+		} );
+
+		test.it( 'Can login into WordPress.com', () => {
+			const loginFlow = new LoginFlow( driver, 'jetpackConnectUser' );
+			return loginFlow.loginUsingExistingForm();
+		} );
+
+		test.it( 'Can approve connection on the authorization page', () => {
+			this.jetpackAuthorizePage = new JetpackAuthorizePage( driver )
+			return this.jetpackAuthorizePage.approveConnection();
+		} );
+
+		test.it( 'Can click the free plan button', () => {
+			this.pickAPlanPage = new PickAPlanPage( driver );
+			return this.pickAPlanPage.selectFreePlanJetpack();
+		} );
+
+		test.it( 'Is redirected back to the Jetpack dashboard with Jumpstart displayed', () => {
+			return this.wpAdminJetpack.jumpstartDisplayed();
 		} );
 	} );
 } );

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -99,7 +99,7 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 		} );
 	} );
 
-	test.describe.only( 'Connect From wp-admin:', function() {
+	test.describe( 'Connect From wp-admin:', function() {
 		this.bailSuite( true );
 
 		test.before( function() {


### PR DESCRIPTION
This PR adds a test for connecting a .org site running jetpack, starting from wp-admin, which is the general flow according to p7rd6c-132-p2. 

Uses the recently introduced `wporg-creator-page` to create a .org site with Jetpack installed (using the jurassic.ninja service). Right now it creates a new site, but we might want to consider creating just 1 site and running all tests against it.

Requires the user `e2eflowtestingjetpackconnect` for logging into WordPress.com.

