### PR TITLE
Update Chromedriver to v2.35.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-runtime": "^6.3.19",
     "bluecat": "^1.1.6",
     "chai": "^3.4.1",
-    "chromedriver": "2.33.2",
+    "chromedriver": "2.35.0",
     "config": "1.16.0",
     "creditcard-generator": "0.0.7",
     "esformatter-braces": "^1.2.1",


### PR DESCRIPTION
I saw one generic `timeout` failure on this build: https://circleci.com/gh/Automattic/wp-e2e-tests/17522

I think this is what we were seeing in bulk with the HEADLESS option previously (#754).  I'm just updating Chromedriver to the latest version to rule that out as a potential cause if the issue escalates.