### PR TITLE
Update magic login link selector

### DIFF
--- a/lib/pages/login-page.js
+++ b/lib/pages/login-page.js
@@ -35,7 +35,7 @@ export default class LoginPage extends BaseContainer {
 	}
 
 	requestMagicLink( emailAddress ) {
-		driverHelper.clickWhenClickable( this.driver, By.css( '.wp-login__links a[href="#"]' ) );
+		driverHelper.clickWhenClickable( this.driver, By.css( 'a[data-e2e-link="magic-login-link"]' ) );
 		driverHelper.setWhenSettable( this.driver, By.css( '.magic-login__email-fields input[name="emailAddress"]' ), emailAddress );
 		driverHelper.clickWhenClickable( this.driver, By.css( '.magic-login__form-action button.is-primary' ) );
 		return driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.magic-login__check-email-image' ) );


### PR DESCRIPTION
This relies upon https://github.com/Automattic/wp-calypso/pull/20040 being merged

Fixes #771 