### PR TITLE
Fixup: Write url to screenshot and post it on Slack

### DIFF
--- a/lib/after.js
+++ b/lib/after.js
@@ -49,6 +49,8 @@ test.afterEach( function() {
 		filenameCallback = () => `FAILED-${locale}-${screenSize}-${shortTestFileName}-${date}`;
 	} else if ( config.get( 'saveAllScreenshots' ) === true ) {
 		filenameCallback = () => `${locale}-${screenSize}-${shortDescribeFileName}-${date}-${shortTestFileName}`;
+	} else {
+		return;
 	}
 
 	return driver.takeScreenshot().then( ( data ) => {

--- a/lib/eyes-helper.js
+++ b/lib/eyes-helper.js
@@ -67,7 +67,7 @@ export function eyesScreenshot( driver, eyes, pageName, selector ) {
 
 		if ( process.env.EYESDEBUG ) {
 			return driver.takeScreenshot().then( ( data ) => {
-				mediaHelper.writeScreenshot( data, `EYES-${pageName}-${driverManager.currentScreenSize()}` );
+				mediaHelper.writeScreenshot( data, () => ( new Date().getTime().toString() ) + `-EYES-${pageName}-${driverManager.currentScreenSize()}` );
 			} );
 		}
 


### PR DESCRIPTION
#823 inadvertently changed the logic so that screenshots were created for every step in a failed flow, which we fix here.

Also, this updates a call `writeScreenshot` that still used the old parameters.