### PR TITLE
Add 'buttonsColorOnPostSignup' as AB test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -74,7 +74,8 @@
     "signupSurveyStep",
     "skipThemesSelectionModal",
     "unlimitedThemeNudge",
-    "condensedPostList"
+    "condensedPostList",
+    "buttonsColorOnPostSignup"
   ],
   "overrideABTests": [
 	[ "signupSurveyStep_20170329", "hideSurveyStep" ],


### PR DESCRIPTION
Introduced in https://github.com/Automattic/wp-calypso/pull/19618