### PR TITLE
Remove selector for old "expanded" posts list

### DIFF
--- a/lib/pages/posts-page.js
+++ b/lib/pages/posts-page.js
@@ -10,7 +10,7 @@ export default class PostsPage extends BaseContainer {
 
 	waitForPosts() {
 		const driver = this.driver;
-		const postSelector = By.css( '.post-item__panel:not( .is-placeholder ), .post__body' );
+		const postSelector = By.css( '.post-item__panel:not( .is-placeholder )' );
 		return driverHelper.waitForInfiniteListLoad(
 			driver,
 			postSelector,


### PR DESCRIPTION
This should be the only further change needed here.  See also #844, https://github.com/Automattic/wp-calypso/pull/20732