### PR TITLE
Log used livebranch into magellan runner output

### DIFF
--- a/magellan-canary.json
+++ b/magellan-canary.json
@@ -13,5 +13,6 @@
   "reporters": [
 	  "./lib/reporter/magellan-reporter.js"
   ],
-  "bail_time": 300000
+	"bail_time": 300000,
+	"setup_teardown": "./scripts/magellan-setup-teardown.js"
 }

--- a/magellan-ie11-canary.json
+++ b/magellan-ie11-canary.json
@@ -13,5 +13,6 @@
   "reporters": [
 	  "./lib/reporter/magellan-reporter.js"
   ],
-  "bail_time": 300000
+	"bail_time": 300000,
+	"setup_teardown": "./scripts/magellan-setup-teardown.js"
 }

--- a/magellan-ie11.json
+++ b/magellan-ie11.json
@@ -13,5 +13,6 @@
   "reporters": [
 	  "./lib/reporter/magellan-reporter.js"
   ],
-  "bail_time": 300000
+	"bail_time": 300000,
+	"setup_teardown": "./scripts/magellan-setup-teardown.js"
 }

--- a/magellan-jetpack-canary.json
+++ b/magellan-jetpack-canary.json
@@ -13,5 +13,6 @@
   "reporters": [
 	  "./lib/reporter/magellan-reporter.js"
   ],
-  "bail_time": 300000
+	"bail_time": 300000,
+	"setup_teardown": "./scripts/magellan-setup-teardown.js"
 }

--- a/magellan-jetpack.json
+++ b/magellan-jetpack.json
@@ -14,5 +14,6 @@
   "reporters": [
 	  "./lib/reporter/magellan-reporter.js"
   ],
-  "bail_time": 300000
+	"bail_time": 300000,
+	"setup_teardown": "./scripts/magellan-setup-teardown.js"
 }

--- a/magellan.json
+++ b/magellan.json
@@ -13,5 +13,6 @@
   "reporters": [
 	  "./lib/reporter/magellan-reporter.js"
   ],
-  "bail_time": 300000
+	"bail_time": 300000,
+  "setup_teardown": "./scripts/magellan-setup-teardown.js"
 }

--- a/run.sh
+++ b/run.sh
@@ -95,10 +95,12 @@ while getopts ":a:Rpb:B:s:gjWCJH:wzl:cm:fiIUvxu:h" opt; do
       continue
       ;;
     b)
+      export LIVEBRANCH=$OPTARG
       NODE_CONFIG_ARGS+=("\"liveBranch\":\"true\",\"branchName\":\"$OPTARG\",\"calypsoBaseURL\":\"https://calypso.live\"")
       continue
       ;;
     B)
+      export LIVEBRANCH=$OPTARG
       NODE_CONFIG_ARGS+=("\"jetpackBranch\":\"true\",\"jetpackBranchName\":\"$OPTARG\"")
       continue
       ;;

--- a/scripts/magellan-setup-teardown.js
+++ b/scripts/magellan-setup-teardown.js
@@ -1,0 +1,37 @@
+var Q = require( 'q' );
+
+var SetupTeardown = function() {
+};
+
+SetupTeardown.prototype = {
+	initialize: function() {
+		var deferred = Q.defer();
+
+		let message = '[INFO] Magellan run just started';
+		if ( process.env.LIVEBRANCH ) {
+			message += `\n[INFO] Using live branch: ${process.env.LIVEBRANCH}`;
+		}
+
+		Promise.resolve( message ).then( value => {
+			console.log( value );
+			return deferred.resolve();
+		} );
+
+		return deferred.promise;
+	},
+
+	flush: function() {
+		var deferred = Q.defer();
+
+		let message = 'Magellan run stopped working';
+
+		Promise.resolve( message ).then( value => {
+			console.log( value );
+			return deferred.resolve();
+		} );
+
+		return deferred.promise;
+	}
+};
+
+module.exports = SetupTeardown;


### PR DESCRIPTION
This PR adds live branch info into Magellan output. This is useful when debugging CircleCI failures


To test:
1. `./run.sh -b some/branch-name -j` or `./run.sh -b some/branch-name -g` expect to see in output:
```
...
[INFO] [Mocha Plugin] Found 35 tests in test files
[INFO] Magellan run just started
[INFO] Using live branch: some/branch-name

Running 35 tests with 3 workers with chrome
...
```
2. `./run.sh -j`  expect to see in output:
```
...
[INFO] [Mocha Plugin] Found 35 tests in test files
[INFO] Magellan run just started

Running 35 tests with 3 workers with chrome
...
```