### PR TITLE
Do deeper check on ABtest values so that order doesn't matter

### DIFF
--- a/lib/base-container.js
+++ b/lib/base-container.js
@@ -1,5 +1,6 @@
 import config from 'config';
 import assert from 'assert';
+import { isEqual } from 'lodash';
 
 import * as driverManager from './driver-manager';
 import * as driverHelper from './driver-helper';
@@ -86,8 +87,8 @@ export default class BaseContainer {
 		} );
 
 		this.driver.executeScript( 'return window.localStorage.ABTests;' ).then( ( abtestsValue ) => {
-			if ( abtestsValue !== `{${expectedABTestValue}}` ) {
-				const message = `The localstorage value for AB tests wasn't set correctly.\nExpected value is:\n'${expectedABTestValue}'\nActual value is:\n'${abtestsValue}'`;
+			if ( !isEqual( JSON.parse( abtestsValue ), JSON.parse( `{${expectedABTestValue}}` ) ) ) {
+				const message = `The localstorage value for AB tests wasn't set correctly.\nExpected value is:\n'{${expectedABTestValue}}'\nActual value is:\n'${abtestsValue}'`;
 				slackNotifier.warn( message, { suppressDuplicateMessages: true } );
 			}
 		} );


### PR DESCRIPTION
Used lodash to compare the A/B test values so that it doesn't fail if the order is different

Also updated error message to include curly brackets so it doesn't lead people down the wrong path if it fails.