### PR TITLE
Disable screenshots upload to slack for LIVEBRANCHES

### DIFF
--- a/lib/reporter/magellan-reporter.js
+++ b/lib/reporter/magellan-reporter.js
@@ -77,7 +77,8 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 						// Send screenshot to Slack on master branch only
 						if (
 							config.has( 'slackTokenForScreenshots' ) &&
-							process.env.CIRCLE_BRANCH === 'master'
+							process.env.CIRCLE_BRANCH === 'master' &&
+							! process.env.LIVEBRANCHES
 						) {
 							const SlackUpload = require( 'node-slack-upload' );
 							const slackUpload = new SlackUpload( config.get( 'slackTokenForScreenshots' ) );


### PR DESCRIPTION
Recently we disabled team pings on test failures for live branches. This PR make sure that screenshots from that failed tests wont be posted to slack