### PR TITLE
Dismiss publish success notice before attempting to revert a draft

### DIFF
--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -50,6 +50,10 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 		return driverHelper.waitTillPresentAndDisplayed( this.driver, viewPostSelector );
 	}
 
+	dismissSuccessViewPostNotice() {
+		return driverHelper.clickWhenClickable( this.driver, By.css( '.notice.is-success .notice__dismiss' ) );
+	}
+
 	publishAndPreviewPublished( { useConfirmStep = false } = {} ) {
 		this.clickPublishPost();
 		if ( useConfirmStep === true ) {

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -971,7 +971,7 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 		} );
 	} );
 
-	test.describe( 'Revert a post to draft: @parallel @jetpack', function() {
+	test.describe.only( 'Revert a post to draft: @parallel @jetpack', function() {
 		this.bailSuite( true );
 
 		test.before( function() {
@@ -1018,6 +1018,7 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 			test.it( 'Can revert the post to draft', function() {
 				let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 				let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+				postEditorToolbarComponent.dismissSuccessViewPostNotice();
 				postEditorSidebarComponent.revertToDraft();
 				postEditorToolbarComponent.waitForIsDraftStatus();
 				postEditorToolbarComponent.statusIsDraft().then( ( isDraft ) => {

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -971,7 +971,7 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 		} );
 	} );
 
-	test.describe.only( 'Revert a post to draft: @parallel @jetpack', function() {
+	test.describe( 'Revert a post to draft: @parallel @jetpack', function() {
 		this.bailSuite( true );
 
 		test.before( function() {


### PR DESCRIPTION
We are seeing failures to open the post editor sidebar while the publish success notice is visible. This PR dismisses that success notice before attempting to revert the draft.