### PR TITLE
Update visdiff screenshots to reduce noise

### DIFF
--- a/lib/pages/profile-page.js
+++ b/lib/pages/profile-page.js
@@ -25,6 +25,19 @@ export default class ProfilePage extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, by.css( '.sidebar a[href$="purchases"]' ) );
 	}
 
+	waitForProfileLinks() {
+		const driver = this.driver;
+		// Only needed for visdiff screenshots for now
+		if ( process.env.VISDIFF ) {
+			const linksLoadingSelector = by.css( '.profile-link.is-placeholder' );
+			driver.wait( function() {
+				return driverHelper.isElementPresent( driver, linksLoadingSelector ).then( function( present ) {
+					return ! present;
+				} );
+			}, this.explicitWaitMS, 'The profile links placeholder was still present when it should have disappeared by now.' );
+		}
+	}
+
 	_closeProfileViewOnMobile() {
 		const self = this;
 		if ( driverManager.currentScreenSize() !== 'mobile' ) {

--- a/lib/pages/reader-manage-page.js
+++ b/lib/pages/reader-manage-page.js
@@ -12,6 +12,8 @@ export default class ReaderPage extends BaseContainer {
 			url = url + '?branch=' + config.get( 'branchName' );
 		}
 		super( driver, by.css( '.following-manage' ), visit, url );
+		this.recommendedSitesSection = by.css( '.reader-recommended-sites' );
+		this.followedSitesSection = by.css( '.following-manage__subscriptions' );
 	}
 
 	waitForSites() {

--- a/specs/wp-log-in-out-spec.js
+++ b/specs/wp-log-in-out-spec.js
@@ -84,6 +84,7 @@ test.describe( `[${host}] Authentication: (${screenSize}) @parallel @jetpack @vi
 
 			test.it( 'Can logout from profile page', function() {
 				let profilePage = new ProfilePage( driver );
+				profilePage.waitForProfileLinks();
 				eyesHelper.eyesScreenshot( driver, eyes, 'Me Profile Page' );
 				profilePage.clickSignOut();
 			} );

--- a/specs/wp-reader-spec.js
+++ b/specs/wp-reader-spec.js
@@ -90,7 +90,8 @@ test.describe( 'Reader: (' + screenSize + ') @parallel @visdiff', function() {
 					test.it( 'Can see the Manage page', function() {
 						this.readerManagePage = new ReaderManagePage( driver, true );
 						this.readerManagePage.waitForSites();
-						eyesHelper.eyesScreenshot( driver, eyes, 'Manage Followed Sites' );
+						eyesHelper.eyesScreenshot( driver, eyes, 'Manage - Recommended Sites', this.readerManagePage.recommendedSitesSection );
+						eyesHelper.eyesScreenshot( driver, eyes, 'Manage - Followed Sites', this.readerManagePage.followedSitesSection );
 					} );
 				} );
 			} );


### PR DESCRIPTION
This PR adjusts the visdiff screenshots for the following pages to reduce noise in the test results:

- Me: Profile Page (`specs/wp-log-in-out-spec.js`)
- Reader: Manage Page (`specs/wp-reader-spec.js`)