### PR TITLE
Fix up domain cancellation hooks to not fail the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "greetings.js",
   "defaultTestArgs": "-g -s $BROWSERSIZE",
   "scripts": {
-	"lint": "eslint . --max-warnings=0",
+    "lint": "eslint . --max-warnings=0",
     "postinstall": "npm pack ./lib/reporter && npm install ./spec-xunit-reporter-0.0.1.tgz --no-save",
     "test": "./run.sh ${TESTARGS:-$npm_package_defaultTestArgs}"
   },

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -680,27 +680,31 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 									stepNum++;
 
 									test.it( 'Cancel the domain', function() {
-										let sideBarComponent = new SideBarComponent( driver );
-										sideBarComponent.selectSettings();
+										try {
+											let sideBarComponent = new SideBarComponent( driver );
+											sideBarComponent.selectSettings();
 
-										let domainOnlySettingsPage = new DomainOnlySettingsPage( driver );
-										domainOnlySettingsPage.manageDomain();
+											let domainOnlySettingsPage = new DomainOnlySettingsPage( driver );
+											domainOnlySettingsPage.manageDomain();
 
-										let domainDetailsPage = new DomainDetailsPage( driver );
-										domainDetailsPage.viewPaymentSettings();
+											let domainDetailsPage = new DomainDetailsPage( driver );
+											domainDetailsPage.viewPaymentSettings();
 
-										let managePurchasePage = new ManagePurchasePage( driver );
-										managePurchasePage.domainDisplayed().then( ( domainDisplayed ) => {
-											assert.equal( domainDisplayed, expectedDomainName, 'The domain displayed on the manage purchase page is unexpected' );
-										} );
-										managePurchasePage.chooseCancelAndRefund();
+											let managePurchasePage = new ManagePurchasePage( driver );
+											managePurchasePage.domainDisplayed().then( ( domainDisplayed ) => {
+												assert.equal( domainDisplayed, expectedDomainName, 'The domain displayed on the manage purchase page is unexpected' );
+											} );
+											managePurchasePage.chooseCancelAndRefund();
 
-										let cancelPurchasePage = new CancelPurchasePage( driver );
-										cancelPurchasePage.clickCancelPurchase();
+											let cancelPurchasePage = new CancelPurchasePage( driver );
+											cancelPurchasePage.clickCancelPurchase();
 
-										let cancelDomainPage = new CancelDomainPage( driver );
-										cancelDomainPage.completeSurveyAndConfirm();
-										return cancelDomainPage.waitToDisappear();
+											let cancelDomainPage = new CancelDomainPage( driver );
+											cancelDomainPage.completeSurveyAndConfirm();
+											return cancelDomainPage.waitToDisappear();
+										} catch ( err ) {
+											SlackNotifier.warn( `There was an error in the hooks that clean up the test domains but since it is cleaning up we really don't care: '${ err }'` );
+										}
 									} );
 								} );
 							} );
