### PR TITLE
add TARGET env var to run-wrapper

### DIFF
--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -31,8 +31,10 @@ if [ "$RUN_SPECIFIED" == "true" ]; then
   TESTARGS=$RUN_ARGS
 elif [[ "$CIRCLE_BRANCH" =~ .*[Jj]etpack.*|.*[Jj][Pp].* ]]; then
   export JETPACKHOST=PRESSABLE
+	export TARGET=JETPACK
   TESTARGS="-R -j" # Execute Jetpack tests
 elif [[ "$CIRCLE_BRANCH" =~ .*[Ww][Oo][Oo].* ]]; then
+	export TARGET=WOO
   TESTARGS="-R -W" # Execute WooCommerce tests
 elif [ "$CIRCLE_BRANCH" == "master" ]; then
   TESTARGS="-R -p -x" # Parallel execution, implies -g -s mobile,desktop

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -31,10 +31,10 @@ if [ "$RUN_SPECIFIED" == "true" ]; then
   TESTARGS=$RUN_ARGS
 elif [[ "$CIRCLE_BRANCH" =~ .*[Jj]etpack.*|.*[Jj][Pp].* ]]; then
   export JETPACKHOST=PRESSABLE
-	export TARGET=JETPACK
+  export TARGET=JETPACK
   TESTARGS="-R -j" # Execute Jetpack tests
 elif [[ "$CIRCLE_BRANCH" =~ .*[Ww][Oo][Oo].* ]]; then
-	export TARGET=WOO
+  export TARGET=WOO
   TESTARGS="-R -W" # Execute WooCommerce tests
 elif [ "$CIRCLE_BRANCH" == "master" ]; then
   TESTARGS="-R -p -x" # Parallel execution, implies -g -s mobile,desktop


### PR DESCRIPTION
Depending on the branch name our PRs can trigger Jetpack / Woo specs. I've added `TARGET` env vars accordingly to make them comply with our new config structure