### PR TITLE
Don't wait for link in PressableSiteSettingsPage constructor

### DIFF
--- a/lib/pages/pressable/pressable-site-settings-page.js
+++ b/lib/pages/pressable/pressable-site-settings-page.js
@@ -10,10 +10,12 @@ const explicitWaitMS = config.get( 'explicitWaitMS' );
 
 export default class PressableSiteSettingsPage extends BaseContainer {
 	constructor( driver ) {
-		const loadingSelector = By.css( '.activating img.loading-image' );
-
 		super( driver, By.css( '.site-show-sections' ) );
-		driverHelper.waitTillNotPresent( this.driver, loadingSelector, explicitWaitMS * 4 );
+	}
+
+	waitForJetpackPremium() {
+		const loadingSelector = By.css( '.activating img.loading-image' );
+		return driverHelper.waitTillNotPresent( this.driver, loadingSelector, explicitWaitMS * 4 );
 	}
 
 	gotoWPAdmin() {

--- a/specs-jetpack-calypso/wp-pressable-nux-spec.js
+++ b/specs-jetpack-calypso/wp-pressable-nux-spec.js
@@ -76,7 +76,9 @@ if ( host === 'PRESSABLE' ) {
 			} );
 
 			test.it( 'Can proceed to Jetpack activation', function() {
-				return new PressableSiteSettingsPage( driver ).activateJetpackPremium();
+				const siteSettings = new PressableSiteSettingsPage( driver );
+				siteSettings.waitForJetpackPremium();
+				return siteSettings.activateJetpackPremium();
 			} );
 
 			test.it( 'Can approve connection on the authorization page', function() {


### PR DESCRIPTION
`PressableSiteSettingsPage` constructor is waiting for Jetpack Premium link to show up. This behavior may create test failures when some of the "old" sites were broken. This PR moves that wait into a separate method to prevent such failures.