### PR TITLE
Add AB test override for new Jetpack plans test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -76,6 +76,7 @@
     [ "domainsCheckoutLocalizedAddresses_20171025", "showDefaultAddressFormat" ],
     [ "signupSiteSegmentStep_20170329", "variant" ],
     [ "checklistThankYouForFreeUser_20171204", "hide" ],
-    [ "checklistThankYouForPaidUser_20171204", "hide" ]
+    [ "checklistThankYouForPaidUser_20171204", "hide" ],
+    [ "promoteYearlyJetpackPlanSavings_20180124", "promoteYearly" ]
   ]
 }


### PR DESCRIPTION
Added to Calypso by https://github.com/Automattic/wp-calypso/pull/21725
in https://github.com/Automattic/wp-calypso/commit/d5e7fac5b73e64169e5fd1731a2e83073bbc8863