### PR TITLE
Add the `inlineHelpWithContactForm` A/B test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -57,6 +57,7 @@
   },
   "knownABTestKeys": [
     "businessPlanDescriptionAT",
+    "inlineHelpWithContactForm",
     "skipThemesSelectionModal",
     "checklistThankYouForFreeUser",
     "checklistThankYouForPaidUser",
@@ -70,6 +71,7 @@
   ],
   "overrideABTests": [
     [ "domainSuggestionTestV6_20180301", "group_0" ],
+    [ "inlineHelpWithContactForm_20180315", "inlinecontact" ],
     [ "upgradePricingDisplayV2_20180305", "original" ],
     [ "businessPlanDescriptionAT_20170605", "original" ],
     [ "skipThemesSelectionModal_20170904", "show" ],


### PR DESCRIPTION
This PR adds the `inlineHelpWithContactForm` A/B test to the list of known A/B tests. 

I chose the new `inlinecontact` variant as default because that is where we want to move things eventually. Please let me know if that's the wrong way to go. 

Also see: Automattic/wp-calypso/pull/22487
