### PR TITLE
Set upcoming onboarding checklist a/b test to hide

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -67,13 +67,17 @@
     "condensedPostList",
     "buttonsColorOnPostSignup",
     "jetpackHidePlanIconsForAllDevices",
-    "signupSiteSegmentStep"
+    "signupSiteSegmentStep",
+    "checklistThankYouForFreeUser",
+    "checklistThankYouForPaidUser"
   ],
   "overrideABTests": [
 	[ "skipThemesSelectionModal_20170830", "show" ],
 	[ "gsuiteUpsell_20171025", "hide" ],
 	[ "domainsCheckoutLocalizedAddresses_20171025", "showDefaultAddressFormat" ],
-	[ "signupSiteSegmentStep_20170329", "control" ]
+	[ "signupSiteSegmentStep_20170329", "control" ],
+	[ "checklistThankYouForFreeUser_20171204", "hide" ],
+	[ "checklistThankYouForPaidUser_20171204", "hide" ]
 
   ]
 }


### PR DESCRIPTION
There is an upcoming a/b test that changes the content of the thank you page to include an onboarding checklist: https://github.com/Automattic/wp-calypso/pull/20501

This config change will ensure existing behavior is preserved for the signup tests.