### PR TITLE
Tests: Remove domainSearchPrefill A/B test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -65,7 +65,6 @@
     "siteGoalsShuffle",
     "upgradePricingDisplayV2",
     "redesignedSidebarBanner",
-    "domainSearchPrefill",
     "mobilePlansTablesOnSignup"
   ],
   "overrideABTests": [
@@ -78,7 +77,6 @@
     [ "siteGoalsShuffle_20180214", "control" ],
     [ "redesignedSidebarBanner_20180222", "oldBanner" ],
     [ "businessPlanDescriptionAT_20170605", "original" ],
-    [ "domainSearchPrefill_20180315", "noPrefill" ],
     [ "mobilePlansTablesOnSignup_20180320", "original" ]
   ]
 }


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/23646

Remove the `domainSearchPrefill` A/B test after its results came out negative.