### PR TITLE
Add abtest setup for plans page

### DIFF
--- a/lib/pages/signup/pick-a-plan-page.js
+++ b/lib/pages/signup/pick-a-plan-page.js
@@ -19,6 +19,7 @@ export default class PickAPlanPage extends BaseContainer {
 			null,
 			config.get( 'explicitWaitMS' ) * 2
 		);
+		this.setABTestControlGroupsInLocalStorage();
 	}
 	_selectPlan( level ) {
 		let prefix = 'table';


### PR DESCRIPTION
Ensure that AB test overrides are properly applied to plans pages.

Should prevent the following warnings and correctly apply the supplied AB test value:

```
Found an AB Testing key in local storage that isn't known: 'promoteYearlyJetpackPlanSavings'. This may cause inconsistent A/B test behaviour, please check this is okay and add it to 'knownABTestKeys' in default.config - […]
```