### PR TITLE
Rename G suite upsell test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -59,7 +59,7 @@
   "knownABTestKeys": [
     "businessPlanDescriptionAT",
     "domainsCheckoutLocalizedAddresses",
-    "gsuiteUpsell",
+    "gsuiteUpsellV2",
     "multiDomainRegistrationV1",
     "presaleChatButton",
     "skipThemesSelectionModal",
@@ -71,7 +71,7 @@
   ],
   "overrideABTests": [
 	[ "skipThemesSelectionModal_20170830", "show" ],
-	[ "gsuiteUpsell_20171025", "hide" ],
+	[ "gsuiteUpsellV2_20171225", "original" ],
 	[ "domainsCheckoutLocalizedAddresses_20171025", "showDefaultAddressFormat" ],
 	[ "signupSiteSegmentStep_20170329", "variant" ],
 	[ "checklistThankYouForFreeUser_20171204", "hide" ],


### PR DESCRIPTION
The previous G Suite upsell has dropped because of some issues. Instead, the new version of the test `gsuiteUpsellV2` is launched.