### PR TITLE
Add 'upgradePricingDisplay' AB test as known

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -63,7 +63,8 @@
     "checklistThankYouForPaidUser",
     "domainSuggestionTestV6",
     "siteGoalsShuffle",
-    "minimizeFreePlan"
+    "minimizeFreePlan",
+    "upgradePricingDisplay"
   ],
   "overrideABTests": [
     [ "skipThemesSelectionModal_20170904", "show" ],


### PR DESCRIPTION
Introduced here: https://github.com/Automattic/wp-calypso/pull/22244