### PR TITLE
Fixing mobile more button

### DIFF
--- a/lib/pages/themes-page.js
+++ b/lib/pages/themes-page.js
@@ -61,7 +61,10 @@ export default class ThemesPage extends BaseContainer {
 	}
 
 	clickNewThemeMoreButton() {
-		return driverHelper.clickWhenClickable( this.driver, by.css( '.is-actionable:not(.is-active) button' ) );
+		const selector = by.css( '.is-actionable:not(.is-active) button' );
+		return this.driver.findElement( selector )
+			.then( moreButtonElement => this.driver.executeScript( 'arguments[0].scrollIntoView( { block: "center", inline: "center" } )', moreButtonElement ) )
+			.then( () => driverHelper.clickWhenClickable( this.driver, selector ) );
 	}
 
 	getFirstThemeName() {


### PR DESCRIPTION
The help button was covering the more button on mobile. I am just scrolling it to the middle of the view so that it isn't behind the help button.