### PR TITLE
Force the correct version of Chromedriver + Chrome

### DIFF
--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -121,6 +121,10 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 					options.addArguments( '--headless' );
 					global.isHeadless = true;
 				}
+
+				const service = new chrome.ServiceBuilder( chromedriver.path ).build();
+				chrome.setDefaultService( service );
+
 				builder = new webdriver.Builder();
 				builder.setChromeOptions( options );
 				global.__BROWSER__ = driver = builder.forBrowser( 'chrome' ).setLoggingPrefs( pref ).build();

--- a/run.sh
+++ b/run.sh
@@ -29,6 +29,16 @@ if [ "$CI" == "true" ]; then
 
   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
   nvm install
+
+  # Temporary workaround to force an updated version of Chrome on CircleCI 1.0 containers
+  # https://github.com/Automattic/wp-e2e-tests/issues/783
+  # p6fDka-v0-p2
+  if [ "$(google-chrome --version | awk -F. '{ print $1 }' | awk '{ print $3 }')" -le "59" ]; then
+    curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+    sudo dpkg -i google-chrome.deb
+    sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
+    rm google-chrome.deb
+  fi
 fi
 
 # Function to join arrays into a string


### PR DESCRIPTION
PR #965 forced WebDriver to load the correct version of Chromedriver installed via npm, but this version is incompatible with the version of Chrome running on CircleCI 1.0 wrapper-repos.

Until we determine the long term solution (likely getting rid of wrapper repos altogether), this PR will force those CI 1.0 containers to download the current stable version of Chrome.