### PR TITLE
Add e2e test: domain mapping via existing site

### DIFF
--- a/lib/components/enter-a-domain-component.js
+++ b/lib/components/enter-a-domain-component.js
@@ -1,0 +1,21 @@
+import { By } from 'selenium-webdriver';
+
+import BaseContainer from '../base-container.js';
+import * as driverHelper from '../driver-helper';
+
+export default class EnterADomainComponent extends BaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.map-domain-step__add-domain' ) );
+	}
+
+	enterADomain() {
+		const blogName = 'myawesomedomain.com';
+		const entryInputSelector = By.className( 'map-domain-step__external-domain' );
+		driverHelper.setWhenSettable( this.driver, entryInputSelector, blogName );
+	}
+
+	clickonAddButtonToAddDomainToTheCart() {
+		const addDomainSelector = By.css( '.map-domain-step__go.button.is-primary' );
+		return driverHelper.clickWhenClickable( this.driver, addDomainSelector, this.explicitWaitMS );
+	}
+}

--- a/lib/components/enter-a-domain-component.js
+++ b/lib/components/enter-a-domain-component.js
@@ -8,14 +8,13 @@ export default class EnterADomainComponent extends BaseContainer {
 		super( driver, By.css( '.map-domain-step__add-domain' ) );
 	}
 
-	enterADomain() {
-		const blogName = 'myawesomedomain.com';
+	enterADomain( blogName ) {
 		const entryInputSelector = By.className( 'map-domain-step__external-domain' );
 		driverHelper.setWhenSettable( this.driver, entryInputSelector, blogName );
 	}
 
 	clickonAddButtonToAddDomainToTheCart() {
 		const addDomainSelector = By.css( '.map-domain-step__go.button.is-primary' );
-		return driverHelper.clickWhenClickable( this.driver, addDomainSelector, this.explicitWaitMS );
+		return driverHelper.clickWhenClickable( this.driver, addDomainSelector );
 	}
 }

