### PR TITLE
Add mobilePlansTablesOnSignup AB test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -67,7 +67,8 @@
     "minimizedFreePlanForUnsignedUser",
     "upgradePricingDisplayV2",
     "redesignedSidebarBanner",
-    "domainSearchPrefill"
+    "domainSearchPrefill",
+    "mobilePlansTablesOnSignup"
   ],
   "overrideABTests": [
     [ "domainSuggestionTestV6_20180301", "group_0" ],
@@ -81,6 +82,7 @@
     [ "siteGoalsShuffle_20180214", "control" ],
     [ "redesignedSidebarBanner_20180222", "oldBanner" ],
     [ "businessPlanDescriptionAT_20170605", "original" ],
-    [ "domainSearchPrefill_20180315", "noPrefill" ]
+    [ "domainSearchPrefill_20180315", "noPrefill" ],
+    [ "mobilePlansTablesOnSignup_20180320", "original" ]
   ]
 }


### PR DESCRIPTION
Adds `mobilePlansTablesOnSignup ` AB test.

Related: https://github.com/Automattic/wp-calypso/pull/23454