### PR TITLE
Remove the @canary flag from premium theme signup

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1176,7 +1176,7 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 		} );
 	} );
 
-	test.describe( 'Sign up while purchasing premium theme @parallel @email @canary', function() {
+	test.describe( 'Sign up while purchasing premium theme @parallel @email', function() {
 		this.bailSuite( true );
 		let stepNum = 1;
 


### PR DESCRIPTION
We're still seeing flaky signup behavior on wpcalypso.wordpress.com that lands us on the login page when doing a new account with a purchase.