### PR TITLE
Cleanup debug logging from Magellan Reporter

### DIFF
--- a/lib/reporter/magellan-reporter.js
+++ b/lib/reporter/magellan-reporter.js
@@ -64,13 +64,11 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 				// Screenshots
 				fs.readdir( screenshotDir, function( dirErr, files ) {
 					if ( dirErr ) {
-						console.log( `failCondition: Failed to read screenshot directory, maybe it doesn't exist: ${dirErr.message}` );
 						return 1;
 					}
 
 					files.forEach( function( screenshotPath ) {
 						if ( ! screenshotPath.match( /png$/i ) ) {
-							console.log( `${screenshotPath} is not a PNG file` );
 							return;
 						}
 
@@ -136,7 +134,6 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 				// Screenshots
 				fs.readdir( screenshotDir, function( dirErr, screenshotFiles ) {
 					if ( dirErr ) {
-						console.log( `passCondition: Failed to read screenshot directory, maybe it doesn't exist: ${dirErr.message}` );
 						return 1;
 					}
 


### PR DESCRIPTION
Forget to clean it up in original PR. These log statements are creating noise in CI output.