### PR TITLE
Fix theme activation flow for Jetpack

### DIFF
--- a/lib/pages/wp-admin/wp-admin-customizer-page.js
+++ b/lib/pages/wp-admin/wp-admin-customizer-page.js
@@ -1,0 +1,8 @@
+import { By as by } from 'selenium-webdriver';
+import BaseContainer from '../../base-container';
+
+export default class WPAdminCustomizerPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( '.wp-customizer' ) );
+	}
+}

--- a/specs/wp-theme-switch-spec.js
+++ b/specs/wp-theme-switch-spec.js
@@ -12,6 +12,8 @@ import ThemePreviewPage from '../lib/pages/theme-preview-page.js';
 import ThemeDetailPage from '../lib/pages/theme-detail-page.js';
 import ThemeDialogComponent from '../lib/components/theme-dialog-component.js';
 import SidebarComponent from '../lib/components/sidebar-component';
+import WPAdminCustomizerPage from '../lib/pages/wp-admin/wp-admin-customizer-page.js';
+import WPAdminLogonPage from '../lib/pages/wp-admin/wp-admin-logon-page.js';
 import * as dataHelper from '../lib/data-helper';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
@@ -99,14 +101,31 @@ test.describe( `[${host}] Activating Themes: (${screenSize}) @parallel @jetpack`
 				return themesPage.clickPopoverItem( 'Activate' );
 			} );
 
-			test.it( 'Can see the theme thanks dialog and customize the site from this dialog', function() {
+			test.it( 'Can see the theme thanks dialog', function() {
 				let themeDialogComponent = new ThemeDialogComponent( driver );
 				themeDialogComponent.customizeSite();
-				let customizerPage = new CustomizerPage( driver );
-				return customizerPage.displayed().then( ( displayed ) => {
-					assert( displayed, 'The customizer page was not displayed' );
-				} );
 			} );
+
+			if ( host === 'WPCOM' ) {
+				test.it( 'Can customize the site from the theme thanks dialog', function() {
+					let customizerPage = new CustomizerPage( driver );
+					return customizerPage.displayed().then( ( displayed ) => {
+						assert( displayed, 'The customizer page was not displayed' );
+					} );
+				} );
+			} else {
+				test.it( 'Can log in via Jetpack SSO', function() {
+					let wpAdminLogonPage = new WPAdminLogonPage( driver );
+					return wpAdminLogonPage.logonSSO();
+				} );
+
+				test.it( 'Can customize the site from the theme thanks dialog', function() {
+					let wpAdminCustomizerPage = new WPAdminCustomizerPage( driver );
+					return wpAdminCustomizerPage.displayed().then( ( displayed ) => {
+						assert( displayed, 'The customizer page was not displayed' );
+					} );
+				} );
+			}
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR fixes the theme activation flow that was broken due to https://github.com/Automattic/wp-e2e-tests/pull/813:

- If the host is WPCOM, the test checks that the customizer opens in Calypso as before.
- If the host is not WPCOM (i.e. Jetpack test runs), the test logs in to WP Admin via SSO and checks that the WP Admin customizer opens as expected.

To test:

- Set the `NODE_ENV` config including a Jetpack user.
- Set the `JETPACKHOST`.
- Run `./node_modules/.bin/mocha specs/wp-theme-switch-spec.js`.
- Repeat the above with a WPCOM user in the config and `WPCOM` as the host.