### PR TITLE
[Domains] Add Kracken TLD filters test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -66,7 +66,8 @@
     "mobilePlansTablesOnSignup",
     "springSale30PercentOff",
     "showMoneyBackGuarantee",
-    "multiyearSubscriptions"
+    "multiyearSubscriptions",
+    "krackenShowTldFilterBar"
   ],
   "overrideABTests": [
     [ "upgradePricingDisplayV3_20180402", "original" ],
@@ -78,6 +79,7 @@
     [ "mobilePlansTablesOnSignup_20180330", "original" ],
     [ "springSale30PercentOff_20180413", "control" ],
     [ "showMoneyBackGuarantee_20180409", "no" ],
-    [ "multiyearSubscriptions_20180417", "hide" ]
+    [ "multiyearSubscriptions_20180417", "hide" ],
+    [ "krackenShowTldFilterBar_20180502", "hide" ]
   ]
 }


### PR DESCRIPTION
This adds support for [this upcoming change](https://github.com/Automattic/wp-calypso/pull/24509) affecting the domain registration experience.