### PR TITLE
i18n: Skip the whole suite for unsupported locales

### DIFF
--- a/specs-i18n/search-wordpress-on-google.js
+++ b/specs-i18n/search-wordpress-on-google.js
@@ -43,16 +43,18 @@ function doGoogleAdSearch( search_params ) {
 		this.timeout( mochaTimeOut );
 		this.bailSuite( true );
 
+		test.before( function() {
+			if ( locale === 'tr' || locale === 'ar' || locale === 'zh-tw' ) {
+				this.skip( 'Currently no advertising in this locale' );
+			}
+		} );
+
 		test.beforeEach( function() {
 			driver.manage().deleteAllCookies();
 			driverManager.deleteLocalStorage( driver );
 		} );
 
 		test.it( 'Google search contains our ad', function() {
-			if ( locale === 'tr' || locale === 'ar' || locale === 'zh-tw' ) {
-				this.skip( 'Currently no advertising in this locale' );
-			}
-
 			const googleFlow = new GoogleFlow( driver, 'desktop' );
 			const that = this;
 			googleFlow.search( search_params, test_data ).then( () => {


### PR DESCRIPTION
Right now we have failing tests for the three locales where we don't advertise because skipping of the tests is done only for one of them. This changes the test so that the whole suite is skipped for these locales.