### PR TITLE
Fix mocha deprecation warning

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,3 @@
---compilers js:babel-register
+--require babel-core/register
 --require lib/before.js
 lib/after.js


### PR DESCRIPTION
This appears when running the specs:

```
(node:40403) DeprecationWarning: "--compilers" will be removed in a future version of Mocha; see https://git.io/vdcSr for more info
```

This PR upgrades the command as necessary

Introduced: https://github.com/Automattic/wp-e2e-tests/pull/991