### PR TITLE
Remove viewers before adding new viewer

### DIFF
--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -404,6 +404,12 @@ testDescribe( `[${host}] Invites:  (${screenSize})`, function() {
 					} );
 				} );
 
+				test.it( 'Can remove all viewers', function() {
+					return this.peoplePage.selectViewers()
+					.then( () => this.peoplePage.emptyUsers() )
+					.then( () => this.peoplePage.selectTeam() );
+				} );
+
 				test.it( 'Can invite a new user as an viewer', function() {
 					this.peoplePage.inviteUser();
 					this.invitePeoplePage = new InvitePeoplePage( driver );


### PR DESCRIPTION
This PR fixes the `Inviting New User as a Viewer of a Private Site` test which is failing from time to time (due to viewers didn't get deleted after test)