### PR TITLE
Update magellan browser for IE11

### DIFF
--- a/magellan-ie11-canary.json
+++ b/magellan-ie11-canary.json
@@ -8,7 +8,7 @@
   "max_workers": 1,
   "suiteTag": "ie11canary",
   "sauce": false,
-  "browser": "chrome",
+  "browser": "ie11",
   "framework": "testarmada-magellan-mocha-plugin",
   "reporters": [
 	  "./lib/reporter/magellan-reporter.js"

--- a/magellan-ie11.json
+++ b/magellan-ie11.json
@@ -8,7 +8,7 @@
   "max_workers": 3,
   "suiteTag": "parallel",
   "sauce": false,
-  "browser": "chrome",
+  "browser": "ie11",
   "framework": "testarmada-magellan-mocha-plugin",
   "reporters": [
 	  "./lib/reporter/magellan-reporter.js"


### PR DESCRIPTION
I don't think this does anything but change the console output
When running IE11 tests at the moment Magellan says running in Chrome which can be misleading
Hopefully this just changes that


```
Magellan 8.8.6
Will try to load configuration from magellan-ie11.json
Loaded configuration from:  /home/circleci/wp-e2e-tests/wp-e2e-tests/magellan-ie11.json
Magellan is creating temporary files at: /home/circleci/wp-e2e-tests/wp-e2e-tests/temp
Sauce configuration OK
[INFO] [Mocha Plugin] Scanning test files for tests ...
[INFO] [Mocha Plugin] Found 7 tests in test files

Running 7 tests with 3 workers with chrome
```

should become:


```
Magellan 8.8.6
Will try to load configuration from magellan-ie11.json
Loaded configuration from:  /home/circleci/wp-e2e-tests/magellan-ie11.json
Magellan is creating temporary files at: /home/circleci/wp-e2e-tests/temp
Sauce configuration OK
[INFO] [Mocha Plugin] Scanning test files for tests ...
[INFO] [Mocha Plugin] Found 7 tests in test files

Running 7 tests with 3 workers with ie11

```
