### PR TITLE
Remove site segment test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -65,7 +65,6 @@
     "skipThemesSelectionModal",
     "unlimitedThemeNudge",
     "jetpackHidePlanIconsForAllDevices",
-    "signupSiteSegmentStep",
     "checklistThankYouForFreeUser",
     "checklistThankYouForPaidUser",
     "paymentMethodsOnPlans",
@@ -75,7 +74,6 @@
     [ "skipThemesSelectionModal_20170830", "show" ],
     [ "gsuiteUpsellV2_20171225", "original" ],
     [ "domainsCheckoutLocalizedAddresses_20171025", "showDefaultAddressFormat" ],
-    [ "signupSiteSegmentStep_20170329", "variant" ],
     [ "checklistThankYouForFreeUser_20171204", "hide" ],
     [ "checklistThankYouForPaidUser_20171204", "hide" ],
     [ "promoteYearlyJetpackPlanSavings_20180124", "original" ]


### PR DESCRIPTION
We are removing the siteSegment test over here: https://github.com/Automattic/wp-calypso/pull/21797

This PR removes the siteSegment test from our e2e tests. 

@alisterscott and @taggon can you please review?

@alisterscott can you explain the order of operations once this PR has been approved? Do we merge and deploy the other PR in wp-calypso before this one? or do we deploy and merge this one first?