### PR TITLE
Remove sitegoalsshuffle and use vertical plans (for mobile)

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -70,10 +70,9 @@
     [ "skipThemesSelectionModal_20170904", "show" ],
     [ "checklistThankYouForFreeUser_20171204", "hide" ],
     [ "checklistThankYouForPaidUser_20171204", "hide" ],
-    [ "siteGoalsShuffle_20180214", "control" ],
     [ "redesignedSidebarBanner_20180222", "oldBanner" ],
     [ "businessPlanDescriptionAT_20170605", "original" ],
-    [ "mobilePlansTablesOnSignup_20180330", "original" ],
+    [ "mobilePlansTablesOnSignup_20180330", "vertical" ],
     [ "domainSuggestionKrakenV313_20180329", "group_0" ]
   ]
 }

--- a/lib/pages/signup/pick-a-plan-page.js
+++ b/lib/pages/signup/pick-a-plan-page.js
@@ -7,6 +7,7 @@ import BaseContainer from '../../base-container.js';
 
 import * as driverHelper from '../../driver-helper.js';
 import { getJetpackHost } from '../../data-helper.js';
+import * as driverManager from '../../driver-manager';
 
 export default class PickAPlanPage extends BaseContainer {
 	constructor( driver ) {
@@ -21,7 +22,10 @@ export default class PickAPlanPage extends BaseContainer {
 		this.host = getJetpackHost();
 	}
 	_selectPlan( level ) {
-		const prefix = '.plans-features-main';
+		const prefix =
+			driverManager.currentScreenSize() === 'mobile'
+				? '.plan-features__mobile'
+				: '.plan-features__table';
 		const selector = By.css( `${ prefix } button.is-${ level }-plan:not([disabled])` );
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}

--- a/lib/pages/signup/pick-a-plan-page.js
+++ b/lib/pages/signup/pick-a-plan-page.js
@@ -22,10 +22,13 @@ export default class PickAPlanPage extends BaseContainer {
 		this.host = getJetpackHost();
 	}
 	_selectPlan( level ) {
-		const prefix =
+		let prefix =
 			driverManager.currentScreenSize() === 'mobile'
 				? '.plan-features__mobile'
 				: '.plan-features__table';
+		if ( level === 'free' ) {
+			prefix = '';
+		}
 		const selector = By.css( `${ prefix } button.is-${ level }-plan:not([disabled])` );
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -656,7 +656,8 @@ testDescribe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() 
 		}
 	);
 
-	test.describe(
+	// Disabled due to https://github.com/Automattic/wp-e2e-tests/issues/1132
+	test.xdescribe(
 		'Sign up for a site on a business paid plan w/ domain name coming in via /create as business flow @parallel',
 		function() {
 			this.bailSuite( true );


### PR DESCRIPTION
Includes

1. Removes sitesgoalshuffle override as this isn't in use any more
2. Sets the vertical plan behaviour due to issues with horizontal scroll raised in #1126 
3. Updates the plan selectors for using vertical plans
4. Temporarily disables the business sign up test #1132