### PR TITLE
WporgCreatorPage: Add multiple templates support

### DIFF
--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -4,15 +4,22 @@ import BaseContainer from '../base-container';
 
 import * as driverHelper from '../driver-helper';
 
-const TEMPLATE_URL = 'http://jurassic.ninja/create?shortlived';
+const TEMPLATES = {
+	default: 'http://jurassic.ninja/create?shortlived',
+	noJetpack: 'http://jurassic.ninja/create?shortlived&nojetpack',
+};
 const PASSWORD_ELEMENT = By.css( '#jurassic_password' );
 const URL_ELEMENT = By.css( '#jurassic_url' );
 const CONTINUE_LINK = By.linkText( 'The new WP is ready to go, visit it!' );
 const PROGRESS_MESSAGE = By.css( '#progress' );
 
 export default class WporgCreatorPage extends BaseContainer {
-	constructor( driver ) {
-		super( driver, PROGRESS_MESSAGE, /* visit url */ true, TEMPLATE_URL );
+	constructor( driver, template = 'default' ) {
+		if ( ! TEMPLATES[ template ] ) {
+			throw new Error( 'Incorrect WporgCreatorPage template specified.' );
+		}
+
+		super( driver, PROGRESS_MESSAGE, /* visit url */ true, TEMPLATES[ template ] );
 		driverHelper.waitTillPresentAndDisplayed( driver, CONTINUE_LINK, this.explicitWaitMS * 2 );
 		driverHelper.clickWhenClickable( driver, CONTINUE_LINK );
 	}


### PR DESCRIPTION
This PR updates `WporgCreatorPage` to allow multiple templates, and introduces a new template for a site without Jetpack. Default behavior remains unchanged, so all tests that use the `WporgCreatorPage` should still pass.