### PR TITLE
Update mobilePlansTablesOnSignup AB test timestamp

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -76,7 +76,7 @@
     [ "siteGoalsShuffle_20180214", "control" ],
     [ "redesignedSidebarBanner_20180222", "oldBanner" ],
     [ "businessPlanDescriptionAT_20170605", "original" ],
-    [ "mobilePlansTablesOnSignup_20180320", "original" ],
+    [ "mobilePlansTablesOnSignup_20180330", "original" ],
     [ "domainSuggestionKrakenV313_20180329", "group_0" ]
   ]
 }


### PR DESCRIPTION
Updates mobilePlansTablesOnSignup AB test timestamp.

Related: https://github.com/Automattic/wp-calypso/pull/23802