### PR TITLE
Update notifications spec

### DIFF
--- a/specs/wp-notifications-spec.js
+++ b/specs/wp-notifications-spec.js
@@ -10,6 +10,7 @@ import LoginFlow from '../lib/flows/login-flow.js';
 
 import ViewSitePage from '../lib/pages/view-site-page.js';
 import ViewPostPage from '../lib/pages/view-post-page.js';
+import ReaderPage from '../lib/pages/reader-page';
 
 import NavbarComponent from '../lib/components/navbar-component.js';
 import NotificationsComponent from '../lib/components/notifications-component.js';
@@ -26,7 +27,7 @@ test.before( function() {
 	driver = driverManager.startBrowser();
 } );
 
-test.describe( `[${host}] Notifications: (${screenSize}) @parallel`, function() {
+test.describe.only( `[${host}] Notifications: (${screenSize}) @parallel`, function() {
 	this.timeout( mochaTimeOut );
 	this.bailSuite( true );
 
@@ -72,7 +73,9 @@ test.describe( `[${host}] Notifications: (${screenSize}) @parallel`, function() 
 			test.describe( 'Log in as notifications user', function() {
 				test.it( 'Can log in as notifications user', function() {
 					this.loginFlow = new LoginFlow( driver, 'notificationsUser' );
-					return this.loginFlow.login();
+					this.loginFlow.login();
+					this.readerPage = new ReaderPage( driver );
+					return this.readerPage.waitForPage();
 				} );
 
 				test.describe( 'See the notification', function() {

--- a/specs/wp-notifications-spec.js
+++ b/specs/wp-notifications-spec.js
@@ -27,7 +27,7 @@ test.before( function() {
 	driver = driverManager.startBrowser();
 } );
 
-test.describe.only( `[${host}] Notifications: (${screenSize}) @parallel`, function() {
+test.describe( `[${host}] Notifications: (${screenSize}) @parallel`, function() {
 	this.timeout( mochaTimeOut );
 	this.bailSuite( true );
 


### PR DESCRIPTION
This now waits for the reader page to appear before using the notifications shortcut.

There was a race condition where the page wasn't loaded so the shortcut key didn't work sometimes (mainly on calypso.localhost)