### PR TITLE
Switch JN tests to use stable Jetpack

### DIFF
--- a/lib/pages/wp-admin/wp-admin-dashboard-page.js
+++ b/lib/pages/wp-admin/wp-admin-dashboard-page.js
@@ -9,6 +9,7 @@ export default class WPAdminDashboardPage extends BaseContainer {
 		let wpAdminURL;
 
 		if ( url ) {
+			url = url.replace( /^https?:\/\//, '' ).replace( /\/wp-admin/, '' );
 			wpAdminURL = `http://${url}/wp-admin`;
 			visit = true;
 		}

--- a/lib/pages/wp-admin/wp-admin-dashboard-page.js
+++ b/lib/pages/wp-admin/wp-admin-dashboard-page.js
@@ -10,7 +10,7 @@ export default class WPAdminDashboardPage extends BaseContainer {
 
 		if ( url ) {
 			url = url.replace( /^https?:\/\//, '' ).replace( /\/wp-admin/, '' );
-			wpAdminURL = `http://${url}/wp-admin`;
+			wpAdminURL = `https://${url}/wp-admin`;
 			visit = true;
 		}
 

--- a/scripts/jetpack/wp-jetpack-jn-activate.js
+++ b/scripts/jetpack/wp-jetpack-jn-activate.js
@@ -44,7 +44,7 @@ test.describe( `[${host}] Jurassic Ninja Connection: (${screenSize}) @jetpack`, 
 	this.bailSuite( true );
 
 	test.it( 'Can connect from WP Admin', () => {
-		this.jnFlow = new JetpackConnectFlow( driver, 'jetpackUserJN' );
+		this.jnFlow = new JetpackConnectFlow( driver, 'jetpackUserJN', 'default' );
 		return this.jnFlow.connectFromWPAdmin();
 	} );
 


### PR DESCRIPTION
Workaround for https://github.com/Automattic/jetpack/issues/9020

Actually, Jetpack stable was used after fffa9b0e4a1a985c5d70ef76f72099bf64442395 (overlooked while refactoring `JetpackConnectFlow`). This PR make just makes it clearly visible, and fixing one more issue along the way.