### PR TITLE
Jetpack Connect: Fix intermittent failures

### DIFF
--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -20,7 +20,7 @@ export default class WporgCreatorPage extends BaseContainer {
 		}
 
 		super( driver, PROGRESS_MESSAGE, /* visit url */ true, TEMPLATES[ template ] );
-		driverHelper.waitTillPresentAndDisplayed( driver, CONTINUE_LINK, this.explicitWaitMS * 2 );
+		driverHelper.waitTillPresentAndDisplayed( driver, CONTINUE_LINK, this.explicitWaitMS * 3 );
 		driverHelper.clickWhenClickable( driver, CONTINUE_LINK );
 	}
 

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -65,6 +65,10 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 						// make the 'add site' stuff below more robust instead.
 						return driver.navigate().refresh();
 					}
+					// Wait until Custom Post Type links are present to avoid sidebar positions
+					// changing when attempting to click 'Settings'
+					driverHelper.waitTillPresentAndDisplayed( driver, By.linkText( 'Feedback' ) );
+
 					this.sidebarComponent.selectSettings();
 					const settingsPage = new SettingsPage( driver );
 					settingsPage.manageConnection();
@@ -128,7 +132,7 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 		} );
 
 		test.it( 'Can click the login link in the account creation page', () => {
-			this.createAccountPage = new CreateYourAccountPage( driver )
+			this.createAccountPage = new CreateYourAccountPage( driver );
 			return this.createAccountPage.clickLoginLink();
 		} );
 
@@ -138,7 +142,7 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 		} );
 
 		test.it( 'Can approve connection on the authorization page', () => {
-			this.jetpackAuthorizePage = new JetpackAuthorizePage( driver )
+			this.jetpackAuthorizePage = new JetpackAuthorizePage( driver );
 			return this.jetpackAuthorizePage.approveConnection();
 		} );
 


### PR DESCRIPTION
1) Fixes a problem when attempting to click the sidebar _Settings_ link. The custom-post-type sidebar links sometimes show up just before the click, giving this error:
```
WebDriverError: unknown error: Element <a href="/settings/general/motionless-mamba-21.jurassic.ninja">...</a> is not clickable at point (186, 825). Other element would receive the click: <a href="/plugins/motionless-mamba-21.jurassic.ninja">...</a>
```
Fix by waiting for the links.

2) Increases the timeout for creating wporg sites.
