### PR TITLE
Fix i18n tests to work locally

### DIFF
--- a/lib/pages/external/google-search.js
+++ b/lib/pages/external/google-search.js
@@ -9,6 +9,7 @@ export default class GoogleSearchPage extends BaseContainer {
 
 		const iframe = this.driver.findElement( frame );
 		driver.switchTo().frame( iframe );
+		driver.sleep( 2000 ); // https://stackoverflow.com/questions/41429723/unhandled-error-cannot-find-context-with-specified-id-using-robot-framework
 
 		const selector = by.xpath( '//li[@class="ads-ad"]//a[contains(@href, "' + referenceUrl + '")]' );
 		this.driver.wait( until.elementLocated( selector ), this.explicitWaitMS, 'Could not locate the ad link' );

--- a/magellan-i18n.json
+++ b/magellan-i18n.json
@@ -3,7 +3,7 @@
     "specs-i18n/"
   ],
   "mocha_opts": "test/mocha.opts",
-  "mocha_args": "-R spec-xunit-reporter -d",
+  "mocha_args": "-R spec-xunit-reporter",
   "max_test_attempts": 1,
   "max_workers": 1,
   "suiteTag": "i18n",

--- a/specs-i18n/search-wordpress-on-google.js
+++ b/specs-i18n/search-wordpress-on-google.js
@@ -34,6 +34,7 @@ function doGoogleAdSearch( search_params ) {
 
 	test.describe( description + ' @i18n (' + locale + ')', function() {
 		this.timeout( mochaTimeOut );
+		this.bailSuite( true );
 
 		test.beforeEach( function() {
 			driver.manage().deleteAllCookies();
@@ -56,10 +57,6 @@ function doGoogleAdSearch( search_params ) {
 		} );
 
 		test.it( 'Our landing page exists', function() {
-			if ( ! this.searchPage ) {
-				this.skip( 'Depends on previous test passing' );
-			}
-
 			const that = this;
 			this.searchPage.getAdUrl().then( url => {
 				that.landingPage = new LandingPage( driver, url );
@@ -67,10 +64,6 @@ function doGoogleAdSearch( search_params ) {
 		} );
 
 		test.it( 'Localized string found on landing page', function() {
-			if ( ! this.landingPage ) {
-				this.skip( 'Depends on previous test passing' );
-			}
-
 			this.landingPage.checkLocalizedString( test_data.wpcom_landing_page_string );
 		} );
 	} );


### PR DESCRIPTION
- Add `bailSuite` to stop execution if one of the tests get failed
- add `sleep` delay after switching to iframe to prevent `{"code":-
32000,"message":"Cannot find context with specified id"}` as suggested [here](https://stackoverflow.com/questions/41429723/unhandled-error-cannot-find-context-with-specified-id-using-robot-framework)
- remove debug mocha option `-d` from magellan config

To test:
`$ TARGET=I18N ./node_modules/.bin/magellan --config=./magellan-i18n.json`