### PR TITLE
Add steps to force the Chromedriver we installed via npm

### DIFF
--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -121,6 +121,10 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 					options.addArguments( '--headless' );
 					global.isHeadless = true;
 				}
+
+				const service = new chrome.ServiceBuilder( chromedriver.path ).build();
+				chrome.setDefaultService( service );
+
 				builder = new webdriver.Builder();
 				builder.setChromeOptions( options );
 				global.__BROWSER__ = driver = builder.forBrowser( 'chrome' ).setLoggingPrefs( pref ).build();


### PR DESCRIPTION
We install Chromedriver via npm, but if it exists elsewhere on the system with a higher precedence in the `$PATH` we'll still use the other version.  This was causing problems on some of the CircleCI 1.0 builds on `wp-e2e-tests-for-branches`

This PR adds the necessary configuration to force it to pull the right path (_borrowed_ from [here](https://stackoverflow.com/a/27733960))