### PR TITLE
Remove unlimitedThemeNudge a/b test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -63,7 +63,6 @@
     "multiDomainRegistrationV1",
     "presaleChatButton",
     "skipThemesSelectionModal",
-    "unlimitedThemeNudge",
     "jetpackHidePlanIconsForAllDevices",
     "checklistThankYouForFreeUser",
     "checklistThankYouForPaidUser",


### PR DESCRIPTION
We will be removing this a/b test with https://github.com/Automattic/wp-calypso/pull/22196 and releasing this functionality to all users.

No existing tests need to handle this new behaviour - it's just an extra icon displayed for paid themes for a wpcom free or personal plan.