### PR TITLE
Rename the Upgrade Pricing Display test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -61,14 +61,14 @@
     "skipThemesSelectionModal",
     "checklistThankYouForFreeUser",
     "checklistThankYouForPaidUser",
-    "upgradePricingDisplayV2",
+    "upgradePricingDisplayV3",
     "redesignedSidebarBanner",
     "mobilePlansTablesOnSignup",
     "springSale30PercentOff",
     "showMoneyBackGuarantee"
   ],
   "overrideABTests": [
-    [ "upgradePricingDisplayV2_20180305", "original" ],
+    [ "upgradePricingDisplayV3_20180402", "original" ],
     [ "skipThemesSelectionModal_20170904", "show" ],
     [ "checklistThankYouForFreeUser_20171204", "hide" ],
     [ "checklistThankYouForPaidUser_20171204", "hide" ],


### PR DESCRIPTION
Since we [relaunched the Upgrade Pricing Display A/B test](https://github.com/Automattic/wp-calypso/pull/23905) , the relevant configuration should be updated.

