### PR TITLE
Wait for enabled button before clicking plan

### DIFF
--- a/lib/pages/signup/pick-a-plan-page.js
+++ b/lib/pages/signup/pick-a-plan-page.js
@@ -26,7 +26,7 @@ export default class PickAPlanPage extends BaseContainer {
 			prefix = '.plan-features__mobile-plan';
 		}
 
-		const selector = By.css( `${prefix} button.is-${level}-plan` );
+		const selector = By.css( `${prefix} button.is-${level}-plan:not([disabled])` );
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	selectFreePlan() {


### PR DESCRIPTION
Fixes some erroneous test failures where the button is clicked while disabled before it's ready to handle the click.

This PR fixes the issue by selecting an enabled button.

I was consistently seeing failures here:

https://github.com/Automattic/wp-e2e-tests/blob/31e6131b64e5dc7df95f5b6e1a10403444bef942/specs-jetpack-calypso/wp-jetpack-plans-spec.js#L78

The button can be `disabled` with a noop handler, wait until the button is ready to handle the click:

https://github.com/Automattic/wp-calypso/blob/f985c3bc84857f75a2c9debc61572523b44a9881/client/my-sites/plan-features/actions.jsx#L99-L101