### PR TITLE
Remove completed ab test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -67,7 +67,6 @@
     "jetpackHidePlanIconsForAllDevices",
     "checklistThankYouForFreeUser",
     "checklistThankYouForPaidUser",
-    "promoteYearlyJetpackPlanSavings",
     "domainSuggestionTestV5"
   ],
   "overrideABTests": [
@@ -76,7 +75,6 @@
     [ "domainsCheckoutLocalizedAddresses_20171025", "showDefaultAddressFormat" ],
     [ "checklistThankYouForFreeUser_20171204", "hide" ],
     [ "checklistThankYouForPaidUser_20171204", "hide" ],
-    [ "promoteYearlyJetpackPlanSavings_20180124", "original" ],
     [ "domainSuggestionTestV5_20180204", "group_0" ]
   ]
 }


### PR DESCRIPTION
Remove `promoteYearlyJetpackPlanSavings` AB test config.

Will be disabled in Calypso by:

https://github.com/Automattic/wp-calypso/pull/22135