### PR TITLE
Add 'jetpackHidePlanIconsForAllDevices' back to known AB tests

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -66,7 +66,7 @@
     "unlimitedThemeNudge",
     "condensedPostList",
     "buttonsColorOnPostSignup",
-	"jetpackHidePlanIconsOnMobile"
+	"jetpackHidePlanIconsForAllDevices"
   ],
   "overrideABTests": [
 	[ "skipThemesSelectionModal_20170830", "show" ],

--- a/config/default.json
+++ b/config/default.json
@@ -65,7 +65,8 @@
     "skipThemesSelectionModal",
     "unlimitedThemeNudge",
     "condensedPostList",
-    "buttonsColorOnPostSignup"
+    "buttonsColorOnPostSignup",
+	"jetpackHidePlanIconsOnMobile"
   ],
   "overrideABTests": [
 	[ "skipThemesSelectionModal_20170830", "show" ],


### PR DESCRIPTION
Accidently removed in #825