### PR TITLE
Wait for payment button to be enabled for checkout

### DIFF
--- a/lib/components/secure-payment-component.js
+++ b/lib/components/secure-payment-component.js
@@ -44,10 +44,12 @@ export default class SecurePaymentComponent extends BaseContainer {
 	}
 
 	submitPaymentDetails() {
-		return driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.credit-card-payment-box button.is-primary' )
-		);
+		const disabledPaymentButton = By.css( '.credit-card-payment-box button[disabled]' );
+		const PaymentButton = By.css( '.credit-card-payment-box button.is-primary' );
+
+		return driverHelper
+			.waitTillNotPresent( this.driver, disabledPaymentButton )
+			.then( () => driverHelper.clickWhenClickable( this.driver, PaymentButton ) );
 	}
 
 	removePlanAndDomain() {


### PR DESCRIPTION
This PR adds a wait for the payment button to become enabled before clicking it during checkout.

This prevents the test from trying to click that button while the price is being calculated and the button is disabled — this is new behavior as of https://github.com/Automattic/wp-calypso/pull/24409.

To test:

- Run `./node_modules/.bin/mocha specs -g 'Sign up for a domain only purchase'`. This test fails on master when it tries to click the payment button too early, and passes on this branch.