### PR TITLE
Removing unnecessary class selector after deploy of Automattic/wp-calypso#23253

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -228,7 +228,7 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 
 	// Selects the first day of the second week of next month - to (hopefully) always select a future date on the calendar
 	chooseFutureDate() {
-		const nextMonthSelector = By.css( '.DayPicker-NavButton--next, .date-picker__next-month' );
+		const nextMonthSelector = By.css( '.date-picker__next-month' );
 		const firstDayOfSecondWeekSelector = By.css( '.DayPicker-Body .DayPicker-Week:nth-of-type(2) .DayPicker-Day' );
 		this._openClosePostDateSelector( { shouldOpen: true } );
 		driverHelper.clickWhenClickable( this.driver, nextMonthSelector );


### PR DESCRIPTION
Cleaning up after #1043 by removing the now defunct classname after deploy of Automattic/wp-calypso#23253