### PR TITLE
Account for the post editor Save button to be hidden on mobile sidebar view

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -1,4 +1,3 @@
-import config from 'config';
 import { By, until } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper.js';
 import BaseContainer from '../base-container.js';
@@ -19,6 +18,18 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 		driver.findElement( contentSelector ).getAttribute( 'class' ).then( ( c ) => {
 			if ( c.indexOf( 'focus-sidebar' ) < 0 ) {
 				driverHelper.clickWhenClickable( driver, cogSelector );
+			}
+		} );
+	}
+
+	hideComponentIfNecessary() {
+		const driver = this.driver;
+		const contentSelector = By.css( 'div.is-section-post-editor' );
+		const cogSelector = By.css( 'button.editor-ground-control__toggle-sidebar' );
+		driverHelper.waitTillPresentAndDisplayed( driver, contentSelector );
+		return driver.findElement( contentSelector ).getAttribute( 'class' ).then( ( c ) => {
+			if ( c.indexOf( 'focus-sidebar' ) !== -1 ) {
+				return driverHelper.clickWhenClickable( driver, cogSelector );
 			}
 		} );
 	}

--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -1,6 +1,7 @@
 import config from 'config';
 import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper.js';
+import * as driverManager from '../driver-manager.js';
 import * as dataHelper from '../data-helper';
 
 import BaseContainer from '../base-container.js';
@@ -16,7 +17,12 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 	}
 
 	ensureSaved( { clickSave = true } = {} ) {
-		const saveSelector = By.css( '.editor-ground-control__status button.editor-ground-control__save' );
+		let saveSelectorString = 'div.card.editor-ground-control .editor-ground-control__status button.editor-ground-control__save';
+		if ( driverManager.currentScreenSize() === 'mobile' ) {
+			saveSelectorString = 'div.post-editor__content .editor-ground-control__status button.editor-ground-control__save';
+		}
+
+		const saveSelector = By.css( saveSelectorString );
 		const savedSelector = By.css( 'span.editor-ground-control__save-status[data-e2e-status="Saved"]' );
 		const driver = this.driver;
 
@@ -25,7 +31,6 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 		}
 
 		return driverHelper.waitTillPresentAndDisplayed( driver, savedSelector );
-
 	}
 
 	clickPublishPost() {

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -86,30 +86,32 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 
 					test.it( 'Can add a new category', function() {
 						let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
-						let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
 						postEditorSidebarComponent.addNewCategory( newCategoryName );
-						postEditorSidebarComponent.getCategoriesAndTags().then( function( subtitle ) {
-							assert( ! subtitle.match( /Uncategorized/ ), 'Post still marked Uncategorized after adding new category BEFORE SAVE' );
-						} );
-						postEditorToolbarComponent.ensureSaved();
-						postEditorSidebarComponent.getCategoriesAndTags().then( function( subtitle ) {
-							assert( ! subtitle.match( /Uncategorized/ ), 'Post still marked Uncategorized after adding new category AFTER SAVE' );
-						} );
 					} );
 
 					test.it( 'Can add a new tag', function() {
 						let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
-						let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
 						postEditorSidebarComponent.addNewTag( newTagName );
-						postEditorToolbarComponent.ensureSaved();
-						postEditorSidebarComponent.getCategoriesAndTags().then( function( subtitle ) {
-							assert( subtitle.match( `#${newTagName}` ), `New tag #${newTagName} not applied` );
-						} );
 					} );
 
 					test.it( 'Close categories and tags', function() {
 						let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 						postEditorSidebarComponent.closeCategoriesAndTags();
+					} );
+
+					test.it( 'Verify categories and tags present after save', function() {
+						let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+						let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+
+						postEditorSidebarComponent.hideComponentIfNecessary();
+						postEditorToolbarComponent.ensureSaved();
+						postEditorSidebarComponent.displayComponentIfNecessary()
+						postEditorSidebarComponent.getCategoriesAndTags().then( function( subtitle ) {
+							assert( ! subtitle.match( /Uncategorized/ ), 'Post still marked Uncategorized after adding new category AFTER SAVE' );
+						} );
+						postEditorSidebarComponent.getCategoriesAndTags().then( function( subtitle ) {
+							assert( subtitle.match( `#${newTagName}` ), `New tag #${newTagName} not applied` );
+						} );
 					} );
 
 					test.describe( 'Publicize Options', function() {
@@ -147,6 +149,9 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 						test.describe( 'Preview (https only)', function() {
 							if ( httpsHost ) {
 								test.it( 'Can launch post preview', function() {
+									let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+									postEditorSidebarComponent.hideComponentIfNecessary();
+
 									this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
 									this.postEditorToolbarComponent.ensureSaved();
 									this.postEditorToolbarComponent.launchPreview();
@@ -240,7 +245,7 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 							} else { // Jetpack tests
 								test.it( 'Can publish content', function() {
 									let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
-									postEditorToolbarComponent.publishThePost(  { useConfirmStep: true } );
+									postEditorToolbarComponent.publishThePost( { useConfirmStep: true } );
 								} );
 							}
 


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/20326 changed the layout of the editor, which caused breakage in the tests as the Saved/Saving/Save link is no longer visible while the sidebar is open.  This PR moves around a few of the verification steps and adds a new function to be able to hide the sidebar as necessary.