### PR TITLE
Update post trash spec to not expect post restore prompt

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -202,16 +202,12 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 	trashPost() {
 		const trashSelector = By.css( 'button.editor-delete-post__button' );
 		const confirmationSelector = By.css( 'button[data-e2e-button="accept"]' );
-		//const doNotRestoreSelector = By.css( 'div.dialog__action-buttons button:not(.is-primary)' );
 
 		driverHelper.waitTillPresentAndDisplayed( this.driver, trashSelector );
 		driverHelper.clickWhenClickable( this.driver, trashSelector );
 
 		driverHelper.clickWhenClickable( this.driver, confirmationSelector );
-		driverHelper.waitTillNotPresent( this.driver, confirmationSelector );
-
-		//driverHelper.waitTillPresentAndDisplayed( this.driver, doNotRestoreSelector );
-		//return driverHelper.clickWhenClickable( this.driver, doNotRestoreSelector );
+		return driverHelper.waitTillNotPresent( this.driver, confirmationSelector );
 	}
 
 	openFeaturedImageDialog() {

--- a/lib/pages/posts-page.js
+++ b/lib/pages/posts-page.js
@@ -29,6 +29,10 @@ export default class PostsPage extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, PostsPage._getPostXpathSelector( title ) );
 	}
 
+	successNoticeDisplayed() {
+		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, By.css( '.notice.is-success' ) );
+	}
+
 	static _getPostXpathSelector( title ) {
 		return By.xpath( `//div[@class='post-type-list']//a[text()= '${title}']` );
 	}

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -834,10 +834,10 @@ test.describe( `[${host}] Editor: Posts (${screenSize})`, function() {
 				return postEditorSidebarComponent.trashPost();
 			} );
 
-			test.it( 'Can then see the Posts page', function() {
+			test.it( 'Can then see the Posts page with a confirmation message', function() {
 				const postsPage = new PostsPage( driver );
-				return postsPage.displayed().then( ( displayed ) => {
-					return assert.equal( displayed, true, 'The Posts page is not displayed' );
+				return postsPage.successNoticeDisplayed().then( ( displayed ) => {
+					return assert.equal( displayed, true, 'The Posts page success notice for deleting the post is not displayed' );
 				} );
 			} );
 		} );


### PR DESCRIPTION
Continues on https://github.com/Automattic/wp-e2e-tests/pull/1081

Change in https://github.com/Automattic/wp-calypso/pull/23377