### PR TITLE
Add minimizeFreePlan test to the default settings

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -62,12 +62,14 @@
     "checklistThankYouForFreeUser",
     "checklistThankYouForPaidUser",
     "domainSuggestionTestV6",
-    "siteGoalsShuffle"
+    "siteGoalsShuffle",
+    "minimizeFreePlan"
   ],
   "overrideABTests": [
     [ "skipThemesSelectionModal_20170904", "show" ],
     [ "checklistThankYouForFreeUser_20171204", "hide" ],
     [ "checklistThankYouForPaidUser_20171204", "hide" ],
-    [ "domainSuggestionTestV6_20180219", "group_0" ]
+    [ "domainSuggestionTestV6_20180219", "group_0" ],
+    [ "minimizeFreePlan_20180219", "original" ]
   ]
 }


### PR DESCRIPTION
Related: https://github.com/Automattic/wp-calypso/pull/22384