### PR TITLE
Add a refresh if jurassic ninja doesn't show

### DIFF
--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -46,6 +46,11 @@ export default class WporgCreatorPage extends BaseContainer {
 	}
 
 	waitForWpadmin() {
+		driverHelper.isEventuallyPresentAndDisplayed( this.driver, PASSWORD_ELEMENT ).then( ( wpAdminDisplayed ) => {
+			if ( !wpAdminDisplayed ) {
+				this.driver.navigate().refresh();
+			}
+		} );
 		return driverHelper.waitTillPresentAndDisplayed( this.driver, PASSWORD_ELEMENT );
 	}
 }


### PR DESCRIPTION
Sometimes this screen appears:

<img width="914" alt="screen-shot-2018-03-12-at-20-20-48" src="https://user-images.githubusercontent.com/128826/38072500-f0965e2a-3369-11e8-8c6d-64484c93def0.png">

All it needs is a refresh, which this PR now does