### PR TITLE
Wait more for JN site to start-up

### DIFF
--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -20,7 +20,7 @@ export default class WporgCreatorPage extends BaseContainer {
 		}
 
 		super( driver, PROGRESS_MESSAGE, /* visit url */ true, TEMPLATES[ template ] );
-		driverHelper.waitTillPresentAndDisplayed( driver, CONTINUE_LINK, this.explicitWaitMS * 3 );
+		driverHelper.waitTillPresentAndDisplayed( driver, CONTINUE_LINK, this.explicitWaitMS * 4 );
 		driverHelper.clickWhenClickable( driver, CONTINUE_LINK );
 	}
 


### PR DESCRIPTION
Jurassic Ninja starts to start-up slowly, let's give it more time so tests won't fail.