### PR TITLE
Switch back to Jetpack master for JN tests

### DIFF
--- a/scripts/jetpack/wp-jetpack-jn-activate.js
+++ b/scripts/jetpack/wp-jetpack-jn-activate.js
@@ -44,7 +44,7 @@ test.describe( `[${host}] Jurassic Ninja Connection: (${screenSize}) @jetpack`, 
 	this.bailSuite( true );
 
 	test.it( 'Can connect from WP Admin', () => {
-		this.jnFlow = new JetpackConnectFlow( driver, 'jetpackUserJN' );
+		this.jnFlow = new JetpackConnectFlow( driver, 'jetpackUserJN', 'jetpackMaster' );
 		return this.jnFlow.connectFromWPAdmin();
 	} );
 


### PR DESCRIPTION
This PR reverts back changes made in #1021 workaround

Do not merge until https://github.com/Automattic/jetpack/issues/9020 is fixed