### PR TITLE
Fix promoteYearlyJetpackPlanSavings AB test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -77,6 +77,6 @@
     [ "signupSiteSegmentStep_20170329", "variant" ],
     [ "checklistThankYouForFreeUser_20171204", "hide" ],
     [ "checklistThankYouForPaidUser_20171204", "hide" ],
-    [ "promoteYearlyJetpackPlanSavings_20180124", "promoteYearly" ]
+    [ "promoteYearlyJetpackPlanSavings_20180124", "original" ]
   ]
 }


### PR DESCRIPTION
Wrong version. Use `original`.

https://github.com/Automattic/wp-calypso/blob/d5acc6c96228050810f3745106e552d1b64fe881/client/lib/abtest/active-tests.js#L123-L131