### PR TITLE
Remove buttonsColorOnPostSignup from known tests

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -65,7 +65,6 @@
     "skipThemesSelectionModal",
     "unlimitedThemeNudge",
     "condensedPostList",
-    "buttonsColorOnPostSignup",
     "jetpackHidePlanIconsForAllDevices",
     "signupSiteSegmentStep",
     "checklistThankYouForFreeUser",


### PR DESCRIPTION
This a/b test is now complete and we are going to remove it with https://github.com/Automattic/wp-calypso/pull/20559