### PR TITLE
Set TEMP_ASSET_PATH in the magellan reporter

### DIFF
--- a/lib/reporter/magellan-reporter.js
+++ b/lib/reporter/magellan-reporter.js
@@ -14,6 +14,9 @@ let Reporter = function() {
 util.inherits( Reporter, BaseReporter );
 
 Reporter.prototype.listenTo = function( testRun, test, source ) {
+	// Put the tmpAssetPath into an envvar so media-helper can find it for saving screenshots
+	process.env.TEMP_ASSET_PATH = testRun.tempAssetPath;
+
 	// Print STDOUT/ERR to the screen for extra debugging
 	if ( !! process.env.MAGELLANDEBUG ) {
 		source.stdout.pipe( process.stdout );

--- a/lib/reporter/magellan-reporter.js
+++ b/lib/reporter/magellan-reporter.js
@@ -53,8 +53,8 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 				duration: test.runningTime,
 				err: {}
 			};
-			const reportDir = './reports';
-			let screenshotDir = './screenshots';
+			const reportDir = testRun.tempAssetPath + '/reports';
+			let screenshotDir = testRun.tempAssetPath + '/screenshots';
 			if ( process.env.SCREENSHOTDIR ) {
 				screenshotDir = testRun.tempAssetPath + `/${process.env.SCREENSHOTDIR}`;
 			}
@@ -215,8 +215,14 @@ function getSlackClient() {
 }
 
 function sendFailureNotif( slackClient, reportDir, testRun ) {
-	let files = fs.readdirSync( reportDir );
+	let files;
 	let failuresCount = 0;
+	try {
+		files = fs.readdirSync( reportDir );
+	} catch ( e ) {
+		console.log( `Failed to read directory, maybe it doesn't exist: ${e.message}` );
+		return;
+	}
 	files.forEach( reportPath => {
 		if ( ! reportPath.match( /xml$/i ) ) {
 			return;


### PR DESCRIPTION
@brbrr I _think_ this does the job for setting the path variable so it's accessible to the media helper.  I still have no idea where it was coming from before, though.

It looked good for me locally, but I didn't have a chance to check it against the i18n repo.