### PR TITLE
Add more cases for passwordless login

### DIFF
--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -1,6 +1,6 @@
 import phrase from 'asana-phrase';
 import config from 'config';
-import { map } from 'lodash';
+import { difference, map } from 'lodash';
 
 String.prototype.toProperCase = function() {
 	return this.replace( /\w\S*/g, function( txt ) {
@@ -86,6 +86,31 @@ export function getAccountConfig( account ) {
 	}
 
 	return localConfig[ account ];
+}
+
+export function getAllAccountsWithFeatures( features = [] ) {
+	let allAccounts = [];
+
+	if ( config.has( 'accounts' ) ) {
+		allAccounts = config.get( 'accounts' );
+	} else if ( process.env.ACCOUNT_INFO ) {
+		allAccounts = JSON.parse( process.env.ACCOUNT_INFO );
+	}
+
+	return allAccounts.filter( function( account ) {
+		// return accounts that have all the features requested
+		return difference( features, account.features || [] ).length === 0;
+	} );
+}
+
+export function getRandomAccountWithFeatures( features = [] ) {
+	if ( ! Array.isArray( features ) ) {
+		features = [ features ];
+	}
+
+	const accounts = getAllAccountsWithFeatures( features );
+
+	return accounts[ Math.floor( Math.random() * accounts.length ) ];
 }
 
 export function getJetpackSiteName() {

--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -111,14 +111,28 @@ export function hasAccountWithFeatures( features = [] ) {
 	return getAllAccountsWithFeatures( features ).length > 0;
 }
 
-export function getRandomAccountWithFeatures( features = [] ) {
+export function pickRandomAccountWithFeatures( features = [] ) {
 	if ( ! Array.isArray( features ) ) {
 		features = [ features ];
 	}
 
-	const accounts = getAllAccountsWithFeatures( features );
+	const accounts = getAllAccountsWithFeatures( features ).filter( function( account ) {
+		return ! account.inUse;
+	} );
 
-	return accounts[ Math.floor( Math.random() * accounts.length ) ];
+	if ( accounts.length === 0 ) {
+		return null;
+	}
+
+	const account = accounts[ Math.floor( Math.random() * accounts.length ) ];
+	account.inUse = true;
+
+	return account;
+}
+
+
+export function releaseAccount( account ) {
+	delete account.inUse;
 }
 
 export function getJetpackSiteName() {

--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -103,6 +103,14 @@ export function getAllAccountsWithFeatures( features = [] ) {
 	} );
 }
 
+export function hasAccountWithFeatures( features = [] ) {
+	if ( ! Array.isArray( features ) ) {
+		features = [ features ];
+	}
+
+	return getAllAccountsWithFeatures( features ).length > 0;
+}
+
 export function getRandomAccountWithFeatures( features = [] ) {
 	if ( ! Array.isArray( features ) ) {
 		features = [ features ];

--- a/lib/email-client.js
+++ b/lib/email-client.js
@@ -6,7 +6,7 @@ const emailWaitMS = config.get( 'emailWaitMS' );
 export default class EmailClient {
 	constructor( mailboxId ) {
 		const apiKey = config.get( 'mailosaurAPIKey' );
-		const Mailosaur = require( 'mailosaur' )( apiKey, 'https://www.mailosaur.com/api/' );
+		const Mailosaur = require( 'mailosaur' )( apiKey, 'https://mailosaur.com/api/' );
 		this.mailbox = new Mailosaur.Mailbox( mailboxId );
 	}
 

--- a/lib/email-client.js
+++ b/lib/email-client.js
@@ -70,4 +70,19 @@ export default class EmailClient {
 
 		return d.promise;
 	}
+
+	getNewEmailsByRecipient( emailAddress ) {
+		var self = this;
+		var d = webdriver.promise.defer();
+		this.pollEmailsByRecipient( emailAddress ).then( function( emails ) {
+			self.deleteAllEmail().then( function() {
+				d.fulfill( emails );
+			}, function( err ) {
+				d.reject( err );
+			} );
+		}, function( err ) {
+			d.reject( err );
+		} );
+		return d.promise;
+	}
 }

--- a/lib/email-client.js
+++ b/lib/email-client.js
@@ -70,19 +70,4 @@ export default class EmailClient {
 
 		return d.promise;
 	}
-
-	getNewEmailsByRecipient( emailAddress ) {
-		var self = this;
-		var d = webdriver.promise.defer();
-		this.pollEmailsByRecipient( emailAddress ).then( function( emails ) {
-			self.deleteAllEmail().then( function() {
-				d.fulfill( emails );
-			}, function( err ) {
-				d.reject( err );
-			} );
-		}, function( err ) {
-			d.reject( err );
-		} );
-		return d.promise;
-	}
 }

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -18,7 +18,7 @@ export default class LoginFlow {
 		if ( typeof accountOrFeatures === 'string' ) {
 			const legacyConfig = dataHelper.getAccountConfig( accountOrFeatures );
 			if ( ! legacyConfig ) {
-				throw new Error( `Account key '${accountOrFeatures}' not found in the configuration` );
+				throw new Error( `Account key '${ accountOrFeatures }' not found in the configuration` );
 			}
 			this.account = {
 				email: legacyConfig[0],
@@ -27,6 +27,9 @@ export default class LoginFlow {
 			};
 		} else {
 			this.account = dataHelper.getRandomAccountWithFeatures( accountOrFeatures );
+			if ( ! this.account ) {
+				throw new Error( `Could not find any account matching features '${ accountOrFeatures.toString() }'` );
+			}
 		}
 	}
 

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -12,29 +12,26 @@ import * as dataHelper from '../data-helper';
 const host = dataHelper.getJetpackHost();
 
 export default class LoginFlow {
-	constructor( driver, account ) {
+	constructor( driver, accountOrFeatures ) {
 		this.driver = driver;
-
-		if ( account ) {
-			this.account = account;
+		accountOrFeatures = accountOrFeatures || 'defaultUser';
+		if ( typeof accountOrFeatures === 'string' ) {
+			const legacyConfig = dataHelper.getAccountConfig( accountOrFeatures );
+			if ( ! legacyConfig ) {
+				throw new Error( `Account key '${accountOrFeatures}' not found in the configuration` );
+			}
+			this.account = {
+				email: legacyConfig[0],
+				password: legacyConfig[1],
+				loginURL: legacyConfig[2],
+			};
 		} else {
-			this.account = 'defaultUser';
+			this.account = dataHelper.getRandomAccountWithFeatures( accountOrFeatures );
 		}
-
 	}
 
 	login( { jetpackSSO = false, jetpackDIRECT = false } = {} ) {
-		let testUserName, testPassword, loginURL, loginPage;
-
-		const accountInfo = dataHelper.getAccountConfig( this.account );
-
-		if ( accountInfo !== undefined ) {
-			testUserName = accountInfo[0];
-			testPassword = accountInfo[1];
-			loginURL = accountInfo[2]; // Will only be populated for Jetpack sites
-		} else {
-			throw new Error( `Account key '${this.account}' not found in the configuration` );
-		}
+		let loginURL = this.account.loginURL, loginPage;
 
 		if ( host === 'CI' && this.account !== 'jetpackConnectUser' ) {
 			loginURL = `http://${dataHelper.getJetpackSiteName()}/wp-admin`;
@@ -50,7 +47,7 @@ export default class LoginFlow {
 			loginPage = new LoginPage( this.driver, true );
 		}
 
-		return loginPage.login( testUserName, testPassword );
+		return loginPage.login( this.account.email || this.account.username, this.account.password );
 	}
 
 	loginAndStartNewPost() {

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -26,7 +26,7 @@ export default class LoginFlow {
 				loginURL: legacyConfig[2],
 			};
 		} else {
-			this.account = dataHelper.getRandomAccountWithFeatures( accountOrFeatures );
+			this.account = dataHelper.pickRandomAccountWithFeatures( accountOrFeatures );
 			if ( ! this.account ) {
 				throw new Error( `Could not find any account matching features '${ accountOrFeatures.toString() }'` );
 			}
@@ -195,4 +195,9 @@ export default class LoginFlow {
 		return new StoreDashboardPage( this.driver );
 	}
 
+	end() {
+		if ( typeof this.account !== 'string' ) {
+			dataHelper.releaseAccount( this.account );
+		}
+	}
 }

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -20,6 +20,7 @@ export default class LoginFlow {
 		} else {
 			this.account = 'defaultUser';
 		}
+
 	}
 
 	login( { jetpackSSO = false, jetpackDIRECT = false } = {} ) {

--- a/lib/pages/login-page.js
+++ b/lib/pages/login-page.js
@@ -29,13 +29,16 @@ export default class LoginPage extends BaseContainer {
 		const wpcomLoginSelector = By.css( '.wpcom-site' );
 
 		driverHelper.setWhenSettable( driver, userNameSelector, username );
+
 		return driverHelper.isElementPresent( driver, wpcomLoginSelector ).then( ( isWpcom ) => {
 			if ( isWpcom ) {
 				driver.findElement( userNameSelector ).sendKeys( Key.ENTER );
 			}
 
-			driverHelper.setWhenSettable( driver, passwordSelector, password, { secureValue: true } );
-			driverHelper.clickWhenClickable( driver, submitSelector );
+			if ( password ) {
+				driverHelper.setWhenSettable( driver, passwordSelector, password, { secureValue: true } );
+				driverHelper.clickWhenClickable( driver, submitSelector );
+			}
 			return driverHelper.waitTillNotPresent( driver, userNameSelector );
 		} );
 	}

--- a/specs/wp-log-in-out-spec.js
+++ b/specs/wp-log-in-out-spec.js
@@ -53,8 +53,8 @@ test.describe( `[${host}] Authentication: (${screenSize}) @parallel @jetpack`, f
 
 		let passwordlessUser;
 		if ( passwordlessUser = config.get( 'testAccounts' )[ 'passwordlessUser' ] ) {
-			test.describe.only( 'Can Log in without a password', function() {
-				test.describe( 'Can enter the passwordless flow by entering the email of an account which does not have a password defined', function() {
+			test.describe( 'Can Log in on a passwordless account', function() {
+				test.describe( 'Can request a magic link email by entering the email of an account which does not have a password defined', function() {
 					let magicLoginLink;
 					test.before( function () {
 						this.emailClient = new EmailClient( config.get( 'passwordlessInboxId' ) );

--- a/specs/wp-log-in-out-spec.js
+++ b/specs/wp-log-in-out-spec.js
@@ -100,14 +100,9 @@ test.describe( `[${host}] Authentication: (${screenSize}) @parallel @jetpack`, f
 
 				test.it( 'Can find the magic link in the email received', function() {
 					return emailClient.pollEmailsByRecipient( loginFlow.account.email ).then( function( emails ) {
-						for ( let email of emails ) {
-							if ( email.subject.indexOf( 'WordPress.com' ) > -1 ) {
-								magicLinkEmail = email;
-								magicLoginLink = email.html.links[0].href;
-								break;
-							}
-						}
+						magicLinkEmail = emails.find( email => email.subject.indexOf( 'WordPress.com' ) > -1 );
 						assert( magicLinkEmail !== undefined, 'Could not find the magic login email' );
+						magicLoginLink = magicLinkEmail.html.links[0].href;
 						assert( magicLoginLink !== undefined, 'Could not locate the magic login link in the email' );
 						return true;
 					} );

--- a/specs/wp-log-in-out-spec.js
+++ b/specs/wp-log-in-out-spec.js
@@ -88,41 +88,43 @@ test.describe( `[${host}] Authentication: (${screenSize}) @parallel @jetpack`, f
 		} );
 	} );
 
-	test.describe( 'Can Log in on a passwordless account', function() {
-		test.describe( 'Can request a magic link email by entering the email of an account which does not have a password defined', function() {
-			let magicLoginLink, loginFlow;
-			test.before( function () {
-				loginFlow = new LoginFlow( driver, [ 'passwordless' ] );
-				this.emailClient = new EmailClient( get( loginFlow.account, 'mailosaur.inboxId' ) );
-				return loginFlow.login();
-			} );
-
-			test.it( 'Can find the magic link in the email received', function() {
-				return this.emailClient.getNewEmailsByRecipient( loginFlow.account.email ).then( function( emails ) {
-					for ( let email of emails ) {
-						if ( email.subject.indexOf( 'WordPress.com' ) > -1 ) {
-							magicLoginLink = email.html.links[0].href;
-							break;
-						}
-					}
-					assert( magicLoginLink !== undefined, 'Could not locate the magic login link email link' );
-					return true;
+	if ( dataHelper.hasAccountWithFeatures( 'passwordless' ) ) {
+		test.describe( 'Can Log in on a passwordless account', function() {
+			test.describe( 'Can request a magic link email by entering the email of an account which does not have a password defined', function() {
+				let magicLoginLink, loginFlow;
+				test.before( function () {
+					loginFlow = new LoginFlow( driver, [ 'passwordless' ] );
+					this.emailClient = new EmailClient( get( loginFlow.account, 'mailosaur.inboxId' ) );
+					return loginFlow.login();
 				} );
-			} );
 
-			test.describe( 'Can use the magic link to log in', function() {
-				test.it( 'Visit the magic link and we\'re logged in', function() {
-					driver.get( magicLoginLink );
-					this.magicLoginPage = new MagicLoginPage( driver );
-					this.magicLoginPage.finishLogin();
-					let readerPage = new ReaderPage( driver );
-					return readerPage.displayed().then( function( displayed ) {
-						return assert.equal( displayed, true, 'The reader page is not displayed after log in' );
+				test.it( 'Can find the magic link in the email received', function() {
+					return this.emailClient.getNewEmailsByRecipient( loginFlow.account.email ).then( function( emails ) {
+						for ( let email of emails ) {
+							if ( email.subject.indexOf( 'WordPress.com' ) > -1 ) {
+								magicLoginLink = email.html.links[0].href;
+								break;
+							}
+						}
+						assert( magicLoginLink !== undefined, 'Could not locate the magic login link email link' );
+						return true;
+					} );
+				} );
+
+				test.describe( 'Can use the magic link to log in', function() {
+					test.it( 'Visit the magic link and we\'re logged in', function() {
+						driver.get( magicLoginLink );
+						this.magicLoginPage = new MagicLoginPage( driver );
+						this.magicLoginPage.finishLogin();
+						let readerPage = new ReaderPage( driver );
+						return readerPage.displayed().then( function( displayed ) {
+							return assert.equal( displayed, true, 'The reader page is not displayed after log in' );
+						} );
 					} );
 				} );
 			} );
 		} );
-	} );
+	}
 } );
 
 


### PR DESCRIPTION
This PR adds a simple test case for passwordless login on WordPress.com.

It also introduces a new format for defining and using test accounts.
The main idea is to have the ability to define multiple accounts for the same "feature". For instance, here we'd like to test passwordless login, we can then define multiple accounts that have have the `"passworless"` feature:
```json
{
  "accounts": [
	{
	  "email": "passwordless1@gmail.com",
	  "features": [ "passwordless" ]
	},
	{
	  "email": "passwordless2@gmail.com",
	  "features": [ "passwordless" ]
	},
	{
	  "email": "passwordless3@gmail.com",
	  "features": [ "passwordless" ]
	},
	{
	  "email": "passwordless4@gmail.com",
	  "features": [ "passwordless" ]
	}
  ]
}
```

When running the passwordless tests, one of the accounts will be used at a time (most probably) so we should avoid triggering 2 magic link emails for the same account at the same time.

### Testing Instructions
- Apply this patch and use pb/1cc8a for your `config/local-development.json`
- Boot wp-calypso locally
- Run the testsuite: `env BROWSERSIZE=mobile ./node_modules/.bin/mocha specs/wp-log-in-out-spec.js`
- Assert that all the tests pass

### Reviews
- [ ] Product
- [ ] Code
  