### PR TITLE
Remove redundant step in Jetpack Connect spec 

### DIFF
--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -146,11 +146,6 @@ test.describe( `Jetpack Connect: (${ screenSize })`, function() {
 			return this.wpAdminJetpack.connectWordPressCom();
 		} );
 
-		test.it( 'Can click the login link in the account creation page', () => {
-			this.createAccountPage = new CreateYourAccountPage( driver );
-			return this.createAccountPage.clickLoginLink();
-		} );
-
 		test.it( 'Can login into WordPress.com', () => {
 			const loginFlow = new LoginFlow( driver, 'jetpackConnectUser' );
 			return loginFlow.loginUsingExistingForm();

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -7,7 +7,6 @@ import * as driverHelper from '../lib/driver-helper';
 import { By } from 'selenium-webdriver';
 
 import AddNewSitePage from '../lib/pages/add-new-site-page';
-import CreateYourAccountPage from '../lib/pages/signup/create-your-account-page.js';
 import JetpackAuthorizePage from '../lib/pages/jetpack-authorize-page';
 import JetpackConnectInstallPage from '../lib/pages/jetpack-connect-install-page';
 import PickAPlanPage from '../lib/pages/signup/pick-a-plan-page';


### PR DESCRIPTION
This step becomes redundant because the default jurassic.ninja user is registered in WP.com. That's why `Activate` button redirects straight to the login screen. 

Internal ref: p1517297854000195-slack-e2e-testing-discuss

