### PR TITLE
Fix ambiguous search locator in Plugins page

### DIFF
--- a/lib/pages/plugins-browser-page.js
+++ b/lib/pages/plugins-browser-page.js
@@ -11,7 +11,7 @@ export default class PluginsBrowserPage extends BaseContainer {
 	}
 
 	searchForPlugin( searchTerm ) {
-		driverHelper.clickWhenClickable( this.driver, by.css( 'div.search' ) );
+		driverHelper.clickWhenClickable( this.driver, by.css( '.plugins-browser__main-header .search' ) );
 		return driverHelper.setWhenSettable( this.driver, by.css( '.plugins-browser__main-header input[type="search"]' ), searchTerm, { pauseBetweenKeysMS: 100 } );
 	}
 


### PR DESCRIPTION
When running tests against JN target there are 2 elements are found with 'div.search' which cause tests to fail. This PR make that locator unique.

To test:
1. `$ export JETPACKHOST=JN`
2. `$ mocha scripts/jetpack/wp-jetpack-jn-activate.js` - to create test site
3. `$ mocha specs-jetpack-calypso/wp-jetpack-plugins-spec.js -g 'Jetpack Sites on Calypso - Searching Plugins:'`