### PR TITLE
Try increasing purchases list timeout

### DIFF
--- a/lib/pages/purchases-page.js
+++ b/lib/pages/purchases-page.js
@@ -40,6 +40,6 @@ export default class PurchasesPage extends BaseContainer {
 	}
 
 	_waitForPurchases() {
-		driverHelper.waitTillNotPresent( this.driver, by.css( '.is-placeholder' ) );
+		driverHelper.waitTillNotPresent( this.driver, by.css( '.is-placeholder' ), this.explicitWaitMS * 3 );
 	}
 }


### PR DESCRIPTION
The clean up step of purchase specs often fail as purchases take time to load.

This increases the timeout for the purchases threefold to make sure this waits appropriately. 