### PR TITLE
Try to make #changeToNewRole a bit more reliable

### DIFF
--- a/lib/pages/edit-team-member-page.js
+++ b/lib/pages/edit-team-member-page.js
@@ -19,9 +19,15 @@ export default class EditTeamMemberPage extends BaseContainer {
 	}
 
 	changeToNewRole( roleName ) {
-		DriverHelper.clickWhenClickable( this.driver, By.css( `select#roles option[value=${roleName}]` ) );
-		DriverHelper.clickWhenClickable( this.driver, By.css( 'button.form-button.is-primary' ) );
-		return this.driver.wait( until.elementLocated( By.css( '.is-success' ) ), this.explicitWaitMS, 'Could not locate the success message' );
+		const roleSelector = By.css( `select#roles option[value=${roleName}]` );
+		const buttonSelector = By.css( '.edit-team-member-form__form button:not([disabled])' );
+
+		return DriverHelper.clickWhenClickable( this.driver, roleSelector )
+		.then( () => DriverHelper.clickWhenClickable( this.driver, buttonSelector ) )
+		.then( () => this.driver.wait(
+			until.elementLocated( By.css( '.people-notices__notice.is-success' ) ),
+			this.explicitWaitMS,
+			'Could not locate the success message' ) );
 	}
 
 	successNoticeDisplayed() {


### PR DESCRIPTION
There are 2 buttons with the same locators in the EditTeamMemberPage. 'Update' button is in `disabled` state it role was not changed.

This PR makes `#changeToNewRole` click only on active 'Update' button, also it chains the driver-related calls to guarantee synchronous execution  