### PR TITLE
Set the domain suggestion group

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -68,6 +68,7 @@
   "overrideABTests": [
     [ "skipThemesSelectionModal_20170904", "show" ],
     [ "checklistThankYouForFreeUser_20171204", "hide" ],
-    [ "checklistThankYouForPaidUser_20171204", "hide" ]
+    [ "checklistThankYouForPaidUser_20171204", "hide" ],
+    [ "domainSuggestionTestV6_20180215", "group_0" ]
   ]
 }


### PR DESCRIPTION
This is causing inconsistent behaviour

Uses group_0

Introduced here: https://github.com/Automattic/wp-calypso/pull/22463/