### PR TITLE
Hide environment badge for visdiff screenshots

### DIFF
--- a/lib/eyes-helper.js
+++ b/lib/eyes-helper.js
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import config from 'config';
-import * as driverManager from './driver-manager.js';
+import { By } from 'selenium-webdriver';
+import * as driverHelper from './driver-helper';
+import * as driverManager from './driver-manager';
 import * as mediaHelper from './media-helper';
 import * as slackNotifier from '../lib/slack-notifier';
 
@@ -64,6 +66,13 @@ export function eyesScreenshot( driver, eyes, pageName, selector ) {
 	if ( process.env.VISDIFF ) {
 		let browserName = global.browserName || 'chrome';
 		console.log( `eyesScreenshot - ${pageName} - [${browserName}][${driverManager.currentScreenSize()}]` );
+
+		// If there is a visible environment badge, hide it.
+		driverHelper.isElementPresent( driver, By.css( '.environment-badge' ) ).then( function( isPresent ) {
+			if ( isPresent ) {
+				driver.executeScript( 'document.querySelector( ".environment-badge" ).style.visibility = "hidden";' );
+			}
+		} );
 
 		if ( process.env.EYESDEBUG ) {
 			return driver.takeScreenshot().then( ( data ) => {


### PR DESCRIPTION
This PR helps resolve the second issue from https://github.com/Automattic/wp-e2e-tests/issues/1019. It hides the environment badge when taking visdiff screenshots, so we can run our visdiff tests in wpcalypso.

Once merged, I'll set our visdiff cron jobs to use the `-u` flag so we can adjust the environment as needed for test runs (as opposed to setting this in the visdiff config).

To test:

- Set your `NODE_ENV` env var and if using the encrypted config set `TARGET=VISDIFF`.
- Run the visdiff tests in production to confirm they still work there: `./run.sh -v`
- Run the visdiff tests in wpcalypso to confirm they work and the environment badge is hidden in the screenshots: `./run.sh -v -u 'http://wpcalypso.wordpress.com'`