### PR TITLE
Remove NPS survey from e2e tests

### DIFF
--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -51,8 +51,7 @@ export default class LoginFlow {
 
 	login( { jetpackSSO = false, jetpackDIRECT = false, screenshot = false } = {}, eyes ) {
 		let loginURL = this.account.loginURL,
-			loginPage,
-			readerPage;
+			loginPage;
 
 		if (
 			( host === 'CI' || host === 'JN' ) &&
@@ -75,10 +74,7 @@ export default class LoginFlow {
 			eyesHelper.eyesScreenshot( this.driver, eyes, 'Login Page' );
 		}
 
-		loginPage.login( this.account.email || this.account.username, this.account.password );
-
-		readerPage = new ReaderPage( this.driver );
-		return readerPage.dismissNpsSurvey();
+		return loginPage.login( this.account.email || this.account.username, this.account.password );
 	}
 
 	loginAndStartNewPost() {

--- a/lib/pages/reader-page.js
+++ b/lib/pages/reader-page.js
@@ -60,8 +60,4 @@ export default class ReaderPage extends BaseContainer {
 			by.css( '.comments__comment-moderation' )
 		);
 	}
-
-	dismissNpsSurvey() {
-		return driverHelper.clickIfPresent( this.driver, by.css( '.nps-survey__not-answer-button' ) );
-	}
 }


### PR DESCRIPTION
This removes the NPS survey steps added in https://github.com/Automattic/wp-e2e-tests/pull/1118. It can be merged after https://github.com/Automattic/wp-calypso/pull/24465, which will prevent the NPS survey from being shown during e2e tests.