### PR TITLE
Remove both of the minimizedFreePlan tests

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -63,8 +63,6 @@
     "checklistThankYouForPaidUser",
     "domainSuggestionTestV6",
     "siteGoalsShuffle",
-    "minimizedFreePlanForSignedUser",
-    "minimizedFreePlanForUnsignedUser",
     "upgradePricingDisplayV2",
     "redesignedSidebarBanner",
     "domainSearchPrefill"
@@ -76,8 +74,6 @@
     [ "skipThemesSelectionModal_20170904", "show" ],
     [ "checklistThankYouForFreeUser_20171204", "hide" ],
     [ "checklistThankYouForPaidUser_20171204", "hide" ],
-    [ "minimizedFreePlanForSignedUser_20180308", "original" ],
-    [ "minimizedFreePlanForUnsignedUser_20180308", "original" ],
     [ "siteGoalsShuffle_20180214", "control" ],
     [ "redesignedSidebarBanner_20180222", "oldBanner" ],
     [ "businessPlanDescriptionAT_20170605", "original" ],


### PR DESCRIPTION
We're going to close the tests soon.
Related: https://github.com/Automattic/wp-calypso/pull/23406  https://github.com/Automattic/wp-calypso/pull/23489