### PR TITLE
Post Editor: use the post title as the default Publicize message

### DIFF
--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -134,7 +134,7 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 								let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 
 								postEditorSidebarComponent.publicizeMessageDisplayed().then( function( messageDisplayed ) {
-									assert.equal( messageDisplayed, blogPostTitle, 'The publicize message is not defaulting to empty' );
+									assert.equal( messageDisplayed, blogPostTitle, 'The publicize message is not defaulting to the post\'s title' );
 								} );
 							} );
 

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -132,8 +132,9 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 
 							test.it( 'Can see the default publicise message', function() {
 								let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
+
 								postEditorSidebarComponent.publicizeMessageDisplayed().then( function( messageDisplayed ) {
-									assert.equal( messageDisplayed, '', 'The publicize message is not defaulting to empty' );
+									assert.equal( messageDisplayed, blogPostTitle, 'The publicize message is not defaulting to empty' );
 								} );
 							} );
 


### PR DESCRIPTION
See: https://github.com/Automattic/wp-calypso/pull/23447

It found it hard to run the updated test ( or the tests on master ) against my calypso PR. There were a few failures that seemed unrelated to the changes: failures to take screen shots, failures because of A/B tests. And the tests take quite a while to run. However, the tests related to Publicize seem to pass as expected.

I'm not 100% certain that my Calypso PR is not breaking anything else.