### PR TITLE
Try setting AB tests before the start page

### DIFF
--- a/lib/pages/signup/start-page.js
+++ b/lib/pages/signup/start-page.js
@@ -2,6 +2,7 @@ import { By } from 'selenium-webdriver';
 import config from 'config';
 
 import BaseContainer from '../../base-container';
+import LoginPage from '../login-page';
 import * as dataHelper from '../../data-helper';
 
 export default class StartPage extends BaseContainer {
@@ -36,9 +37,12 @@ export default class StartPage extends BaseContainer {
 
 		let ABTestControlFlow = flow !== '' ? flow : 'main';
 
+		// use loginPage to set control groups so that start page already has them set upon visit
+		let loginPage = new LoginPage( driver, true );
+		loginPage.setABTestControlGroupsInLocalStorage( LoginPage.getLoginURL(), culture, ABTestControlFlow );
+
 		super( driver, By.css( '.step-wrapper' ), visit, url );
 		this.checkForUnknownABTestKeys();
-		this.setABTestControlGroupsInLocalStorage( url, culture, ABTestControlFlow );
 	}
 
 	static appendQueryString( existingQueryString, queryStringPair ) {


### PR DESCRIPTION
This sets the AB test overrides by visiting /log-in before then visiting the start page when they'll already be set.

Fixes the first part of #1019 