### PR TITLE
Skip the domain purchase/cancellation steps

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -607,14 +607,14 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 							} );
 						} );
 
-						test.it( 'Can enter and submit test payment details', function() {
+						test.xit( 'Can enter and submit test payment details', function() {
 							this.securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 							this.securePaymentComponent.submitPaymentDetails();
 							this.securePaymentComponent.waitForCreditCardPaymentProcessing();
 							return this.securePaymentComponent.waitForPageToDisappear();
 						} );
 
-						test.describe( `Step ${stepNum}: Checkout Thank You Page`, function() {
+						test.xdescribe( `Step ${stepNum}: Checkout Thank You Page`, function() {
 							stepNum++;
 
 							test.it( 'Can see the secure check out thank you page and click "go to my domain" button to see the domain only settings page', function() {


### PR DESCRIPTION
The domain purchases are timing out due to issues with the test environment (potentially we haven't been cancelling the domains like we thought).  Disabling this part of the test until we figure out what's going on.