### PR TITLE
Try clearing localstorage on override

### DIFF
--- a/lib/base-container.js
+++ b/lib/base-container.js
@@ -76,6 +76,8 @@ export default class BaseContainer {
 			return '"' + entry[ 0 ] + '":"' + entry[ 1 ] + '"';
 		} ).join( ',' );
 
+		this.driver.executeScript( 'window.localStorage.clear();' );
+
 		this.driver.executeScript( `window.localStorage.setItem('ABTests','{${expectedABTestValue}}');` );
 
 		this.driver.executeScript( `window.localStorage.setItem('signupFlowName','"${flow}"');` );


### PR DESCRIPTION
When overriding AB test keys we could have other localstorage items there, so this clears it before overriding - the other values should be regenerated by Calypso