### PR TITLE
i18n: Disable ar and zh-tw in Google Search

### DIFF
--- a/lib/pages/external/google-search.js
+++ b/lib/pages/external/google-search.js
@@ -14,7 +14,11 @@ export default class GoogleSearchPage extends BaseContainer {
 		const selector = by.xpath( '//li[@class="ads-ad"]//a[contains(@href, "' + referenceUrl +'")]' )
 		this.driver.wait( until.elementLocated( selector ), this.explicitWaitMS, 'Could not locate the ad link' );
 		this.adLink = this.driver.findElement( selector );
+	}
+
+	adExists() {
 		this.driver.wait( until.elementIsVisible( this.adLink ), this.explicitWaitMS, 'Could not see ad link' );
+		return true;
 	}
 
 	getAdUrl() {

--- a/localization-data.json
+++ b/localization-data.json
@@ -8,7 +8,7 @@
 
 		"google_searches": [
 			{
-				"url": "www.google.com.ar",
+				"domain": "www.google.com.ar",
 				"query": "wordpress",
 				"location": 1005390,
 				"comment_location": "Cairo, Egypt"

--- a/specs-i18n/search-wordpress-on-google.js
+++ b/specs-i18n/search-wordpress-on-google.js
@@ -47,7 +47,10 @@ function doGoogleAdSearch( search_params ) {
 			const googleFlow = new GoogleFlow( driver, 'desktop' );
 			const that = this;
 			googleFlow.search( search_params, test_data ).then( searchPageUrl => {
-				that.searchPage = new GoogleSearchPage( driver, 'https://' + test_data.wpcom_base_url );
+				const searchPage = new GoogleSearchPage( driver, 'https://' + test_data.wpcom_base_url );
+				if ( this.searchPage.adExists() ) {
+					that.searchPage = searchPage;
+				}
 			});
 		} );
 

--- a/specs-i18n/search-wordpress-on-google.js
+++ b/specs-i18n/search-wordpress-on-google.js
@@ -29,9 +29,6 @@ test.after( function( done ) {
 } );
 
 function doGoogleAdSearch( search_params ) {
-	if ( locale === 'tr' ) {
-		this.skip( 'Currently no advertising in this locale' );
-	}
 	var description = 'Search for "' + search_params.query + '" on ' + search_params.domain + ' from ' +
 		search_params.comment_location;
 
@@ -44,6 +41,10 @@ function doGoogleAdSearch( search_params ) {
 		} );
 
 		test.it( `Google search contains our ad`, function() {
+			if ( locale === 'tr' || locale === 'ar' || locale === 'zh-tw' ) {
+				this.skip( 'Currently no advertising in this locale' );
+			}
+
 			const googleFlow = new GoogleFlow( driver, 'desktop' );
 			const that = this;
 			googleFlow.search( search_params, test_data ).then( searchPageUrl => {
@@ -55,10 +56,11 @@ function doGoogleAdSearch( search_params ) {
 		} );
 
 		test.it( `Our landing page exists`, function() {
-			const that = this;
 			if ( ! this.searchPage ) {
 				this.skip( 'Depends on previous test passing' );
 			}
+
+			const that = this;
 			this.searchPage.getAdUrl().then( url => {
 				that.landingPage = new LandingPage( driver, url );
 			} );
@@ -68,6 +70,7 @@ function doGoogleAdSearch( search_params ) {
 			if ( ! this.landingPage ) {
 				this.skip( 'Depends on previous test passing' );
 			}
+
 			this.landingPage.checkLocalizedString( test_data.wpcom_landing_page_string );
 		} );
 	} );


### PR DESCRIPTION
We currently don't advertise in these locales, so let's skip the tests.

This also removes the erroneous creation of a screenshot when skipping a test.