### PR TITLE
Add overrides for all known A/B tests

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -70,8 +70,8 @@
     "redesignedSidebarBanner"
   ],
   "overrideABTests": [
-	[ "domainSuggestionTestV6_20180301", "group_0" ],
-	[ "upgradePricingDisplayV2_20180305", "original" ],
+    [ "domainSuggestionTestV6_20180301", "group_0" ],
+    [ "upgradePricingDisplayV2_20180305", "original" ],
     [ "businessPlanDescriptionAT_20170605", "original" ],
     [ "skipThemesSelectionModal_20170904", "show" ],
     [ "checklistThankYouForFreeUser_20171204", "hide" ],
@@ -79,6 +79,8 @@
     [ "minimizeFreePlan_20180219", "original" ],
     [ "minimizedFreePlanForSignedUser_20180308", "original" ],
     [ "minimizedFreePlanForNonSignedUser_20180308", "original" ],
-    [ "siteGoalsShuffle_20180214", "control" ]
+    [ "siteGoalsShuffle_20180214", "control" ],
+    [ "redesignedSidebarBanner_20180222", "oldBanner" ],
+    [ "businessPlanDescriptionAT_20170605", "original" ]
   ]
 }


### PR DESCRIPTION
While reviewing visual regression tests results I noticed that some a/b tests were causing failures in Applitools due to testing visual (but not functional) changes.

Previously we only added A/B test overrides for tests that made functional changes. Adding them for all A/B tests will guard against unnecessary visdiff failures or noise.

Related update to Calypso docs: https://github.com/Automattic/wp-calypso/pull/23123