### PR TITLE
Select 2fa options using the new data-e2e-link attributes

### DIFF
--- a/lib/pages/login-page.js
+++ b/lib/pages/login-page.js
@@ -46,11 +46,11 @@ export default class LoginPage extends BaseContainer {
 		let actionSelector;
 
 		if ( twoFAMethod === 'sms' ) {
-			actionSelector = By.linkText( 'Code via text message' );
+			actionSelector = By.css( 'button[data-e2e-link="2fa-sms-link"]' );
 		} else if ( twoFAMethod === 'otp' ) {
-			actionSelector = By.linkText( 'Your authenticator app' );
+			actionSelector = By.css( 'button[data-e2e-link="2fa-otp-link"]' );
 		} else if ( twoFAMethod === 'backup' ) {
-			actionSelector = By.linkText( 'I can\'t access my phone' );
+			actionSelector = By.css( 'button[data-e2e-link="lost-phone-link"]' );
 		}
 
 		if ( actionSelector ) {

--- a/specs/wp-log-in-out-spec.js
+++ b/specs/wp-log-in-out-spec.js
@@ -103,27 +103,25 @@ test.describe( `[${host}] Authentication: (${screenSize}) @parallel @jetpack @vi
 
 	if ( dataHelper.hasAccountWithFeatures( '+2fa-sms -passwordless' ) ) {
 		test.describe( 'Can Log in on a 2fa account', function() {
-			test.before( function() {
-				return driverManager.clearCookiesAndDeleteLocalStorage( driver );
-			} );
-
 			let loginFlow, twoFALoginPage, twoFACode;
 			test.before( function( done ) {
-				loginFlow = new LoginFlow( driver, [ '+2fa-sms', '-passwordless' ] );
-				// make sure we listen for SMS before we trigger any
-				const xmppClient = listenForSMS( loginFlow.account );
-				xmppClient.once( 'e2e:ready', () => {
-					// send sms now!
-					loginFlow.login();
-					twoFALoginPage = new LoginPage( driver );
-					twoFALoginPage.use2FAMethod( 'sms' );
-				} );
-				xmppClient.on( 'e2e:sms', sms => {
-					const twoFACodeMatches = sms.body.match( /^\d+/ );
-					twoFACode = twoFACodeMatches && twoFACodeMatches[0];
-					if ( twoFACode ) {
-						xmppClient.stop().then( () => done() );
-					}
+				driverManager.clearCookiesAndDeleteLocalStorage( driver ).then( function() {
+					loginFlow = new LoginFlow( driver, [ '+2fa-sms', '-passwordless' ] );
+					// make sure we listen for SMS before we trigger any
+					const xmppClient = listenForSMS( loginFlow.account );
+					xmppClient.once( 'e2e:ready', () => {
+						// send sms now!
+						loginFlow.login();
+						twoFALoginPage = new LoginPage( driver );
+						twoFALoginPage.use2FAMethod( 'sms' );
+					} );
+					xmppClient.on( 'e2e:sms', sms => {
+						const twoFACodeMatches = sms.body.match( /^\d+/ );
+						twoFACode = twoFACodeMatches && twoFACodeMatches[0];
+						if ( twoFACode ) {
+							xmppClient.stop().then( () => done() );
+						}
+					} );
 				} );
 			} );
 
@@ -143,16 +141,14 @@ test.describe( `[${host}] Authentication: (${screenSize}) @parallel @jetpack @vi
 
 	if ( dataHelper.hasAccountWithFeatures( '+2fa-otp -passwordless' ) ) {
 		test.describe( 'Can Log in on a 2fa account', function() {
-			test.before( function() {
-				return driverManager.clearCookiesAndDeleteLocalStorage( driver );
-			} );
-
 			let loginFlow, twoFALoginPage;
 			test.before( function() {
-				loginFlow = new LoginFlow( driver, [ '+2fa-otp', '-passwordless' ] );
-				loginFlow.login();
-				twoFALoginPage = new LoginPage( driver );
-				return twoFALoginPage.use2FAMethod( 'otp' );
+				return driverManager.clearCookiesAndDeleteLocalStorage( driver ).then( function() {
+					loginFlow = new LoginFlow( driver, [ '+2fa-otp', '-passwordless' ] );
+					loginFlow.login();
+					twoFALoginPage = new LoginPage( driver );
+					return twoFALoginPage.use2FAMethod( 'otp' );
+				} );
 			} );
 
 			test.it( 'Should be on the /log-in/authenticator page', function() {


### PR DESCRIPTION
Addresses https://github.com/Automattic/wp-e2e-tests/issues/906

This PR updates our test to use the new `data-e2e-link` attributes added to the login 2fa screens in https://github.com/Automattic/wp-calypso/pull/22088.
It also fixes a race condition when clearing the cookies before each login tests.

### Testing Instructions
- Check that the login suite passes
`NODE_ENV=test BROWSERSIZE=mobile ./node_modules/.bin/mocha specs/wp-log-in-out-spec.js`

### Reviews
- [x] Code
- [ ] Product