### PR TITLE
Add a simple activity log verification to publishing a post

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -17,7 +17,7 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 		const contentSelector = By.css( 'div.is-section-post-editor' );
 		const cogSelector = By.css( 'button.editor-ground-control__toggle-sidebar' );
 		driverHelper.waitTillPresentAndDisplayed( driver, contentSelector );
-		driver
+		return driver
 			.findElement( contentSelector )
 			.getAttribute( 'class' )
 			.then( c => {

--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -75,7 +75,7 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 			this.editorConfirmationSidebarComponent.confirmAndPublish();
 		}
 		this.waitForSuccessViewPostNotice();
-		this.previewPublishedPostOrPage();
+		return this.previewPublishedPostOrPage();
 	}
 
 	publishAndViewContent( { reloadPageTwice = false, useConfirmStep = false } = {} ) {
@@ -94,13 +94,14 @@ export default class PostEditorToolbarComponent extends BaseContainer {
 	}
 
 	publishThePost( { useConfirmStep = false } = {} ) {
-		this.clickPublishPost();
+		let result = this.clickPublishPost();
 		if ( useConfirmStep === true ) {
 			this.editorConfirmationSidebarComponent = new EditorConfirmationSidebarComponent(
 				this.driver
 			);
-			this.editorConfirmationSidebarComponent.confirmAndPublish();
+			return this.editorConfirmationSidebarComponent.confirmAndPublish();
 		}
+		return result;
 	}
 
 	viewPublishedPostOrPage( { reloadPageTwice = false } = {} ) {

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -65,7 +65,7 @@ export default class EditorPage extends BaseContainer {
 			'Could not locate the editor iFrame.'
 		);
 		this.driver.findElement( webdriver.By.id( 'tinymce' ) ).sendKeys( blogPostText );
-		this.driver.switchTo().defaultContent();
+		return this.driver.switchTo().defaultContent();
 	}
 
 	chooseInsertMediaOption() {
@@ -401,7 +401,7 @@ export default class EditorPage extends BaseContainer {
 			'Could not locate the editor iFrame.'
 		);
 		driverHelper.waitTillPresentAndDisplayed( this.driver, by.css( '.wpview-type-contact-form' ) );
-		this.driver.switchTo().defaultContent();
+		return this.driver.switchTo().defaultContent();
 	}
 
 	ensurePaymentButtonDisplayedInPost() {
@@ -414,7 +414,7 @@ export default class EditorPage extends BaseContainer {
 			this.driver,
 			by.css( '.wpview-type-simple-payments' )
 		);
-		this.driver.switchTo().defaultContent();
+		return this.driver.switchTo().defaultContent();
 	}
 
 	waitForTitle() {

--- a/lib/pages/stats/activity-page.js
+++ b/lib/pages/stats/activity-page.js
@@ -78,6 +78,6 @@ export default class ActivityPage extends BaseContainer {
 				.then( present => {
 					return present;
 				} );
-		}, this.explicitWaitMS );
+		}, this.explicitWaitMS * 2 );
 	}
 }

--- a/lib/pages/stats/activity-page.js
+++ b/lib/pages/stats/activity-page.js
@@ -63,4 +63,21 @@ export default class ActivityPage extends BaseContainer {
 
 		return driverHelper.isEventuallyPresentAndDisplayed( this.driver, bannerIconSelector );
 	}
+
+	postTitleDisplayed( postTitle ) {
+		const driver = this.driver;
+		return driver.wait( () => {
+			driver.navigate().refresh();
+			return driverHelper
+				.isElementPresent(
+					driver,
+					By.xpath(
+						`//div[@class='activity-log-item__description-content']//a//em[text()='${ postTitle }']`
+					)
+				)
+				.then( present => {
+					return present;
+				} );
+		}, this.explicitWaitMS );
+	}
 }

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -487,8 +487,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				sidebarComponent.ensureSidebarMenuVisible();
 				sidebarComponent.selectStats();
 				new StatsPage( driver ).openActivity();
-				const activityPage = new ActivityPage( driver );
-				return activityPage.postTitleDisplayed( blogPostTitle ).then( displayed => {
+				return new ActivityPage( driver ).postTitleDisplayed( blogPostTitle ).then( displayed => {
 					assert(
 						displayed,
 						`The published post title '${ blogPostTitle }' was not displayed in activity log after publishing`

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -483,6 +483,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 			test.it( 'Can see the post in the Activity log', function() {
 				new ReaderPage( driver, true ).displayed();
+				new NavbarComponent( driver ).clickMySites();
 				const sidebarComponent = new SidebarComponent( driver );
 				sidebarComponent.ensureSidebarMenuVisible();
 				sidebarComponent.selectStats();

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -478,11 +478,11 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
 				postEditorToolbarComponent.ensureSaved();
 				postEditorToolbarComponent.publishThePost( { useConfirmStep: true } );
-				postEditorToolbarComponent.waitForSuccessViewPostNotice();
-				return postEditorToolbarComponent.closeEditor();
+				return postEditorToolbarComponent.waitForSuccessViewPostNotice();
 			} );
 
 			test.it( 'Can see the post in the Activity log', function() {
+				new ReaderPage( driver, true ).displayed();
 				const sidebarComponent = new SidebarComponent( driver );
 				sidebarComponent.ensureSidebarMenuVisible();
 				sidebarComponent.selectStats();


### PR DESCRIPTION
This adds a check after publishing a public post that the post title is shown in the activity log

The Pressable Jetpack site doesn't work at present -> need to investigate why