### PR TITLE
Updated class selector to reflect new component in PR#23253

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -228,7 +228,7 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 
 	// Selects the first day of the second week of next month - to (hopefully) always select a future date on the calendar
 	chooseFutureDate() {
-		const nextMonthSelector = By.css( '.DayPicker-NavButton--next' );
+		const nextMonthSelector = By.css( '.date-picker__next-month' );
 		const firstDayOfSecondWeekSelector = By.css( '.DayPicker-Body .DayPicker-Week:nth-of-type(2) .DayPicker-Day' );
 		this._openClosePostDateSelector( { shouldOpen: true } );
 		driverHelper.clickWhenClickable( this.driver, nextMonthSelector );

--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -228,7 +228,7 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 
 	// Selects the first day of the second week of next month - to (hopefully) always select a future date on the calendar
 	chooseFutureDate() {
-		const nextMonthSelector = By.css( '.date-picker__next-month' );
+		const nextMonthSelector = By.css( '.DayPicker-NavButton--next, .date-picker__next-month' );
 		const firstDayOfSecondWeekSelector = By.css( '.DayPicker-Body .DayPicker-Week:nth-of-type(2) .DayPicker-Day' );
 		this._openClosePostDateSelector( { shouldOpen: true } );
 		driverHelper.clickWhenClickable( this.driver, nextMonthSelector );


### PR DESCRIPTION
In Calypso we've made [changes](https://github.com/Automattic/wp-calypso/pull/23253#issuecomment-372873699)  to the date picker, affecting the post editor e2e tests:

`(36 / 38) <-- Worker 2 FAIL (will retry).  Spent 38068 msec [WPCOM] Editor: Posts (mobile) Schedule Basic Public Post @parallel @jetpack @chrome`

This PR updates `nextMonthSelector` in `PostEditorSidebarComponent.chooseFutureDate` to use the [new class name](https://github.com/Automattic/wp-calypso/blob/ffde314eea1102b73180ad900ce3e8f6e8d90205/client/components/date-picker/style.scss#L67).