### PR TITLE
Fix Login flow still checking the account name in a few places

### DIFF
--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -21,11 +21,13 @@ export default class LoginFlow {
 			if ( ! legacyConfig ) {
 				throw new Error( `Account key '${ accountOrFeatures }' not found in the configuration` );
 			}
+
 			this.account = {
 				email: legacyConfig[0],
 				username: legacyConfig[0],
 				password: legacyConfig[1],
 				loginURL: legacyConfig[2],
+				legacyAccountName: accountOrFeatures,
 			};
 		} else {
 			this.account = dataHelper.pickRandomAccountWithFeatures( accountOrFeatures );
@@ -38,7 +40,7 @@ export default class LoginFlow {
 	login( { jetpackSSO = false, jetpackDIRECT = false, screenshot = false } = {}, eyes ) {
 		let loginURL = this.account.loginURL, loginPage;
 
-		if ( host === 'CI' && this.account.username !== 'jetpackConnectUser' ) {
+		if ( host === 'CI' && this.account.legacyAccountName !== 'jetpackConnectUser' ) {
 			loginURL = `http://${dataHelper.getJetpackSiteName()}/wp-admin`;
 		}
 
@@ -61,7 +63,7 @@ export default class LoginFlow {
 
 	loginAndStartNewPost() {
 		let siteURL = null;
-		if ( host !== 'WPCOM' && this.account.username !== 'jetpackConnectUser' ) {
+		if ( host !== 'WPCOM' && this.account.legacyAccountName !== 'jetpackConnectUser' ) {
 			siteURL = dataHelper.getJetpackSiteName();
 		}
 
@@ -123,7 +125,7 @@ export default class LoginFlow {
 		let navbarComponent = new NavbarComponent( this.driver );
 		navbarComponent.clickMySites();
 
-		if ( host === 'CI' && this.account.username !== 'jetpackConnectUser' ) {
+		if ( host === 'CI' && this.account.legacyAccountName !== 'jetpackConnectUser' ) {
 			const siteURL = dataHelper.getJetpackSiteName();
 
 			let sideBarComponent = new SidebarComponent( this.driver );
@@ -147,7 +149,7 @@ export default class LoginFlow {
 		this.loginAndSelectMySite();
 		let sideBarComponent = new SidebarComponent( this.driver );
 
-		if ( host === 'CI' && this.account.username !== 'jetpackConnectUser' ) {
+		if ( host === 'CI' && this.account.legacyAccountName !== 'jetpackConnectUser' ) {
 			const siteURL = dataHelper.getJetpackSiteName();
 
 			sideBarComponent.selectSiteSwitcher();


### PR DESCRIPTION
https://github.com/Automattic/wp-e2e-tests/pull/884 didn't actually fix the login flow, as it's failing for CI jetpack.

This PR should hopefully.

### Testing Instructions
- Prepare your env to test Jetpack CI locally: https://github.com/Automattic/wp-e2e-tests/blob/master/docs/running-tests.md#jetpack-ci-like-tests-localy 
- run `CIRCLE_SHA1={your_sha1} JETPACKHOST=CI NODE_ENV=test ./node_modules/.bin/mocha ./specs-jetpack-calypso/wp-jetpack-connect-spec.js`
- Assert that all tests pass