### PR TITLE
Adding time for JP authorization to complete

### DIFF
--- a/lib/pages/jetpack-authorize-page.js
+++ b/lib/pages/jetpack-authorize-page.js
@@ -16,7 +16,10 @@ export default class JetpackAuthorizePage extends BaseContainer {
 	}
 
 	approveConnection() {
-		return driverHelper.clickWhenClickable( this.driver, by.css( '.jetpack-connect__authorize-form button' ) );
+		const authorizeButtonSelector = by.css( '.jetpack-connect__authorize-form button' );
+		const authorizingSelector = by.css( '.jetpack-connect__logged-in-form-loading' );
+		return driverHelper.clickWhenClickable( this.driver, authorizeButtonSelector )
+		.then( () => driverHelper.waitTillNotPresent( this.driver, authorizingSelector, this.explicitWaitMS * 2 ) );
 	}
 
 	approveSSOConnection() {


### PR DESCRIPTION
Helps #1070 by waiting double the time of the standard wait for the authorizing spinner to go away.