### PR TITLE
Add support for domain register redesign take 2

### DIFF
--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -84,7 +84,7 @@ export default class FindADomainComponent extends BaseContainer {
 	}
 
 	selectFreeAddress() {
-		const freeAddressSelector = By.css( '.domain-suggestion.is-clickable' );
+		const freeAddressSelector = By.css( '.domain-search-results__domain-suggestions > .domain-suggestion.is-clickable' );
 		return driverHelper.clickWhenClickable( this.driver, freeAddressSelector, this.explicitWaitMS );
 	}
 


### PR DESCRIPTION
Follow-up of #1130. 

I'd forgotten to update the `selectFreeAddress` function's CSS selector in the previous change, resulting in e2e test failures for [this PR](https://github.com/Automattic/wp-calypso/pull/24137). 

This change updates the CSS selector for `selectFreeAddress` and thereby fixes this test: `Basic sign up for a free site @parallel @email @canary @ie11canary @chrome`.