### PR TITLE
Fix Free Plan selection during Signup

### DIFF
--- a/lib/pages/signup/pick-a-plan-page.js
+++ b/lib/pages/signup/pick-a-plan-page.js
@@ -26,12 +26,8 @@ export default class PickAPlanPage extends BaseContainer {
 		return driverHelper.clickWhenClickable( this.driver, selector );
 	}
 	selectFreePlan() {
-		// Jetpack connect no longer displays the Free plan, so we have to click the "Skip" button
-		if ( this.host !== 'WPCOM' ) {
-			return driverHelper.clickWhenClickable( this.driver, By.css( '.plans-skip-button button' ) );
-		}
-
-		return this._selectPlan( 'free' );
+		// During signup, we no longer display the Free plan, so we have to click the "Skip" button
+		return driverHelper.clickWhenClickable( this.driver, By.css( '.plans-skip-button button' ) );
 	}
 	// Explicitly select the free button on jetpack without needing `host` above.
 	selectFreePlanJetpack() {


### PR DESCRIPTION
Companion PR to https://github.com/Automattic/wp-calypso/pull/24333, which broken tests that look for the 'Start with Free [Plan]' button based on the previous class name.