--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -35,7 +35,7 @@ export default class FindADomainComponent extends BaseContainer {
 	checkAndRetryForFreeBlogAddresses( expectedBlogAddresses, blogName ) {
 		const self = this;
 		self.freeBlogAddress().then( ( actualAddress ) => {
-			if (expectedBlogAddresses.indexOf( actualAddress ) < 0) {
+			if ( expectedBlogAddresses.indexOf( actualAddress ) < 0 ) {
 				let message = `The displayed free blog address: '${actualAddress}' was not in the expected addresses: '${expectedBlogAddresses}'. Re-searching for '${blogName}' now.`;
 				slackNotifier.warn( message );
 				self.searchForBlogNameAndWaitForResults( blogName );

--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -10,40 +10,46 @@ export default class FindADomainComponent extends BaseContainer {
 		super( driver, By.css( '.register-domain-step' ) );
 		this.declineGoogleAppsLinkSelector = By.className( 'google-apps-dialog__cancel-link' );
 	}
+
 	waitForResults() {
 		const driver = this.driver;
 		const resultsLoadingSelector = By.css( '.domain-suggestion.is-placeholder' );
 		driver.wait( function() {
 			return driverHelper.isElementPresent( driver, resultsLoadingSelector ).then( function( present ) {
-				return ! present;
+				return !present;
 			} );
 		}, this.explicitWaitMS * 2, 'The domain results loading element was still present when it should have disappeared by now.' );
 		return this.checkForUnknownABTestKeys();
 	}
+
 	waitForGoogleApps() {
 		return this.driver.wait( until.elementLocated( this.declineGoogleAppsLinkSelector ), this.explicitWaitMS, 'Could not locate the link to decline google apps.' );
 	}
+
 	searchForBlogNameAndWaitForResults( blogName ) {
 		const searchInputSelector = By.className( 'search__input' );
 		driverHelper.setWhenSettable( this.driver, searchInputSelector, blogName );
 		return this.waitForResults();
 	}
+
 	checkAndRetryForFreeBlogAddresses( expectedBlogAddresses, blogName ) {
 		const self = this;
 		self.freeBlogAddress().then( ( actualAddress ) => {
-			if ( expectedBlogAddresses.indexOf( actualAddress ) < 0 ) {
+			if (expectedBlogAddresses.indexOf( actualAddress ) < 0) {
 				let message = `The displayed free blog address: '${actualAddress}' was not in the expected addresses: '${expectedBlogAddresses}'. Re-searching for '${blogName}' now.`;
 				slackNotifier.warn( message );
 				self.searchForBlogNameAndWaitForResults( blogName );
 			}
 		} );
 	}
+
 	freeBlogAddress() {
 		const freeBlogAddressSelector = By.css( '.domain-suggestion__content h3' );
 		return this.driver.findElement( freeBlogAddressSelector ).getText().then( function( text ) {
 			return text;
 		} );
 	}
+
 	selectDotComAddress( dotComAddress ) {
 		const selector = By.css( `[data-e2e-domain="${ dotComAddress }"]` );
 		this.driver.wait( until.elementLocated( selector ), this.explicitWaitMS, 'Could not locate the select button for the paid address: ' + dotComAddress );
@@ -51,23 +57,33 @@ export default class FindADomainComponent extends BaseContainer {
 		this.driver.wait( until.elementIsEnabled( element ), this.explicitWaitMS, 'The paid address button for ' + dotComAddress + ' does not appear to be enabled to click' );
 		return driverHelper.clickWhenClickable( this.driver, selector, this.explicitWaitMS );
 	}
+
 	selectFreeAddress() {
 		const freeAddressSelector = By.css( '.domain-suggestion.is-clickable' );
 		return driverHelper.clickWhenClickable( this.driver, freeAddressSelector, this.explicitWaitMS );
 	}
+
 	selectMapOwnDomain() {
 		const mapOwnSelector = By.css( 'div.domain-mapping-suggestion button' );
 		return driverHelper.clickWhenClickable( this.driver, mapOwnSelector, this.explicitWaitMS );
-	};
+	}
+
+	selectUseOwnDomain() {
+		const useOwnDomain = By.css( '.domain-suggestion.card.is-compact.is-clickable.is-visible.domain-transfer-suggestion' );
+		return driverHelper.clickWhenClickable( this.driver, useOwnDomain, this.explicitWaitMS );
+	}
+
 	waitForOwnDomainMapping() {
 		const ownDomainInputSelector = By.css( 'input.map-domain-step__external-domain' );
 		this.driver.wait( until.elementLocated( ownDomainInputSelector ), this.explicitWaitMS, 'Could not locate the own domain input selector' );
 		const ownDomainInputElement = this.driver.findElement( ownDomainInputSelector );
 		return this.driver.wait( until.elementIsVisible( ownDomainInputElement ), this.explicitWaitMS, 'Could not see the own domain input selector visible' );
 	}
+
 	declineGoogleApps() {
 		return driverHelper.clickWhenClickable( this.driver, this.declineGoogleAppsLinkSelector, this.explicitWaitMS );
 	}
+
 	selectAddEmailForGoogleApps() {
 		const googleAppsFieldsSelector = By.css( 'fieldset.google-apps-dialog__user-fields' );
 		this.waitForGoogleApps();
@@ -76,6 +92,7 @@ export default class FindADomainComponent extends BaseContainer {
 		const googleAppsFieldsElement = this.driver.findElement( googleAppsFieldsSelector );
 		return this.driver.wait( until.elementIsVisible( googleAppsFieldsElement ), this.explicitWaitMS, 'Could not see the google apps information fieldset displayed, check it is visible' );
 	}
+
 	selectPreviousStep() {
 		return driverHelper.clickWhenClickable( this.driver, By.css( 'a.previous-step' ), this.explicitWaitMS );
 	}

--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -63,21 +63,9 @@ export default class FindADomainComponent extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, freeAddressSelector, this.explicitWaitMS );
 	}
 
-	selectMapOwnDomain() {
-		const mapOwnSelector = By.css( 'div.domain-mapping-suggestion button' );
-		return driverHelper.clickWhenClickable( this.driver, mapOwnSelector, this.explicitWaitMS );
-	}
-
 	selectUseOwnDomain() {
 		const useOwnDomain = By.css( '.domain-suggestion.card.domain-transfer-suggestion' );
 		return driverHelper.clickWhenClickable( this.driver, useOwnDomain, this.explicitWaitMS );
-	}
-
-	waitForOwnDomainMapping() {
-		const ownDomainInputSelector = By.css( 'input.map-domain-step__external-domain' );
-		this.driver.wait( until.elementLocated( ownDomainInputSelector ), this.explicitWaitMS, 'Could not locate the own domain input selector' );
-		const ownDomainInputElement = this.driver.findElement( ownDomainInputSelector );
-		return this.driver.wait( until.elementIsVisible( ownDomainInputElement ), this.explicitWaitMS, 'Could not see the own domain input selector visible' );
 	}
 
 	declineGoogleApps() {

--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -69,7 +69,7 @@ export default class FindADomainComponent extends BaseContainer {
 	}
 
 	selectUseOwnDomain() {
-		const useOwnDomain = By.css( '.domain-suggestion.card.is-compact.is-clickable.is-visible.domain-transfer-suggestion' );
+		const useOwnDomain = By.css( '.domain-suggestion.card.domain-transfer-suggestion' );
 		return driverHelper.clickWhenClickable( this.driver, useOwnDomain, this.explicitWaitMS );
 	}
 

--- a/lib/components/map-a-domain-component.js
+++ b/lib/components/map-a-domain-component.js
@@ -1,0 +1,15 @@
+import { By } from 'selenium-webdriver';
+
+import BaseContainer from '../base-container.js';
+import * as driverHelper from '../driver-helper';
+
+export default class MapADomainComponent extends BaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.transfer-domain-step' ) );
+	}
+
+	selectManuallyConnectExistingDomain() {
+		const manuallyConnectSelector = By.css( '#primary > main > span > div > div:nth-child(2) > div > div > p > a:nth-child(1)' );
+		return driverHelper.clickWhenClickable( this.driver, manuallyConnectSelector, this.explicitWaitMS );
+	}
+}

--- a/lib/components/map-a-domain-component.js
+++ b/lib/components/map-a-domain-component.js
@@ -9,7 +9,7 @@ export default class MapADomainComponent extends BaseContainer {
 	}
 
 	selectManuallyConnectExistingDomain() {
-		const manuallyConnectSelector = By.css( '#primary > main > span > div > div:nth-child(2) > div > div > p > a:nth-child(1)' );
+		const manuallyConnectSelector = By.css( '.card.transfer-domain-step__map-option a[href="#"]' );
 		return driverHelper.clickWhenClickable( this.driver, manuallyConnectSelector, this.explicitWaitMS );
 	}
 }

--- a/lib/pages/domain-map-checkout-page.js
+++ b/lib/pages/domain-map-checkout-page.js
@@ -1,0 +1,9 @@
+import { By } from 'selenium-webdriver';
+
+import BaseContainer from '../base-container.js';
+
+export default class MapADomainCheckoutPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.checkout__payment-box-container' ) );
+	}
+}

--- a/lib/pages/domain-map-page.js
+++ b/lib/pages/domain-map-page.js
@@ -1,0 +1,9 @@
+import { By } from 'selenium-webdriver';
+
+import BaseContainer from '../base-container.js';
+
+export default class MapADomainPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.map-domain-step' ) );
+	}
+}

