### PR TITLE
Try using dserve

### DIFF
--- a/config/live-branches.json
+++ b/config/live-branches.json
@@ -1,5 +1,5 @@
 {
-  "calypsoBaseURL": "https://calypso.live",
+  "calypsoBaseURL": "https://dserve.a8c.com",
   "explicitWaitMS": 40000,
   "mochaTimeoutMS": 320000,
   "browser": "chrome",

--- a/docs/running-tests.md
+++ b/docs/running-tests.md
@@ -55,7 +55,7 @@ The `run.sh` script takes the following parameters, which can be combined to exe
 -a [workers]	  - Number of parallel workers in Magellan (defaults to 3)
 -R		  - Use custom Slack/Spec/XUnit reporter, otherwise just use Spec reporter
 -p 		  - Execute the tests in parallel via CircleCI envvars (implies -g -s mobile,desktop)
--b [branch]	  - Run tests on given branch via https://calypso.live
+-b [branch]	  - Run tests on given branch via https://dserve.a8c.com
 -s		  - Screensizes in a comma-separated list (defaults to mobile,desktop)
 -g		  - Execute general tests in the specs/ directory
 -j 		  - Execute Jetpack tests in the specs-jetpack-calypso/ directory (desktop and mobile)

--- a/run.sh
+++ b/run.sh
@@ -38,7 +38,7 @@ usage () {
 -a [workers]	  - Number of parallel workers in Magellan (defaults to 3)
 -R		  - Use custom Slack/Spec/XUnit reporter, otherwise just use Spec reporter
 -p 		  - Execute the tests in parallel via CircleCI envvars (implies -g -s mobile,desktop)
--b [branch]	  - Run tests on given branch via https://calypso.live
+-b [branch]	  - Run tests on given branch via https://dserve.a8c.com
 -s		  - Screensizes in a comma-separated list (defaults to mobile,desktop)
 -g		  - Execute general tests in the specs/ directory
 -j 		  - Execute Jetpack tests in the specs-jetpack-calypso/ directory (desktop and mobile)
@@ -84,7 +84,7 @@ while getopts ":a:Rpb:s:gjWCH:wl:cm:fiIUvxu:h" opt; do
       continue
       ;;
     b)
-      NODE_CONFIG_ARGS+=("\"liveBranch\":\"true\",\"branchName\":\"$OPTARG\",\"calypsoBaseURL\":\"https://calypso.live\"")
+      NODE_CONFIG_ARGS+=("\"liveBranch\":\"true\",\"branchName\":\"$OPTARG\",\"calypsoBaseURL\":\"https://dserve.a8c.com\"")
       continue
       ;;
     s)


### PR DESCRIPTION
This just uses dserve.a8c.com for the meantime, until we switch dserve over to use calypso.live, in which case we can just revert this PR :)