### PR TITLE
Separate the minimizeFreePlanV2 test into two tests based on user login

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -64,7 +64,8 @@
     "domainSuggestionTestV6",
     "siteGoalsShuffle",
     "minimizeFreePlan",
-    "minimizeFreePlanV2",
+    "minimizedFreePlanForSignedUser",
+    "minimizedFreePlanForNonSignedUser",
     "upgradePricingDisplayV2",
     "redesignedSidebarBanner"
   ],
@@ -76,7 +77,8 @@
     [ "checklistThankYouForFreeUser_20171204", "hide" ],
     [ "checklistThankYouForPaidUser_20171204", "hide" ],
     [ "minimizeFreePlan_20180219", "original" ],
-    [ "minimizeFreePlanV2_20180308", "original" ],
+    [ "minimizedFreePlanForSignedUser_20180308", "original" ],
+    [ "minimizedFreePlanForNonSignedUser_20180308", "original" ],
     [ "siteGoalsShuffle_20180214", "control" ]
   ]
 }


### PR DESCRIPTION
The `minimizeFreePlan` test will be separated into two new tests for signed users and non-signed users respectively.