### PR TITLE
Try not emptying viewers

### DIFF
--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -404,12 +404,6 @@ testDescribe( `[${host}] Invites:  (${screenSize})`, function() {
 					} );
 				} );
 
-				test.it( 'Can remove all viewers', function() {
-					return this.peoplePage.selectViewers()
-					.then( () => this.peoplePage.emptyUsers() )
-					.then( () => this.peoplePage.selectTeam() );
-				} );
-
 				test.it( 'Can invite a new user as an viewer', function() {
 					this.peoplePage.inviteUser();
 					this.invitePeoplePage = new InvitePeoplePage( driver );


### PR DESCRIPTION
I think this creates a race conditon when the invite viewers tests are running at the same time as one scenario will delete the viewers in use for the other scenario.