### PR TITLE
Adds a check around Happychat being available

### DIFF
--- a/lib/pages/cancel-purchase-page.js
+++ b/lib/pages/cancel-purchase-page.js
@@ -19,12 +19,14 @@ export default class CancelPurchasePage extends BaseContainer {
 		const e2eReason = 'e2e testing';
 		const dialogClass = '.cancel-purchase__button-warning-dialog';
 		const buttonDialogClass = '.dialog__action-buttons';
+		const nextButtonSelector = by.css( `${ buttonDialogClass } button[data-e2e-button="next"]` );
 		driverHelper.clickWhenClickable( this.driver, by.css( `${ dialogClass } input[value="anotherReasonOne"]` ) );
 		driverHelper.setWhenSettable( this.driver, by.css( `${ dialogClass } input[name="anotherReasonOneInput"]` ), e2eReason );
 		driverHelper.clickWhenClickable( this.driver, by.css( `${ dialogClass } input[value="anotherReasonTwo"]` ) );
 		driverHelper.setWhenSettable( this.driver, by.css( `${ dialogClass } input[name="anotherReasonTwoInput"]` ), e2eReason );
-		driverHelper.clickWhenClickable( this.driver, by.css( `${ buttonDialogClass } button[data-e2e-button="next"]` ) );
-		driverHelper.clickWhenClickable( this.driver, by.css( `${ buttonDialogClass } button[data-e2e-button="next"]` ) );
+		driverHelper.clickWhenClickable( this.driver, nextButtonSelector );
+		// Happychat Support can sometimes appear
+		driverHelper.clickIfPresent( this.driver, nextButtonSelector, 1 );
 		driverHelper.setWhenSettable( this.driver, by.css( `${ dialogClass } textarea[name="improvementInput"]` ), e2eReason );
 		return driverHelper.clickWhenClickable( this.driver, by.css( `${ buttonDialogClass } button[data-e2e-button="cancel"]` ) );
 	}


### PR DESCRIPTION
https://github.com/Automattic/wp-e2e-tests/pull/1029 introduced an additional step which doesn't always appear

This makes it conditional

I'm still not sure why we recently only started seeing this.

<img width="575" alt="screen shot 2018-03-12 at 1 44 43 pm" src="https://user-images.githubusercontent.com/128826/37264868-9f4a70c2-25fb-11e8-9d88-62ab6899894f.png">
