### PR TITLE
Fix customizer page options

### DIFF
--- a/lib/pages/customizer-page.js
+++ b/lib/pages/customizer-page.js
@@ -311,31 +311,21 @@ export default class CustomizerPage extends BaseContainer {
 	}
 
 	frontPageOptionDisplayed() {
-		let present = false;
 		this._ensureMetaViewOnMobile();
 		this._switchToMetaiFrame();
 
-		present = this.driver.wait( until.elementLocated( by.css( 'select#_customize-dropdown-pages-page_on_front' ) ), this.explicitWaitMS ).then( () => {
-			return true;
-		}, ( ) => {
-			return false;
-		} );
-		this._switchToDefaultContent();
-		return present;
+		driverHelper.waitTillPresentAndDisplayed( this.driver, by.css( '#_customize-input-show_on_front-radio-page' ) );
+
+		return this._switchToDefaultContent();
 	}
 
 	postsPageOptionDisplayed() {
-		let present = false;
 		this._ensureMetaViewOnMobile();
 		this._switchToMetaiFrame();
 
-		present = this.driver.wait( until.elementLocated( by.css( 'select#_customize-dropdown-pages-page_for_posts' ) ), this.explicitWaitMS ).then( () => {
-			return true;
-		}, ( ) => {
-			return false;
-		} );
-		this._switchToDefaultContent();
-		return present;
+		driverHelper.waitTillPresentAndDisplayed( this.driver, by.css( '#_customize-input-show_on_front-radio-posts' ) );
+
+		return this._switchToDefaultContent();
 	}
 
 	previewTitle() {


### PR DESCRIPTION
Fixes #890

The selector was out of date and we weren't actually failing the test - fixes failing the test now and updates the selector

 Setting static front page
                    ✓ Expand static front page (1268ms)
                    ✓ Can see the front page option (47ms)
                    ✓ Can see the posts page option (45ms)