### PR TITLE
Add live branch support to logged out theme page

### DIFF
--- a/lib/pages/themes-page.js
+++ b/lib/pages/themes-page.js
@@ -1,6 +1,7 @@
 import { By as by, until } from 'selenium-webdriver';
-import BaseContainer from '../base-container.js';
-import * as driverHelper from '../driver-helper.js';
+import BaseContainer from '../base-container';
+import * as driverHelper from '../driver-helper';
+import * as dataHelper from '../data-helper';
 import config from 'config';
 
 export default class ThemesPage extends BaseContainer {
@@ -8,6 +9,9 @@ export default class ThemesPage extends BaseContainer {
 		let url;
 		if ( visit === true ) {
 			url = config.get( 'calypsoBaseURL' ) + '/themes';
+			if ( dataHelper.isRunningOnLiveBranch() ) {
+				url = url + '?branch=' + config.get( 'branchName' );
+			}
 		}
 		super( driver, by.css( '.theme__active-focus' ), visit, url );
 		this.waitUntilThemesLoaded();


### PR DESCRIPTION
The /themes page currently doesn't add the query string needed for the branch for calypso.live

@rachelmcr I think you added this test - would you mind seeing if this looks ok?