### PR TITLE
Remove temp chrome workaround

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -21,18 +21,6 @@ if [ "$NODE_ENV" = "" ]; then
 	exit 1
 fi
 
-if [ "$CI" == "true" ]; then
-  # Temporary workaround to force an updated version of Chrome on CircleCI 1.0 containers
-  # https://github.com/Automattic/wp-e2e-tests/issues/783
-  # p6fDka-v0-p2
-  if [ "$(google-chrome --version | awk -F. '{ print $1 }' | awk '{ print $3 }')" -le "59" ]; then
-    curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-    sudo dpkg -i google-chrome.deb
-    sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
-    rm google-chrome.deb
-  fi
-fi
-
 # Function to join arrays into a string
 function joinStr { local IFS="$1"; shift; echo "$*"; }
 


### PR DESCRIPTION
This is no longer needed as we don't use CircleCI 1.0 anymore

Fixes #973