--- a/lib/pages/domain-my-own-page.js
+++ b/lib/pages/domain-my-own-page.js
@@ -1,0 +1,9 @@
+import { By } from 'selenium-webdriver';
+
+import BaseContainer from '../base-container.js';
+
+export default class MyOwnDomainPage extends BaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.transfer-domain-step__domain-description' ) );
+	}
+}

--- a/specs/wp-manage-domains-map-spec.js
+++ b/specs/wp-manage-domains-map-spec.js
@@ -85,7 +85,6 @@ test.describe( `[${host}] Managing Domain Mapping: (${screenSize}) @parallel`, f
 				mapADomainPage.displayed().then( ( displayed ) => {
 					assert.equal( displayed, true, 'Could not see map a domain page' );
 				} );
-
 			} );
 
 			test.it( 'Can enter the domain name', () => {

--- a/specs/wp-manage-domains-map-spec.js
+++ b/specs/wp-manage-domains-map-spec.js
@@ -1,0 +1,128 @@
+import assert from 'assert';
+import test from 'selenium-webdriver/testing';
+
+import config from 'config';
+import * as driverManager from '../lib/driver-manager.js';
+import * as dataHelper from '../lib/data-helper.js';
+
+import LoginFlow from '../lib/flows/login-flow.js';
+import DomainsPage from '../lib/pages/domains-page';
+import ShoppingCartWidgetComponent from '../lib/components/shopping-cart-widget-component';
+import SidebarComponent from '../lib/components/sidebar-component';
+import NavbarComponent from '../lib/components/navbar-component';
+import StatsPage from '../lib/pages/stats-page';
+import ReaderPage from '../lib/pages/reader-page';
+import FindADomainComponent from '../lib/components/find-a-domain-component';
+import MyOwnDomainPage from '../lib/pages/domain-my-own-page';
+import MapADomainComponent from '../lib/components/map-a-domain-component';
+import MapADomainPage from '../lib/pages/domain-map-page';
+import EnterADomainComponent from '../lib/components/enter-a-domain-component';
+import MapADomainCheckoutPage from '../lib/pages/domain-map-checkout-page';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
+
+var driver;
+
+test.before( function() {
+	this.timeout( startBrowserTimeoutMS );
+	driver = driverManager.startBrowser();
+} );
+
+test.describe( `[${host}] Managing Domain Mapping: (${screenSize}) @parallel`, function() {
+	this.bailSuite( true );
+	this.timeout( mochaTimeOut );
+
+	test.describe( 'Map a domain to an existing site', () => {
+		this.bailSuite( true );
+
+		const blogName = dataHelper.getNewBlogName();
+
+		test.before( function() {
+			driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		} );
+
+		test.it( 'Log In and Select Domains', () => {
+			const loginFlow = new LoginFlow( driver );
+			loginFlow.loginAndSelectDomains();
+		} );
+
+		test.describe( 'Can find domain mapping section and enter a domain to map', function() {
+			test.it( 'Can choose add a domain', () => {
+				const domainsPage = new DomainsPage( driver );
+				driver.getCurrentUrl().then( ( urlDisplayed ) => {
+					domainsPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
+				} );
+				return domainsPage.clickAddDomain();
+			} );
+
+			test.it( 'Can see the domain search component', () => {
+				const findADomainComponent = new FindADomainComponent( driver );
+				findADomainComponent.waitForResults();
+			} );
+
+			test.it( 'Can select to use an existing domain', () => {
+				const findADomainComponent = new FindADomainComponent( driver );
+				findADomainComponent.selectUseOwnDomain();
+			} );
+
+			test.it( 'Can see use my own domain page', () => {
+				const myOwnDomainPage = new MyOwnDomainPage( driver );
+				myOwnDomainPage.displayed().then( ( displayed ) => {
+					assert.equal( displayed, true, 'Could not see use my own domain page' );
+				} );
+			} );
+
+			test.it( 'Can select to manually connect existing domain component', () => {
+				const mapADomainComponent = new MapADomainComponent( driver );
+				mapADomainComponent.selectManuallyConnectExistingDomain();
+			} );
+
+			test.it( 'Can see enter a domain component', () => {
+				const mapADomainPage = new MapADomainPage( driver );
+				mapADomainPage.displayed().then( ( displayed ) => {
+					assert.equal( displayed, true, 'Could not see map a domain page' );
+				} );
+
+			} );
+
+			test.it( 'Can enter the domain name', () => {
+				const enterADomainComponent = new EnterADomainComponent( driver );
+				enterADomainComponent.enterADomain( blogName );
+			} );
+
+			test.it( 'Can add domain to the cart', () => {
+				const enterADomainComponent = new EnterADomainComponent( driver );
+				enterADomainComponent.clickonAddButtonToAddDomainToTheCart();
+			} );
+
+			test.describe( 'Can pay for domain mapping', function() {
+				test.it( 'Can see checkout page', () => {
+					const mapADomainCheckoutPage = new MapADomainCheckoutPage( driver );
+					mapADomainCheckoutPage.displayed().then( ( displayed ) => {
+						assert.equal( displayed, true, 'Could not see the secure payment component' );
+					} );
+				} );
+
+				// Remove all items from basket for clean up
+				test.it( 'Can empty cart for next test', () => {
+					this.readerPage = new ReaderPage( driver, true );
+
+					this.navbarComponent = new NavbarComponent( driver );
+					this.navbarComponent.clickMySites();
+
+					this.statsPage = new StatsPage( driver, true );
+
+					this.sideBarComponent = new SidebarComponent( driver );
+					this.sideBarComponent.selectDomains();
+
+					this.domainsPage = new DomainsPage( driver );
+					this.shoppingCartWidgetComponent = new ShoppingCartWidgetComponent( driver );
+					return this.shoppingCartWidgetComponent.empty();
+				} );
+			} );
+		} );
+	} );
+} );

--- a/specs/wp-manage-domains-map-spec.js
+++ b/specs/wp-manage-domains-map-spec.js
@@ -38,7 +38,7 @@ test.describe( `[${host}] Managing Domain Mapping: (${screenSize}) @parallel`, f
 	test.describe( 'Map a domain to an existing site', () => {
 		this.bailSuite( true );
 
-		const blogName = dataHelper.getNewBlogName();
+		const blogName = 'myawesomedomain.com';
 
 		test.before( function() {
 			driverManager.clearCookiesAndDeleteLocalStorage( driver );


### PR DESCRIPTION
This PR adds e2e test for mapping an existing domain via an existing site ( to address this issue: https://github.com/Automattic/wp-e2e-tests/issues/411). 

**NEW FILES CREATED:**

New Spec created: 

* `wp-manage-domains-map-spec.js`

New Components created:

* `enter-a-domain-component.js`
* `find-a-domain-component.js`
* `map-a-domain-component.js`

New Pages created:

* `domain-map-page.js`
* `domain-map-checkout-page.js`
* `domain-my-own-page.js`

**TEST STEPS:**

The test consists of the following steps:

Map a domain to an existing site
      ✓ Log In and Select Domains 
      Can find domain mapping section and enter a domain to map
        ✓ Can choose add a domain 
        ✓ Can see the domain search component 
        ✓ Can select to use an existing domain 
        ✓ Can see use my own domain page 
        ✓ Can select to manually connect existing domain component 
        ✓ Can see enter a domain component
        ✓ Can enter the domain name 
        ✓ Can add domain to the cart 
        Can pay for domain mapping
          ✓ Can see checkout page 
          ✓ Can empty cart for next test 

**TEST GIFS:**

Desktop Test Gif: http://recordit.co/PcVkjWQ6D0

Tablet Test Gif: http://recordit.co/WcPq3wtixJ

Mobile Test Gif: http://recordit.co/FTO73BVJNF
