### PR TITLE
Handle new 'restore post' option following trashing it

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -157,9 +157,17 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 
 	trashPost() {
 		const trashSelector = By.css( 'button.editor-delete-post__button' );
+		const confirmationSelector = By.css( 'button[data-e2e-button="accept"]' );
+		const doNotRestoreSelector = By.css( 'div.dialog__action-buttons button:not(.is-primary)' );
+
 		driverHelper.waitTillPresentAndDisplayed( this.driver, trashSelector );
 		driverHelper.clickWhenClickable( this.driver, trashSelector );
-		return driverHelper.clickWhenClickable( this.driver, By.css( '.dialog button.is-primary' ) );
+
+		driverHelper.clickWhenClickable( this.driver, confirmationSelector );
+		driverHelper.waitTillNotPresent( this.driver, confirmationSelector );
+
+		driverHelper.waitTillPresentAndDisplayed( this.driver, doNotRestoreSelector );
+		return driverHelper.clickWhenClickable( this.driver, doNotRestoreSelector );
 	}
 
 	openFeaturedImageDialog() {


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/18785 changed the Trash Post flow slightly