### PR TITLE
Ignore overriding AB tests for logged in scenarios

### DIFF
--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -77,9 +77,9 @@ export default class LoginFlow {
 
 		this.editorPage = new EditorPage( this.driver );
 
-		this.driver.getCurrentUrl().then( ( urlDisplayed ) => {
-			return this.editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
-		} );
+		// this.driver.getCurrentUrl().then( ( urlDisplayed ) => {
+		// 	return this.editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
+		// } );
 	}
 
 	loginAndStartNewPage() {
@@ -90,9 +90,9 @@ export default class LoginFlow {
 
 		this.editorPage = new EditorPage( this.driver );
 
-		this.driver.getCurrentUrl().then( ( urlDisplayed ) => {
-			return this.editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
-		} );
+		// this.driver.getCurrentUrl().then( ( urlDisplayed ) => {
+		// 	return this.editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
+		// } );
 	}
 
 	loginAndSelectDomains() {

--- a/lib/pages/jetpack-authorize-page.js
+++ b/lib/pages/jetpack-authorize-page.js
@@ -6,9 +6,9 @@ import * as driverHelper from '../driver-helper';
 export default class JetpackAuthorizePage extends BaseContainer {
 	constructor( driver ) {
 		super( driver, by.css( '.is-section-jetpackConnect' ) );
-		driver.getCurrentUrl().then( ( urlDisplayed ) => {
-			this.setABTestControlGroupsInLocalStorage( urlDisplayed );
-		} );
+		// driver.getCurrentUrl().then( ( urlDisplayed ) => {
+		// 	this.setABTestControlGroupsInLocalStorage( urlDisplayed );
+		// } );
 	}
 
 	chooseSignIn() {

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -658,9 +658,9 @@ testDescribe( `[${host}] Invites:  (${screenSize})`, function() {
 									this.navbarComponent.dismissGuidedTours();
 									this.navbarComponent.clickCreateNewPost();
 									this.editorPage = new EditorPage( driver );
-									driver.getCurrentUrl().then( ( urlDisplayed ) => {
-										return this.editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
-									} );
+									// driver.getCurrentUrl().then( ( urlDisplayed ) => {
+									// 	return this.editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
+									// } );
 									this.editorPage.enterTitle( reviewPostTitle );
 									return this.editorPage.enterContent( postQuote );
 								} );
@@ -721,9 +721,9 @@ testDescribe( `[${host}] Invites:  (${screenSize})`, function() {
 												this.navbarComponent = new NavbarComponent( driver );
 												this.navbarComponent.clickCreateNewPost();
 												this.editorPage = new EditorPage( driver );
-												driver.getCurrentUrl().then( ( urlDisplayed ) => {
-													return this.editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
-												} );
+												// driver.getCurrentUrl().then( ( urlDisplayed ) => {
+												// 	return this.editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
+												// } );
 												this.editorPage.enterTitle( publishPostTitle );
 												this.editorPage.enterContent( postQuote );
 											} );

--- a/specs/wp-manage-domains-map-spec.js
+++ b/specs/wp-manage-domains-map-spec.js
@@ -52,9 +52,9 @@ test.describe( `[${host}] Managing Domain Mapping: (${screenSize}) @parallel`, f
 		test.describe( 'Can find domain mapping section and enter a domain to map', function() {
 			test.it( 'Can choose add a domain', () => {
 				const domainsPage = new DomainsPage( driver );
-				driver.getCurrentUrl().then( ( urlDisplayed ) => {
-					domainsPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
-				} );
+				// driver.getCurrentUrl().then( ( urlDisplayed ) => {
+				// 	domainsPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
+				// } );
 				return domainsPage.clickAddDomain();
 			} );
 

--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -63,9 +63,9 @@ test.describe( `[${host}] Managing Domains: (${screenSize}) @parallel`, function
 		test.describe( 'Can search for and select a paid domain', function() {
 			test.it( 'Can choose add a domain', () => {
 				const domainsPage = new DomainsPage( driver );
-				driver.getCurrentUrl().then( ( urlDisplayed ) => {
-					domainsPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
-				} );
+				// driver.getCurrentUrl().then( ( urlDisplayed ) => {
+				// 	domainsPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
+				// } );
 				return domainsPage.clickAddDomain();
 			} );
 

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -851,10 +851,10 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 				return postEditorSidebarComponent.trashPost();
 			} );
 
-			test.it( 'Can then see the Posts page (new)', function() {
-				const postsPage = new PostsPage( driver );
-				return postsPage.displayed().then( ( displayed ) => {
-					return assert.equal( displayed, true, 'The posts page is not displayed' );
+			test.it( 'Can then see the Reader page', function() {
+				const readerPage = new ReaderPage( driver );
+				return readerPage.displayed().then( ( displayed ) => {
+					return assert.equal( displayed, true, 'The reader page is not displayed' );
 				} );
 			} );
 		} );

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -865,9 +865,8 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 
 		test.it( 'Delete Cookies and Local Storage', function() {
 			driverManager.clearCookiesAndDeleteLocalStorage( driver );
+			return SlackNotifier.warn( 'Not running the edit a post test because of https://github.com/Automattic/wp-calypso/issues/22258', { suppressDuplicateMessages: true } );
 		} );
-
-		SlackNotifier.warn( 'Not running the edit a post test because of https://github.com/Automattic/wp-calypso/issues/22258', { suppressDuplicateMessages: true } );
 
 		test.xdescribe( 'Publish a New Post', function() {
 			const originalBlogPostTitle = dataHelper.randomPhrase();


### PR DESCRIPTION
Working around this: https://github.com/Automattic/wp-e2e-tests/issues/929