### PR TITLE
Update plan selector to work for both

### DIFF
--- a/lib/pages/signup/pick-a-plan-page.js
+++ b/lib/pages/signup/pick-a-plan-page.js
@@ -22,12 +22,14 @@ export default class PickAPlanPage extends BaseContainer {
 		this.host = getJetpackHost();
 	}
 	_selectPlan( level ) {
-		let prefix = 'table';
+		let oldPrefix = 'table';
+		const newPrefix = '.plans-features-main';
+
 		if ( this.host !== 'WPCOM' && screenSize === 'mobile' ) {
-			prefix = '.plan-features__mobile-plan';
+			oldPrefix = '.plan-features__mobile-plan';
 		}
 
-		const selector = By.css( `${prefix} button.is-${level}-plan:not([disabled])` );
+		const selector = By.css( `${oldPrefix} button.is-${level}-plan:not([disabled]),${newPrefix} button.is-${level}-plan:not([disabled])` );
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	selectFreePlan() {


### PR DESCRIPTION
Update the plan selector to work for new and old designs

New design here: https://github.com/Automattic/wp-calypso/pull/23489

We can remove the old selector in a subsequent PR (#1062)
