### PR TITLE
Jetpack: Fix unreliable site disconnects in the Jetpack connect tests

### DIFF
--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -145,7 +145,7 @@ export default class SidebarComponent extends BaseContainer {
 	/**
 	 * Removes a single jetpack site with error label from the sites list.
 	 *
-	 * @return Thenable<bool> true if site was removed
+	 * @return Thenable<bool> true if a site was removed
 	 */
 	removeBrokenSite() {
 		const siteSwitcherSelector = By.css( '.current-site__switch-sites' );

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -143,33 +143,10 @@ export default class SidebarComponent extends BaseContainer {
 	}
 
 	/**
-	 * Selects a jetpack site, if present, from the site switcher.
+	 * Removes a single jetpack site with error label from the sites list.
 	 *
-	 * @return Thenable<bool> true if a jetpack site was selected.
+	 * @return Thenable<bool> true if site was removed
 	 */
-	selectJetpackSite() {
-		const siteSwitcherSelector = By.css( '.current-site__switch-sites' );
-		const siteSelector = By.css( '.is-jetpack' );
-
-		this.ensureSidebarMenuVisible();
-		return driverHelper.isElementPresent( this.driver, siteSwitcherSelector ).then( foundSwitcher => {
-			if ( ! foundSwitcher ) {
-				// no site switcher, only one site
-				return false;
-			}
-			this.selectSiteSwitcher();
-			return driverHelper.isElementPresent( this.driver, siteSelector ).then( foundSite => {
-				if ( ! foundSite ) {
-					// no jp sites left
-					driverHelper.clickWhenClickable( this.driver, By.css( '.site' ) );
-					return false;
-				}
-				driverHelper.clickWhenClickable( this.driver, siteSelector );
-				return true;
-			} );
-		} );
-	}
-
 	removeBrokenSite() {
 		const siteSwitcherSelector = By.css( '.current-site__switch-sites' );
 		const brokenSiteButton = By.css( '.is-error .site-indicator__button' );

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -169,4 +169,40 @@ export default class SidebarComponent extends BaseContainer {
 			} );
 		} );
 	}
+
+	removeBrokenSite() {
+		const siteSwitcherSelector = By.css( '.current-site__switch-sites' );
+		const brokenSiteButton = By.css( '.is-error .site-indicator__button' );
+		const disconnectJetpackButton = By.css( '.disconnect-jetpack-button' );
+		const removeSiteButton = By.css( '.disconnect-jetpack__button-wrap .button' );
+
+		this.ensureSidebarMenuVisible();
+		return driverHelper.isElementPresent( this.driver, siteSwitcherSelector ).then( foundSwitcher => {
+			if ( ! foundSwitcher ) {
+				// no site switcher, only one site
+				return false;
+			}
+			this.selectSiteSwitcher();
+			return driverHelper.isElementPresent( this.driver, brokenSiteButton ).then( foundBroken => {
+				if ( ! foundBroken ) {
+					// no broken sites
+					return false;
+				}
+				driverHelper.clickWhenClickable( this.driver, brokenSiteButton );
+				return driverHelper.waitTillPresentAndDisplayed(
+					this.driver,
+					disconnectJetpackButton
+				).then( () => {
+					driverHelper.clickWhenClickable( this.driver, disconnectJetpackButton );
+					return driverHelper.waitTillPresentAndDisplayed(
+						this.driver,
+						removeSiteButton
+					).then( () => {
+						driverHelper.clickWhenClickable( this.driver, removeSiteButton );
+						return true;
+					} );
+				} );
+			} );
+		} );
+	}
 }

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -65,7 +65,6 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 						driver,
 						By.css( '.notice.is-dismissable .notice__dismiss' )
 					);
-					console.log( 'going to remove sites again' );
 					removeSites();
 				} );
 			};

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -35,6 +35,45 @@ test.before( function() {
 test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 	this.timeout( mochaTimeOut );
 
+	test.describe( 'Disconnect expired sites:', function() {
+		this.bailSuite( true );
+
+		test.before( function() {
+			return driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		} );
+
+		test.it( 'Can log in', () => {
+			const loginFlow = new LoginFlow( driver, 'JetpackUserPOOPY' );
+			loginFlow.loginAndSelectMySite();
+		} );
+
+		test.it( 'Can disconnect any expired sites', () => {
+			this.sidebarComponent = new SidebarComponent( driver );
+
+			const removeSites = () => {
+				this.sidebarComponent.removeBrokenSite().then( removed => {
+					if ( ! removed ) {
+						// no sites left to remove
+						return;
+					}
+					// seems like it is not waiting for this
+					driverHelper.waitTillPresentAndDisplayed(
+						driver,
+						By.css( '.notice.is-success.is-dismissable' )
+					);
+					driverHelper.clickWhenClickable(
+						driver,
+						By.css( '.notice.is-dismissable .notice__dismiss' )
+					);
+					console.log( 'going to remove sites again' );
+					removeSites();
+				} );
+			};
+
+			removeSites();
+		} );
+	} );
+
 	test.describe( 'Connect From Calypso:', function() {
 		this.bailSuite( true );
 

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -97,35 +97,9 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 			loginFlow.loginAndSelectMySite();
 		} );
 
-		test.it( 'Can disconnect existing jetpack sites', () => {
-			this.sidebarComponent = new SidebarComponent( driver );
-
-			const removeSites = () => {
-				this.sidebarComponent.selectJetpackSite().then( foundSite => {
-					if ( ! foundSite ) {
-						// Refresh to put the site selector back into a sane state
-						// where it knows there is only one site. Can probably
-						// make the 'add site' stuff below more robust instead.
-						return driver.navigate().refresh();
-					}
-					// Wait until Custom Post Type links are present to avoid sidebar positions
-					// changing when attempting to click 'Settings'
-					driverHelper.waitTillPresentAndDisplayed( driver, By.linkText( 'Feedback' ) );
-
-					this.sidebarComponent.selectSettings();
-					const settingsPage = new SettingsPage( driver );
-					settingsPage.manageConnection();
-					settingsPage.disconnectSite();
-					driverHelper.waitTillPresentAndDisplayed( driver, By.css( '.is-success' ) );
-					removeSites();
-				} );
-			};
-
-			removeSites();
-		} );
-
 		test.it( 'Can add new site', () => {
-			this.sidebarComponent.addNewSite( driver );
+			const sidebarComponent = new SidebarComponent( driver );
+			sidebarComponent.addNewSite( driver );
 			const addNewSitePage = new AddNewSitePage( driver );
 			return addNewSitePage.addSiteUrl( this.url );
 		} );

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -43,7 +43,7 @@ test.describe( `Jetpack Connect: (${ screenSize }) @jetpack`, function() {
 		} );
 
 		test.it( 'Can log in', () => {
-			const loginFlow = new LoginFlow( driver, 'JetpackUserPOOPY' );
+			const loginFlow = new LoginFlow( driver, 'jetpackConnectUser' );
 			loginFlow.loginAndSelectMySite();
 		} );
 


### PR DESCRIPTION
Move site disconnects into a **separate test that disconnects any expired sites**. Disconnecting broken sites can be done from the site switcher and should be more reliable than going through the settings page.

Theoretically this change should allow all the jetpack connect tests in this spec to be run in parallel, because there is no danger of a live site being disconnected.

**Testing**
There should never be any expired sites in the `jetpackConnectUser` account because on the master branch all sites are disconnected in one of the tests. This PR can be tested, slowly, by using a different account, adding some `jurassic.ninja/create?shortlived` sites, and waiting an hour+ for them to expire.

/cc @sirreal