### PR TITLE
Fix AB Override on Premium Themes Signup

### DIFF
--- a/lib/pages/signup/pick-a-plan-page.js
+++ b/lib/pages/signup/pick-a-plan-page.js
@@ -19,9 +19,6 @@ export default class PickAPlanPage extends BaseContainer {
 			null,
 			config.get( 'explicitWaitMS' ) * 2
 		);
-		driver.getCurrentUrl().then( ( urlDisplayed ) => {
-			this.setABTestControlGroupsInLocalStorage( urlDisplayed );
-		} );
 	}
 	_selectPlan( level ) {
 		let prefix = 'table';

--- a/lib/pages/signup/pick-a-plan-page.js
+++ b/lib/pages/signup/pick-a-plan-page.js
@@ -19,6 +19,9 @@ export default class PickAPlanPage extends BaseContainer {
 			null,
 			config.get( 'explicitWaitMS' ) * 2
 		);
+		driver.getCurrentUrl().then( ( urlDisplayed ) => {
+			this.setABTestControlGroupsInLocalStorage( urlDisplayed );
+		} );
 	}
 	_selectPlan( level ) {
 		let prefix = 'table';

--- a/lib/pages/themes-page.js
+++ b/lib/pages/themes-page.js
@@ -5,7 +5,7 @@ import * as dataHelper from '../data-helper';
 import config from 'config';
 
 export default class ThemesPage extends BaseContainer {
-	constructor( driver, visit = false ) {
+	constructor( driver, visit = false, withSignupFlow = null ) {
 		let url;
 		if ( visit === true ) {
 			url = dataHelper.configGet( 'calypsoBaseURL' ) + '/themes';
@@ -15,6 +15,12 @@ export default class ThemesPage extends BaseContainer {
 		}
 		super( driver, by.css( '.theme__active-focus' ), visit, url );
 		this.waitUntilThemesLoaded();
+
+		if ( withSignupFlow !== null ) {
+			driver.getCurrentUrl().then( ( urlDisplayed ) => {
+				this.setABTestControlGroupsInLocalStorage( urlDisplayed, { flow: withSignupFlow } );
+			} );
+		}
 	}
 
 	showOnlyFreeThemes() {

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1079,7 +1079,7 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 			stepNum++;
 
 			test.it( 'Can see the themes page', function() {
-				this.themesPage = new ThemesPage( driver, true );
+				this.themesPage = new ThemesPage( driver, true, 'with-theme' );
 				return this.themesPage.displayed().then( ( displayed ) => {
 					return assert.equal( displayed, true, 'The about page is not displayed' );
 				} );


### PR DESCRIPTION
With the new AB test system we ran into issues with an AB test on the pick a plan page in the premium theme purchase flow, since it wasn't getting set appropriately.  This PR is a little hacky, but adds it specifically into that flow.

I'm going to go ahead and merge this, but would be curious for somebody else from @Automattic/flowpatrol to take a look and make sure I'm not missing an easier solution.