@@ -874,181 +878,41 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 									test.describe( `Step ${stepNum}: Cancel the domain via purchases`, function() {
 										stepNum++;
 
-										test.it( 'Cancel the domaiun', function() {
-											let navBarComponent = new NavBarComponent( driver );
-											navBarComponent.clickProfileLink();
+										test.it( 'Cancel the domain', function() {
+											try {
+												let navBarComponent = new NavBarComponent( driver );
+												navBarComponent.clickProfileLink();
 
-											let profilePage = new ProfilePage( driver );
-											profilePage.chooseManagePurchases();
+												let profilePage = new ProfilePage( driver );
+												profilePage.chooseManagePurchases();
 
-											let purchasesPage = new PurchasesPage( driver );
-											purchasesPage.dismissGuidedTour();
-											purchasesPage.selectBusinessPlan( driver );
+												let purchasesPage = new PurchasesPage( driver );
+												purchasesPage.dismissGuidedTour();
+												purchasesPage.selectBusinessPlan( driver );
 
-											let managePurchasePage = new ManagePurchasePage( driver );
-											managePurchasePage.chooseCancelAndRefund();
+												let managePurchasePage = new ManagePurchasePage( driver );
+												managePurchasePage.chooseCancelAndRefund();
 
-											let cancelPurchasePage = new CancelPurchasePage( driver );
-											cancelPurchasePage.clickCancelPurchase();
-											cancelPurchasePage.completeCancellationSurvey();
-											cancelPurchasePage.waitToDisappear();
-											purchasesPage.waitForAndDismissSuccessMessage();
+												let cancelPurchasePage = new CancelPurchasePage( driver );
+												cancelPurchasePage.clickCancelPurchase();
+												cancelPurchasePage.completeCancellationSurvey();
+												cancelPurchasePage.waitToDisappear();
+												purchasesPage.waitForAndDismissSuccessMessage();
 
-											purchasesPage.selectDomainInPlan( );
+												purchasesPage.selectDomainInPlan( );
 
-											managePurchasePage = new ManagePurchasePage( driver );
-											managePurchasePage.domainDisplayed().then( ( domainDisplayed ) => {
-												assert.equal( domainDisplayed, expectedDomainName, 'The domain displayed on the manage purchase page is unexpected' );
-											} );
-											managePurchasePage.chooseRemovePurchase();
-											managePurchasePage.removeNow();
-											return managePurchasePage.waitTillRemoveNoLongerShown();
+												managePurchasePage = new ManagePurchasePage( driver );
+												managePurchasePage.domainDisplayed().then( ( domainDisplayed ) => {
+													assert.equal( domainDisplayed, expectedDomainName, 'The domain displayed on the manage purchase page is unexpected' );
+												} );
+												managePurchasePage.chooseRemovePurchase();
+												managePurchasePage.removeNow();
+												return managePurchasePage.waitTillRemoveNoLongerShown();
+											} catch ( err ) {
+												SlackNotifier.warn( `There was an error in the hooks that clean up the test domains but since it is cleaning up we really don't care: '${ err }'` );
+											}
 										} );
 									} );
-								} );
-							} );
-						} );
-					} );
-				} );
-			} );
-		} );
-	} );
-
-	test.describe( 'Partially sign up for a site on a business paid plan w/ domain name through main flow @parallel', function() {
-		this.bailSuite( true );
-		let stepNum = 1;
-
-		const siteName = dataHelper.getNewBlogName();
-		const expectedDomainName = `${siteName}.live`;
-		const emailAddress = dataHelper.getEmailAddress( siteName, signupInboxId );
-		const password = config.get( 'passwordForNewTestSignUps' );
-		const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
-		const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
-		const firstName = 'End to End';
-		const lastName = 'Testing';
-		const phoneNumber = '0422 888 888';
-		const countryCode = 'AU';
-		const address = '888 Queen Street';
-		const city = 'Brisbane';
-		const stateCode = 'QLD';
-		const postalCode = '4000';
-
-		test.it( 'Ensure we are not logged in as anyone', function() {
-			return driverManager.ensureNotLoggedIn( driver );
-		} );
-
-		test.it( 'We can set the sandbox cookie for payments', function() {
-			this.WPHomePage = new WPHomePage( driver, { visit: true, culture: locale } );
-			this.WPHomePage.setSandboxModeForPayments( sandboxCookieValue );
-		} );
-
-		test.describe( `Step ${stepNum}: About Page`, function() {
-			stepNum++;
-
-			test.it( 'Can see the about page', function() {
-				this.startPage = new StartPage( driver, { visit: true, culture: locale } );
-				this.aboutPage = new AboutPage( driver );
-				return this.aboutPage.displayed().then( ( displayed ) => {
-					return assert.equal( displayed, true, 'The about page is not displayed' );
-				} );
-			} );
-
-			test.it( 'Can accept defaults for about page', function() {
-				this.aboutPage.submitForm();
-			} );
-
-			test.describe( `Step ${stepNum}: Domains`, function() {
-				stepNum++;
-
-				test.it( 'Can then see the domains page ', function() {
-					this.findADomainComponent = new FindADomainComponent( driver );
-					return this.findADomainComponent.displayed().then( ( displayed ) => {
-						return assert.equal( displayed, true, 'The choose a domain page is not displayed' );
-					} );
-				} );
-
-				test.it( 'Can search for a blog name, can see and select a paid .com address in results', function() {
-					this.findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
-					return this.findADomainComponent.selectDotComAddress( expectedDomainName );
-				} );
-
-				test.describe( `Step ${stepNum}: Plans`, function() {
-					stepNum++;
-
-					test.it( 'Can then see the plans page', function() {
-						this.pickAPlanPage = new PickAPlanPage( driver );
-						return this.pickAPlanPage.displayed().then( ( displayed ) => {
-							return assert.equal( displayed, true, 'The pick a plan page is not displayed' );
-						} );
-					} );
-
-					test.it( 'Can select the business plan', function() {
-						return this.pickAPlanPage.selectBusinessPlan();
-					} );
-
-					test.describe( `Step ${stepNum}: Account`, function() {
-						stepNum++;
-
-						test.it( 'Can then enter account details', function() {
-							this.createYourAccountPage = new CreateYourAccountPage( driver );
-							this.createYourAccountPage.displayed().then( ( displayed ) => {
-								assert.equal( displayed, true, 'The create account page is not displayed' );
-							} );
-							return this.createYourAccountPage.enterAccountDetailsAndSubmit( emailAddress, siteName, password );
-						} );
-
-						test.describe( `Step ${stepNum}: Processing`, function() {
-							stepNum++;
-
-							test.it( 'Can then see the sign up processing page which will finish automatically move along', function() {
-								this.signupProcessingPage = new SignupProcessingPage( driver );
-								return this.signupProcessingPage.waitToDisappear();
-							} );
-
-							test.it( 'Verify login screen not present', () => {
-								return driver.getCurrentUrl().then( ( url ) => {
-									if ( ! url.match( /checkout/ ) ) {
-										let baseURL = config.get( 'calypsoBaseURL' );
-										let newUrl = `${baseURL}/checkout/${expectedDomainName}/business`;
-										SlackNotifier.warn( `WARNING: Signup process sent me to ${url} instead of ${newUrl}!` );
-										return driver.get( decodeURIComponent( newUrl ) );
-									}
-
-									return true;
-								} );
-							} );
-
-							test.describe( `Step ${stepNum}: Secure Payment Page`, function() {
-								stepNum++;
-
-								test.it( 'Can see checkout page', () => {
-									this.checkOutPage = new CheckOutPage( driver );
-									this.checkOutPage.displayed().then( ( displayed ) => {
-										assert.equal( displayed, true, 'Could not see the check out page' );
-									} );
-								} );
-
-								test.it( 'Can choose domain privacy option', () => {
-									this.checkOutPage = new CheckOutPage( driver );
-									this.checkOutPage.selectAddPrivacyProtectionCheckbox();
-								} );
-
-								test.it( 'Can enter domain registrar details', () => {
-									this.checkOutPage = new CheckOutPage( driver );
-									this.checkOutPage.enterRegistarDetails( firstName, lastName, emailAddress, phoneNumber, countryCode, address, city, stateCode, postalCode );
-									this.checkOutPage.submitForm();
-								} );
-
-								test.it( 'Can then see secure payment component', () => {
-									this.securePaymentComponent = new SecurePaymentComponent( driver );
-									this.securePaymentComponent.displayed().then( ( displayed ) => {
-										assert.equal( displayed, true, 'Could not see the secure payment component' );
-									} );
-								} );
-
-								test.it( 'Can enter and submit test payment details and finish', function() {
-									this.securePaymentComponent = new SecurePaymentComponent( driver );
-									return this.securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 								} );
 							} );
 						} );


### PR DESCRIPTION
These hooks are nice to run, but aren't necessary and sometimes fail the build when they do fail - so instead of failing we'll just see a warning in Slack

Also removes a scenario that was duplicated through a bad merge or something