### PR TITLE
Remove obsolete multiDomainRegistrationV1 AB test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -57,7 +57,6 @@
   },
   "knownABTestKeys": [
     "businessPlanDescriptionAT",
-    "multiDomainRegistrationV1",
     "skipThemesSelectionModal",
     "checklistThankYouForFreeUser",
     "checklistThankYouForPaidUser",


### PR DESCRIPTION
This is a follow-up PR for https://github.com/Automattic/wp-calypso/pull/23117 which removes the `multiDomainRegistrationV1` AB test.

@Automattic/flowpatrol is there anything else that we should update here?