### PR TITLE
Update the `inlineHelpWithContactForm` A/B test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -73,7 +73,6 @@
     [ "domainSuggestionTestV6_20180301", "group_0" ],
     [ "inlineHelpWithContactForm_20180306", "inlinecontact" ],
     [ "upgradePricingDisplayV2_20180305", "original" ],
-    [ "businessPlanDescriptionAT_20170605", "original" ],
     [ "skipThemesSelectionModal_20170904", "show" ],
     [ "checklistThankYouForFreeUser_20171204", "hide" ],
     [ "checklistThankYouForPaidUser_20171204", "hide" ],

--- a/config/default.json
+++ b/config/default.json
@@ -71,7 +71,7 @@
   ],
   "overrideABTests": [
     [ "domainSuggestionTestV6_20180301", "group_0" ],
-    [ "inlineHelpWithContactForm_20180315", "inlinecontact" ],
+    [ "inlineHelpWithContactForm_20180306", "inlinecontact" ],
     [ "upgradePricingDisplayV2_20180305", "original" ],
     [ "businessPlanDescriptionAT_20170605", "original" ],
     [ "skipThemesSelectionModal_20170904", "show" ],


### PR DESCRIPTION
Update the override date to match the one in Calypso.

https://github.com/Automattic/wp-calypso/blob/af0f9bf5384fa77e3bee7118ee49174b8a7d004b/client/lib/abtest/active-tests.js#L132

See https://github.com/Automattic/wp-e2e-tests/pull/1009#issuecomment-373463229