### PR TITLE
Clean up the domainSuggestionKrakenV313 test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -62,8 +62,7 @@
     "checklistThankYouForPaidUser",
     "upgradePricingDisplayV2",
     "redesignedSidebarBanner",
-    "mobilePlansTablesOnSignup",
-    "domainSuggestionKrakenV313"
+    "mobilePlansTablesOnSignup"
   ],
   "overrideABTests": [
     [ "upgradePricingDisplayV2_20180305", "original" ],
@@ -73,7 +72,6 @@
     [ "siteGoalsShuffle_20180214", "control" ],
     [ "redesignedSidebarBanner_20180222", "oldBanner" ],
     [ "businessPlanDescriptionAT_20170605", "original" ],
-    [ "mobilePlansTablesOnSignup_20180330", "original" ],
-    [ "domainSuggestionKrakenV313_20180329", "group_0" ]
+    [ "mobilePlansTablesOnSignup_20180330", "original" ]
   ]
 }


### PR DESCRIPTION
We're stopping this test, we're now using `group_1` for Calypso and `group_2` for NUX users.

This should be deployed after https://github.com/Automattic/wp-calypso/pull/24056 is deployed.