### PR TITLE
New way to detect infinite list loading

### DIFF
--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -246,3 +246,11 @@ export function ensureMobileMenuOpen( driver ) {
 		}
 	} );
 }
+
+export function waitForInfiniteListLoad( driver, elementSelector, { numElements = 10 } = {} ) {
+	return driver.wait( function() {
+		return driver.findElements( elementSelector ).then( ( elements ) => {
+			return elements.length >= numElements;
+		} );
+	} );
+};

--- a/lib/pages/posts-page.js
+++ b/lib/pages/posts-page.js
@@ -1,4 +1,4 @@
-import webdriver, { By } from 'selenium-webdriver';
+import { By } from 'selenium-webdriver';
 import BaseContainer from '../base-container.js';
 
 import * as driverHelper from '../driver-helper';
@@ -10,12 +10,8 @@ export default class PostsPage extends BaseContainer {
 
 	waitForPosts() {
 		const driver = this.driver;
-		const resultsLoadingSelector = By.css( '.posts__list .is-placeholder:not(.post-image)' );
-		driver.wait( function() {
-			return driverHelper.isElementPresent( driver, resultsLoadingSelector ).then( function( present ) {
-				return ! present;
-			} );
-		}, this.explicitWaitMS, 'The post results loading element was still present when it should have disappeared by now.' );
+		const postSelector = By.css( '.post-item' );
+		return driverHelper.waitForInfiniteListLoad( driver, postSelector, { numElements: 30 } );
 	}
 
 	isPostDisplayed( title ) {

--- a/lib/pages/posts-page.js
+++ b/lib/pages/posts-page.js
@@ -10,8 +10,8 @@ export default class PostsPage extends BaseContainer {
 
 	waitForPosts() {
 		const driver = this.driver;
-		const postSelector = By.css( '.post-item' );
-		return driverHelper.waitForInfiniteListLoad( driver, postSelector, { numElements: 30 } );
+		const postSelector = By.css( '.post-item,.post__body' );
+		return driverHelper.waitForInfiniteListLoad( driver, postSelector );
 	}
 
 	isPostDisplayed( title ) {


### PR DESCRIPTION
@alisterscott Do you mind taking a look at this when you get back from AFK?  I'm going to go ahead and merge it since it appears to be working fine, but I'm curious for your opinion.

The driver was the new condensed posts list, which changed the selector for the placeholder elements we were watching for to ensure the list was loaded.  And now the list loads in a way such that we _always_ see a placeholder element at the very bottom, offscreen.

So this PR adds a new helper function that just takes a selector and looks for a certain number of that element to be present.  It defaults to 10 elements, which seems to be enough to say that the list is populated.