### PR TITLE
Add new AB test to known tests

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -68,7 +68,8 @@
     "signupSiteSegmentStep",
     "checklistThankYouForFreeUser",
     "checklistThankYouForPaidUser",
-    "paymentMethodsOnPlans"
+    "paymentMethodsOnPlans",
+    "promoteYearlyJetpackPlanSavings"
   ],
   "overrideABTests": [
     [ "skipThemesSelectionModal_20170830", "show" ],


### PR DESCRIPTION
This AB test was added to the overrides, but according to [docs](https://github.com/Automattic/wp-calypso/tree/master/client/lib/abtest#updating-our-end-to-end-tests-to-avoid-inconsistencies-with-ab-tests):

> you would _also_ need to add an override to the same file

This PR adds the test to known tests.