### PR TITLE
Add support for domain registration redesign

### DIFF
--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -59,7 +59,7 @@ export default class FindADomainComponent extends BaseContainer {
 	}
 
 	freeBlogAddress() {
-		const freeBlogAddressSelector = By.css( '.domain-suggestion__content h3' );
+		const freeBlogAddressSelector = By.css( '.domain-search-results__domain-suggestions > .domain-suggestion .domain-registration-suggestion__title' );
 		return this.driver
 			.findElement( freeBlogAddressSelector )
 			.getText()


### PR DESCRIPTION
The existing test fails because it expects the first domain suggestion to be the WordPress.com subdomain suggestion. With the domain registration redesign resulting from the Kracken project, this is no longer the case.

I've corrected/refined the WP.com subdomain suggestion in this PR.