### PR TITLE
Secure Payment Component: Click on stored card if it's present

### DIFF
--- a/lib/components/secure-payment-component.js
+++ b/lib/components/secure-payment-component.js
@@ -54,7 +54,9 @@ export default class SecurePaymentComponent extends BaseContainer {
 
 	payWithStoredCardIfPossible( cardCredentials ) {
 		const storedCardSelector = By.css( '.stored-card' );
-		if ( !driverHelper.isEventuallyPresentAndDisplayed( this.driver, storedCardSelector ) ) {
+		if ( driverHelper.isEventuallyPresentAndDisplayed( this.driver, storedCardSelector ) ) {
+			driverHelper.clickWhenClickable( this.driver, storedCardSelector );
+		} else {
 			this.enterTestCreditCardDetails( cardCredentials );
 		}
 


### PR DESCRIPTION
"Connect from Jetpack.com Pricing page" fails in CI due to expanded new card form. This change should prevent that.