### PR TITLE
Re-enable business plan signup from create

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -656,8 +656,7 @@ testDescribe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() 
 		}
 	);
 
-	// Disabled due to https://github.com/Automattic/wp-e2e-tests/issues/1132
-	test.xdescribe(
+	test.describe(
 		'Sign up for a site on a business paid plan w/ domain name coming in via /create as business flow @parallel',
 		function() {
 			this.bailSuite( true );


### PR DESCRIPTION
Issue was fixed, workaround no longer needed.
Fixes #1132 

Tested by running 
`./node_modules/.bin/mocha specs/wp-signup-spec.js` locally