### PR TITLE
Add retry to signout

### DIFF
--- a/lib/pages/profile-page.js
+++ b/lib/pages/profile-page.js
@@ -17,7 +17,11 @@ export default class ProfilePage extends BaseContainer {
 		this._closeProfileViewOnMobile();
 
 		driverHelper.clickWhenClickable( this.driver, this.signOutSelector );
-		return driverHelper.waitTillNotPresent( this.driver, this.signOutSelector );
+		return driverHelper.waitTillNotPresent( this.driver, this.signOutSelector ).then( () => {}, () => {
+			// Occasionally the click doesn't work on mobile due to the drawer animation, so retry once
+			driverHelper.clickWhenClickable( this.driver, this.signOutSelector );
+			return driverHelper.waitTillNotPresent( this.driver, this.signOutSelector );
+		} );
 	}
 
 	chooseManagePurchases() {


### PR DESCRIPTION
Recently I've seen a lot of failures on logout at the mobile screen width.  My assumption is that it's because the sidebar is sliding in with an animation, and the Sign Out button isn't catching the click.  This PR just adds a retry to clicking Sign Out.  I tried adding a better wait status to the `_closeProfileViewOnMobile()` function to ensure the sidebar was fully loaded, but I still saw the problem in 1/10 runs.