### PR TITLE
Running headless implies closeBrowserOnComplete

### DIFF
--- a/lib/after.js
+++ b/lib/after.js
@@ -67,7 +67,7 @@ test.afterEach( function() {
 	this.timeout( afterHookTimeoutMS );
 	const driver = global.__BROWSER__;
 
-	if ( ( this.currentTest.state === 'failed' && ( config.get( 'closeBrowserOnComplete' ) === true ) ) ) {
+	if ( ( this.currentTest.state === 'failed' && ( config.get( 'closeBrowserOnComplete' ) === true || global.isHeadless === true ) ) ) {
 		driverManager.dismissAllAlerts( driver );
 	}
 } );
@@ -103,7 +103,7 @@ test.after( function() {
 	this.timeout( afterHookTimeoutMS );
 	const driver = global.__BROWSER__;
 
-	if ( ( config.has( 'sauce' ) && config.get( 'sauce' ) ) || config.get( 'closeBrowserOnComplete' ) === true ) {
+	if ( ( config.has( 'sauce' ) && config.get( 'sauce' ) ) || config.get( 'closeBrowserOnComplete' ) === true || global.isHeadless === true ) {
 		return driverManager.quitBrowser( driver );
 	}
 } );

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -115,6 +115,7 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 				}
 				if ( process.env.HEADLESS || ( config.has( 'headless' ) && config.get( 'headless' ) === 'true' ) ) {
 					options.addArguments( '--headless' );
+					global.isHeadless = true;
 				}
 				builder = new webdriver.Builder();
 				builder.setChromeOptions( options );


### PR DESCRIPTION
I routinely run into problems testing locally where I have `closeBrowserOnComplete` overridden to `false`, but forget to return it to `true` when I want to do a full headless run.  This change sets it up so that if you're running headlessly it overrides the value of that flag to always close the window on complete.