### PR TITLE
Use a selector to verify and remove viewers

### DIFF
--- a/lib/pages/people-page.js
+++ b/lib/pages/people-page.js
@@ -77,11 +77,11 @@ export default class PeoplePage extends BaseContainer {
 	}
 
 	viewerDisplayed( username ) {
-		let viewers = this.driver.findElements( By.css( '.people-list-item' ) );
+		let viewers = this.driver.findElements( By.css( '.people-list-item .people-profile__username' ) );
 
 		return webdriver.promise.filter( viewers, function( viewer ) {
 			return viewer.getText().then( function( text ) {
-				return text === `${username}\n@${username}\nRemove`;
+				return text === username;
 			} );
 		} ).then( function( filteredViewers ) {
 			return ( filteredViewers.length === 1 );
@@ -94,19 +94,18 @@ export default class PeoplePage extends BaseContainer {
 	 * @param {bool} useSince Whether to include the "SINCE" line in the pattern match (for Followers, not Viewers)
 	 * @returns {Promise} Promise from the click action
 	 */
-	removeUserByName( username, useSince ) {
+	removeUserByName( username ) {
 		let viewers = this.driver.findElements( By.css( '.people-list-item' ) );
 
 		webdriver.promise.filter( viewers, function( viewer ) {
-			return viewer.getText().then( function( text ) {
-				let re = new RegExp( `${username}\n@${username}\nRemove` );
-
-				if ( useSince ) {
-					re = new RegExp( `${username}\n@${username}\nSINCE.*\nREMOVE` );
-				}
-
-				return text.match( re );
-			} );
+			return viewer.findElement( By.css( '.people-profile__username' ) )
+				.then( ( profileUsernameElement ) => {
+					return profileUsernameElement.getText();
+				} )
+				.then( function( text ) {
+					let re = new RegExp( username );
+					return text.match( re );
+				} );
 		} ).then( function( filteredViewers ) {
 			if ( filteredViewers.length !== 1 ) {
 				throw new Error( `The username '${username}' is not displayed as a viewer to remove` );

--- a/lib/pages/people-page.js
+++ b/lib/pages/people-page.js
@@ -103,8 +103,7 @@ export default class PeoplePage extends BaseContainer {
 					return profileUsernameElement.getText();
 				} )
 				.then( function( text ) {
-					let re = new RegExp( username );
-					return text.match( re );
+					return text === username;
 				} );
 		} ).then( function( filteredViewers ) {
 			if ( filteredViewers.length !== 1 ) {

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -404,12 +404,6 @@ testDescribe( `[${host}] Invites:  (${screenSize})`, function() {
 					} );
 				} );
 
-				test.it( 'Can remove all viewers', function() {
-					return this.peoplePage.selectViewers()
-					.then( () => this.peoplePage.emptyUsers() )
-					.then( () => this.peoplePage.selectTeam() );
-				} );
-
 				test.it( 'Can invite a new user as an viewer', function() {
 					this.peoplePage.inviteUser();
 					this.invitePeoplePage = new InvitePeoplePage( driver );

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -353,7 +353,7 @@ testDescribe( `[${host}] Invites:  (${screenSize})`, function() {
 								test.it( 'Can remove the follower account from the site', function() {
 									this.peoplePage.selectFollowers();
 									this.peoplePage.waitForSearchResults();
-									this.peoplePage.removeUserByName( newUserName, true );
+									this.peoplePage.removeUserByName( newUserName );
 									this.peoplePage.waitForSearchResults();
 									this.peoplePage.viewerDisplayed( newUserName ).then( ( displayed ) => {
 										assert.equal( displayed, false, `The username of '${newUserName}' was still displayed as a site viewer` );
@@ -516,7 +516,7 @@ testDescribe( `[${host}] Invites:  (${screenSize})`, function() {
 
 									test.describe( 'As the original user, I can remove the new user added to site', function() {
 										test.it( 'Can remove the team member from the site', function() {
-											this.peoplePage.removeUserByName( newUserName, false );
+											this.peoplePage.removeUserByName( newUserName );
 											this.peoplePage.waitForSearchResults();
 											this.peoplePage.viewerDisplayed( newUserName ).then( ( displayed ) => {
 												assert.equal( displayed, false, `The username of '${newUserName}' was still displayed as a site viewer` );

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -404,6 +404,12 @@ testDescribe( `[${host}] Invites:  (${screenSize})`, function() {
 					} );
 				} );
 
+				test.it( 'Can remove all viewers', function() {
+					return this.peoplePage.selectViewers()
+					.then( () => this.peoplePage.emptyUsers() )
+					.then( () => this.peoplePage.selectTeam() );
+				} );
+
 				test.it( 'Can invite a new user as an viewer', function() {
 					this.peoplePage.inviteUser();
 					this.invitePeoplePage = new InvitePeoplePage( driver );


### PR DESCRIPTION
We were using a text match which broke when case changed and will not work with other translations. Using selectors now instead.