### PR TITLE
Add multiyearSubscriptions to known tests

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -66,7 +66,7 @@
     "mobilePlansTablesOnSignup",
     "springSale30PercentOff",
     "showMoneyBackGuarantee",
-    "multiyearSubscriptions",
+    "multiyearSubscriptions"
   ],
   "overrideABTests": [
     [ "upgradePricingDisplayV2_20180305", "original" ],
@@ -78,6 +78,6 @@
     [ "mobilePlansTablesOnSignup_20180330", "original" ],
     [ "springSale30PercentOff_20180413", "control" ],
     [ "showMoneyBackGuarantee_20180409", "no" ],
-    [ "multiyearSubscriptions_20180417", "hide" ],
+    [ "multiyearSubscriptions_20180417", "hide" ]
   ]
 }

--- a/config/default.json
+++ b/config/default.json
@@ -65,7 +65,8 @@
     "redesignedSidebarBanner",
     "mobilePlansTablesOnSignup",
     "springSale30PercentOff",
-    "showMoneyBackGuarantee"
+    "showMoneyBackGuarantee",
+    "multiyearSubscriptions",
   ],
   "overrideABTests": [
     [ "upgradePricingDisplayV2_20180305", "original" ],
@@ -76,6 +77,7 @@
     [ "businessPlanDescriptionAT_20170605", "original" ],
     [ "mobilePlansTablesOnSignup_20180330", "original" ],
     [ "springSale30PercentOff_20180413", "control" ],
-    [ "showMoneyBackGuarantee_20180409", "no" ]
+    [ "showMoneyBackGuarantee_20180409", "no" ],
+    [ "multiyearSubscriptions_20180417", "hide" ],
   ]
 }


### PR DESCRIPTION
It's about this test: https://github.com/Automattic/wp-calypso/pull/24300