### PR TITLE
Handle self-hosted login differently than wpcom

### DIFF
--- a/lib/pages/login-page.js
+++ b/lib/pages/login-page.js
@@ -26,12 +26,18 @@ export default class LoginPage extends BaseContainer {
 		const userNameSelector = By.css( '#user_login, #usernameOrEmail' );
 		const passwordSelector = By.css( '#user_pass, #password' );
 		const submitSelector = By.css( '#wp-submit, button[type="submit"]' );
+		const wpcomLoginSelector = By.css( '.wpcom-site' );
 
 		driverHelper.setWhenSettable( driver, userNameSelector, username );
-		driver.findElement( userNameSelector ).sendKeys( Key.ENTER );
-		driverHelper.setWhenSettable( driver, passwordSelector, password, { secureValue: true } );
-		driverHelper.clickWhenClickable( driver, submitSelector );
-		return driverHelper.waitTillNotPresent( driver, userNameSelector );
+		return driverHelper.isElementPresent( driver, wpcomLoginSelector ).then( ( isWpcom ) => {
+			if ( isWpcom ) {
+				driver.findElement( userNameSelector ).sendKeys( Key.ENTER );
+			}
+
+			driverHelper.setWhenSettable( driver, passwordSelector, password, { secureValue: true } );
+			driverHelper.clickWhenClickable( driver, submitSelector );
+			return driverHelper.waitTillNotPresent( driver, userNameSelector );
+		} );
 	}
 
 	requestMagicLink( emailAddress ) {


### PR DESCRIPTION
WordPress.com now has the login process split onto separate pages for username/password, and our tests were updated to handle that in #804.  But that subsequently introduced a timing race into the wp-login.php page for self-hosted sites with frequent failures.

This PR checks for a wpcom-unique div and only assumes the username/password fields are split if that's present.