### PR TITLE
Add upgradePricingDisplayV2 test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -65,10 +65,12 @@
     "siteGoalsShuffle",
     "minimizeFreePlan",
     "upgradePricingDisplay",
+    "upgradePricingDisplayV2",
     "redesignedSidebarBanner"
   ],
   "overrideABTests": [
     [ "upgradePricingDisplay_20180213", "original" ],
+    [ "upgradePricingDisplayV2_20180305", "original" ],
     [ "domainSuggestionTestV6_20180301", "group_0" ],
     [ "businessPlanDescriptionAT_20170605", "original" ],
     [ "skipThemesSelectionModal_20170904", "show" ],


### PR DESCRIPTION
Since the `upgradePricingDisplay` test is going to be renamed to `upgradePricingDisplayV2`, I made two PRs to switch the names. This PR will add the new one.

See also #1005 
Related PR: https://github.com/Automattic/wp-calypso/pull/22986