### PR TITLE
Update My Sites sidebar selectors

### DIFF
--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -8,33 +8,33 @@ export default class SidebarComponent extends BaseContainer {
 	constructor( driver, siteName = null ) {
 		super( driver, By.css( '.sidebar' ) );
 		this.storeSelector = By.css( '.sites-navigation li a[href*=store]' );
-		this.settingsSelector = By.css( '.sites-navigation .settings a' );
+		this.settingsSelector = By.css( '.sites-navigation [data-tip-target="settings"] a' );
 		if ( siteName !== null ) {
 			this.selectSite( siteName );
 		}
 	}
 	selectDomains() {
-		let selector = By.css( '.sites-navigation .domains a' );
+		let selector = By.css( '.sites-navigation [data-tip-target="domains"] a' );
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	selectPeople() {
-		let selector = By.css( '.sites-navigation .users a' );
+		let selector = By.css( '.sites-navigation [data-tip-target="people"] a' );
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	selectAddPerson() {
-		let selector = By.css( '.sites-navigation .users a.sidebar__button' );
+		let selector = By.css( '.sites-navigation [data-tip-target="users"] a.sidebar__button' );
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	selectManagePlugins() {
-		let selector = By.css( '.sites-navigation .plugins a.sidebar__button' );
+		let selector = By.css( '.sites-navigation [data-tip-target="plugins"] a.sidebar__button' );
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	selectThemes() {
-		let selector = By.css( '.sites-navigation .themes a' );
+		let selector = By.css( '.sites-navigation [data-tip-target="themes"] a' );
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	selectPlan() {
-		let selector = By.css( '.sites-navigation .upgrades-nudge a' );
+		let selector = By.css( '.sites-navigation [data-tip-target="plan"] a' );
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	selectAddNewPage() {
@@ -80,10 +80,10 @@ export default class SidebarComponent extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, By.css( '.all-sites a' ) );
 	}
 	selectViewThisSite() {
-		return driverHelper.clickWhenClickable( this.driver, By.css( '.preview a' ) );
+		return driverHelper.clickWhenClickable( this.driver, By.css( '[data-tip-target="sitePreview"] a' ) );
 	}
 	selectPlugins() {
-		let selector = By.css( '.sites-navigation .plugins a' );
+		let selector = By.css( '.sites-navigation [data-tip-target="plugins"] a' );
 		let dismissNoticeSelector = By.css( '.notice.is-dismissable .notice__dismiss' );
 		const driver = this.driver;
 
@@ -119,7 +119,7 @@ export default class SidebarComponent extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	customizeTheme() {
-		const selector = By.css( '.sites-navigation .themes a[href*=customize]' );
+		const selector = By.css( '.sites-navigation [data-tip-target="themes"] a[href*=customize]' );
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	getCurrentSiteDomain() {


### PR DESCRIPTION
This PR updates our e2e to use the `data-tip-target` attributes in the selectors for My Sites sidebar menu items. (We previously used class names to select these menu items, but those class names were removed in https://github.com/Automattic/wp-calypso/pull/21808.)

This PR relies on https://github.com/Automattic/wp-calypso/pull/21825, which updates Calypso to ensure all sidebar items include this attribute.