### PR TITLE
Cancel plan and domain all at once

### DIFF
--- a/lib/pages/cancel-purchase-page.js
+++ b/lib/pages/cancel-purchase-page.js
@@ -11,6 +11,13 @@ export default class CancelPurchasePage extends BaseContainer {
 		this.cancelButtonSelector = by.css( 'button.cancel-purchase__button' );
 	}
 
+	chooseCancelPlanAndDomain() {
+		// Choose both plan and domain option
+		driverHelper.clickWhenClickable( this.driver, by.css( 'input[name="cancel_bundled_domain_false"]' ) );
+		// Agree to cancelling domain
+		return driverHelper.setCheckbox( this.driver, by.css( 'input[type="checkbox"]' ) );
+	}
+
 	clickCancelPurchase() {
 		return driverHelper.clickWhenClickable( this.driver, this.cancelButtonSelector );
 	}

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -903,20 +903,11 @@ testDescribe( `[${host}] Sign Up  (${screenSize}, ${locale})`, function() {
 													managePurchasePage.chooseCancelAndRefund();
 
 													let cancelPurchasePage = new CancelPurchasePage( driver );
+													cancelPurchasePage.chooseCancelPlanAndDomain();
 													cancelPurchasePage.clickCancelPurchase();
 													cancelPurchasePage.completeCancellationSurvey();
 													cancelPurchasePage.waitToDisappear();
-													purchasesPage.waitForAndDismissSuccessMessage();
-
-													purchasesPage.selectDomainInPlan( );
-
-													managePurchasePage = new ManagePurchasePage( driver );
-													managePurchasePage.domainDisplayed().then( ( domainDisplayed ) => {
-														assert.equal( domainDisplayed, expectedDomainName, 'The domain displayed on the manage purchase page is unexpected' );
-													} );
-													managePurchasePage.chooseCancelAndRefund();
-													managePurchasePage.confirmCancelDomain();
-													return managePurchasePage.waitTillRemoveNoLongerShown();
+													return purchasesPage.waitForAndDismissSuccessMessage();
 												} catch ( err ) {
 													SlackNotifier.warn( `There was an error in the hooks that clean up the test domains but since it is cleaning up we really don't care: '${ err }'` );
 												}


### PR DESCRIPTION
At the moment we cancel a plan then a domain when signing up for these.

There seems to be an option now to cancel both at the same time which should speed up our tests a little bit and hopefully make them more reliable/consistent:

<img width="696" alt="cancel both" src="https://user-images.githubusercontent.com/128826/37267256-c894213a-260a-11e8-9444-5b19254607bc.png">

The domain only sign up still does a cancellation of just a domain
