### PR TITLE
Update the revert a draft test to not expect notice

### DIFF
--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -52,10 +52,6 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 		return driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.notice.is-success' ) );
 	}
 
-	dismissSuccessViewPostNotice() {
-		return driverHelper.clickWhenClickable( this.driver, By.css( '.notice.is-success .notice__dismiss' ) );
-	}
-
 	publishAndPreviewPublished( { useConfirmStep = false } = {} ) {
 		this.clickPublishPost();
 		if ( useConfirmStep === true ) {

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -1069,7 +1069,6 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 			test.it( 'Can revert the post to draft', function() {
 				let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 				let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
-				postEditorToolbarComponent.dismissSuccessViewPostNotice();
 				postEditorSidebarComponent.revertToDraft();
 				postEditorToolbarComponent.waitForIsDraftStatus();
 				postEditorToolbarComponent.statusIsDraft().then( ( isDraft ) => {


### PR DESCRIPTION
There was a change to not show the editor notice after clicking edit: https://github.com/Automattic/wp-calypso/pull/23250

This updates our test as we were still expecting this