### PR TITLE
Update magellan mocha plugin to latest version

### DIFF
--- a/lib/reporter/magellan-reporter.js
+++ b/lib/reporter/magellan-reporter.js
@@ -14,9 +14,6 @@ let Reporter = function() {
 util.inherits( Reporter, BaseReporter );
 
 Reporter.prototype.listenTo = function( testRun, test, source ) {
-	// Put the tmpAssetPath into an envvar so media-helper can find it for saving screenshots
-	process.env.TEMP_ASSET_PATH = testRun.tempAssetPath;
-
 	// Print STDOUT/ERR to the screen for extra debugging
 	if ( !! process.env.MAGELLANDEBUG ) {
 		source.stdout.pipe( process.stdout );
@@ -67,11 +64,13 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 				// Screenshots
 				fs.readdir( screenshotDir, function( dirErr, files ) {
 					if ( dirErr ) {
+						console.log( `failCondition: Failed to read screenshot directory, maybe it doesn't exist: ${dirErr.message}` );
 						return 1;
 					}
 
 					files.forEach( function( screenshotPath ) {
 						if ( ! screenshotPath.match( /png$/i ) ) {
+							console.log( `${screenshotPath} is not a PNG file` );
 							return;
 						}
 
@@ -137,6 +136,7 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 				// Screenshots
 				fs.readdir( screenshotDir, function( dirErr, screenshotFiles ) {
 					if ( dirErr ) {
+						console.log( `passCondition: Failed to read screenshot directory, maybe it doesn't exist: ${dirErr.message}` );
 						return 1;
 					}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12168,7 +12168,7 @@
       }
     },
     "testarmada-magellan-mocha-plugin": {
-      "version": "github:Automattic/magellan-mocha-plugin#b10a53bb3cffcd8f77fc975b5388e9ac74b91223",
+      "version": "github:Automattic/magellan-mocha-plugin#660cf2c462d2e8d2cb886afc79450fe91e481d48",
       "requires": {
         "cli-color": "1.2.0",
         "lodash": "4.17.5",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "speakeasy": "^2.0.0",
     "spec-xunit-reporter": "./lib/reporter",
     "testarmada-magellan": "8.8.6",
-    "testarmada-magellan-mocha-plugin": "github:Automattic/magellan-mocha-plugin#b10a53b",
+    "testarmada-magellan-mocha-plugin": "github:Automattic/magellan-mocha-plugin#660cf2c",
     "wpcom": "5.4.0",
     "xml2json-command": "^0.0.3",
     "xmpp.js": "^0.3.0",


### PR DESCRIPTION
This is the continuation of https://github.com/Automattic/wp-e2e-tests/pull/1087
Turns out setting `TEST_ASSET_PATH` in `magellan-report` did not work because of some sort race condition.

That env var should be set in `magellan-mocha` plugin itself: https://github.com/Automattic/magellan-mocha-plugin/pull/2

To test:

Run `$ ./node_modules/.bin/magellan --config=./magellan.json --test=path/to/test.js` against any spec file which will fail.
Make sure `./screensots` has `FAILED` screenshot & `./reports` has some reports 
