### PR TITLE
Wait for 25 seconds for finding the container element for the Jetpack Admin Page

### DIFF
--- a/lib/pages/wp-admin/wp-admin-jetpack-page.js
+++ b/lib/pages/wp-admin/wp-admin-jetpack-page.js
@@ -5,7 +5,8 @@ import * as driverHelper from '../../driver-helper';
 
 export default class WPAdminJetpackPage extends BaseContainer {
 	constructor( driver ) {
-		super( driver, by.css( '#jp-plugin-container' ) );
+		const ADMIN_PAGE_WAIT_MS = 25000;
+		super( driver, by.css( '#jp-plugin-container' ), false, null, ADMIN_PAGE_WAIT_MS );
 	}
 
 	connectWordPressCom() {


### PR DESCRIPTION
Makes the `WPAdminJetpackPage` class wait for 25 seconds before giving up on finding the element with id `jp-plugin-container`.

**Context**

After adding SSL to Jurassic Ninja sites the launching time was increased by about 4 seconds, so added to the average 17 seconds that we were experiencing before enabling SSL, we're now experiencing failed jobs when reaching the default timeout of 20 seconds (defined in config/default).