### PR TITLE
Add product validation to sign up specs

### DIFF
--- a/lib/components/secure-payment-component.js
+++ b/lib/components/secure-payment-component.js
@@ -8,7 +8,9 @@ import * as driverHelper from '../driver-helper.js';
 export default class SecurePaymentComponent extends BaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.secure-payment-form' ) );
-		this.paymentButtonSelector = By.css( '.credit-card-payment-box button.is-primary' );
+		this.paymentButtonSelector = By.css(
+			'.credit-card-payment-box button.is-primary:not([disabled])'
+		);
 	}
 
 	enterTestCreditCardDetails( {
@@ -117,10 +119,13 @@ export default class SecurePaymentComponent extends BaseContainer {
 	}
 
 	cartTotalDisplayed() {
-		return this.driver.findElement( By.css( '.cart-total-amount' ) ).getText();
+		const selector = By.css( '.cart-total-amount' );
+		driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
+		return this.driver.findElement( selector ).getText();
 	}
 
 	paymentButtonText() {
+		driverHelper.waitTillPresentAndDisplayed( this.driver, this.paymentButtonSelector );
 		return this.driver.findElement( this.paymentButtonSelector ).getText();
 	}
 }

--- a/lib/components/secure-payment-component.js
+++ b/lib/components/secure-payment-component.js
@@ -91,6 +91,20 @@ export default class SecurePaymentComponent extends BaseContainer {
 			.then( products => promise.all( products.map( e => e.getText() ) ) );
 	}
 
+	numberOfProductsInCart() {
+		return this.driver.findElements( By.css( '.product-name' ) ).then( elements => {
+			return elements.length;
+		} );
+	}
+
+	cartContainsProduct( productSlug, expectedQuantity = 1 ) {
+		return this.driver
+			.findElements( By.css( `.product-name[data-e2e-product-slug="${ productSlug }"]` ) )
+			.then( elements => {
+				return elements.length === expectedQuantity;
+			} );
+	}
+
 	payWithStoredCardIfPossible( cardCredentials ) {
 		const storedCardSelector = By.css( '.stored-card' );
 		if ( driverHelper.isEventuallyPresentAndDisplayed( this.driver, storedCardSelector ) ) {

--- a/lib/components/secure-payment-component.js
+++ b/lib/components/secure-payment-component.js
@@ -11,6 +11,11 @@ export default class SecurePaymentComponent extends BaseContainer {
 		this.paymentButtonSelector = By.css(
 			'.credit-card-payment-box button.is-primary:not([disabled])'
 		);
+		this.personalPlanSlug = 'personal-bundle';
+		this.premiumPlanSlug = 'value_bundle';
+		this.businessPlanSlug = 'business-bundle';
+		this.dotLiveDomainSlug = 'dotlive_domain';
+		this.privateWhoisSlug = 'private_whois';
 	}
 
 	enterTestCreditCardDetails( {
@@ -99,12 +104,24 @@ export default class SecurePaymentComponent extends BaseContainer {
 		} );
 	}
 
-	cartContainsProduct( productSlug, expectedQuantity = 1 ) {
-		return this.driver
-			.findElements( By.css( `.product-name[data-e2e-product-slug="${ productSlug }"]` ) )
-			.then( elements => {
-				return elements.length === expectedQuantity;
-			} );
+	containsPersonalPlan() {
+		return this._cartContainsProduct( this.personalPlanSlug );
+	}
+
+	containsPremiumPlan() {
+		return this._cartContainsProduct( this.premiumPlanSlug );
+	}
+
+	containsBusinessPlan() {
+		return this._cartContainsProduct( this.businessPlanSlug );
+	}
+
+	containsDotLiveDomain() {
+		return this._cartContainsProduct( this.dotLiveDomainSlug );
+	}
+
+	containsPrivateWhois() {
+		return this._cartContainsProduct( this.privateWhoisSlug );
 	}
 
 	payWithStoredCardIfPossible( cardCredentials ) {
@@ -127,5 +144,13 @@ export default class SecurePaymentComponent extends BaseContainer {
 	paymentButtonText() {
 		driverHelper.waitTillPresentAndDisplayed( this.driver, this.paymentButtonSelector );
 		return this.driver.findElement( this.paymentButtonSelector ).getText();
+	}
+
+	_cartContainsProduct( productSlug, expectedQuantity = 1 ) {
+		return this.driver
+			.findElements( By.css( `.product-name[data-e2e-product-slug="${ productSlug }"]` ) )
+			.then( elements => {
+				return elements.length === expectedQuantity;
+			} );
 	}
 }

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -407,10 +407,8 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			);
 
 			test.it(
-				'Can then see the secure payment page, and can enter and submit test payment details',
+				'Can then see the secure payment page with the expected currency in the cart',
 				async function() {
-					const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
-
 					const securePaymentComponent = new SecurePaymentComponent( driver );
 					if ( driverManager.currentScreenSize() === 'desktop' ) {
 						const totalShown = await securePaymentComponent.cartTotalDisplayed();
@@ -425,11 +423,33 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 						paymentButtonText.includes( expectedCurrencySymbol ),
 						`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
 					);
-					await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
-					await securePaymentComponent.submitPaymentDetails();
-					return await securePaymentComponent.waitForPageToDisappear();
 				}
 			);
+
+			test.it(
+				'Can then see the secure payment page with the expected products in the cart',
+				async function() {
+					const securePaymentComponent = new SecurePaymentComponent( driver );
+					const premiumPlanInCart = await securePaymentComponent.cartContainsProduct(
+						premiumPlanSlug
+					);
+					assert.equal( premiumPlanInCart, true, "The cart doesn't contain the premium plan" );
+					const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
+					assert.equal(
+						numberOfProductsInCart,
+						1,
+						"The cart doesn't contain the expected number of products"
+					);
+				}
+			);
+
+			test.it( 'Can submit test payment details', async function() {
+				const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
+				const securePaymentComponent = new SecurePaymentComponent( driver );
+				await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
+				await securePaymentComponent.submitPaymentDetails();
+				return await securePaymentComponent.waitForPageToDisappear();
+			} );
 
 			test.it( 'Can see the secure check out thank you page', async function() {
 				return await new CheckOutThankyouPage( driver ).displayed();

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -188,7 +188,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 	);
 
 	test.describe(
-		'Sign up for a site on a premium paid plan through main flow @parallel @visdiff',
+		'Sign up for a site on a premium paid plan through main flow in USD currency @parallel @visdiff',
 		function() {
 			this.bailSuite( true );
 
@@ -196,6 +196,8 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 			const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 			const password = config.get( 'passwordForNewTestSignUps' );
+			const currencyValue = 'USD';
+			const expectedCurrencySymbol = '$';
 
 			test.before( function() {
 				let testEnvironment = 'WordPress.com';
@@ -214,7 +216,8 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 					culture: locale,
 				} );
 				await eyesHelper.eyesScreenshot( driver, eyes, 'Logged Out Homepage' );
-				return await wPHomePage.setSandboxModeForPayments( sandboxCookieValue );
+				await wPHomePage.setSandboxModeForPayments( sandboxCookieValue );
+				return await wPHomePage.setCurrencyForPayments( currencyValue );
 			} );
 
 			test.it( 'Can visit the start page', async function() {
@@ -306,6 +309,26 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 						numberOfProductsInCart,
 						1,
 						"The cart doesn't contain the expected number of products"
+					);
+				}
+			);
+
+			test.it(
+				'Can then see the secure payment page with the expected currency in the cart',
+				async function() {
+					const securePaymentComponent = new SecurePaymentComponent( driver );
+					if ( driverManager.currentScreenSize() === 'desktop' ) {
+						const totalShown = await securePaymentComponent.cartTotalDisplayed();
+						assert.equal(
+							totalShown.indexOf( expectedCurrencySymbol ),
+							0,
+							`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
+						);
+					}
+					const paymentButtonText = await securePaymentComponent.paymentButtonText();
+					return assert(
+						paymentButtonText.includes( expectedCurrencySymbol ),
+						`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
 					);
 				}
 			);

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -50,6 +50,7 @@ const signupInboxId = config.get( 'signupInboxId' );
 const host = dataHelper.getJetpackHost();
 const locale = driverManager.currentLocale();
 const passwordForTestAccounts = config.get( 'passwordForNewTestSignUps' );
+const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
 
 let driver;
 
@@ -204,7 +205,6 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			} );
 
 			test.it( 'We can set the sandbox cookie for payments', async function() {
-				const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
 				const wPHomePage = new WPHomePage( driver, {
 					visit: true,
 					culture: locale,
@@ -362,7 +362,6 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			} );
 
 			test.it( 'We can set the sandbox cookie for payments', async function() {
-				const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
 				const wpHomePage = await new WPHomePage( driver, {
 					visit: true,
 					culture: locale,
@@ -489,7 +488,6 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			} );
 
 			test.it( 'We can set the sandbox cookie for payments', async function() {
-				const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
 				const wpHomePage = await new WPHomePage( driver, {
 					visit: true,
 					culture: locale,
@@ -617,7 +615,6 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			} );
 
 			test.it( 'We can visit set the sandbox cookie for payments', async function() {
-				const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
 				const wpHomePage = await new WPHomePage( driver, {
 					visit: true,
 					culture: locale,
@@ -788,7 +785,6 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			} );
 
 			test.it( 'We can set the sandbox cookie for payments', async function() {
-				const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
 				const wpHomePage = await new WPHomePage( driver, {
 					visit: true,
 					culture: locale,
@@ -1079,7 +1075,6 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			} );
 
 			test.it( 'We can set the sandbox cookie for payments', async function() {
-				const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
 				const wpHomePage = await new WPHomePage( driver, {
 					visit: true,
 					culture: locale,

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -49,6 +49,7 @@ const screenSize = driverManager.currentScreenSize();
 const signupInboxId = config.get( 'signupInboxId' );
 const host = dataHelper.getJetpackHost();
 const locale = driverManager.currentLocale();
+const passwordForTestAccounts = config.get( 'passwordForNewTestSignUps' );
 
 let driver;
 
@@ -70,7 +71,6 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			let newBlogAddress = '';
 			const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 			const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-			const password = config.get( 'passwordForNewTestSignUps' );
 			let magicLoginLink;
 
 			test.it( 'Ensure we are not logged in as anyone', async function() {
@@ -119,7 +119,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				return await new CreateYourAccountPage( driver ).enterAccountDetailsAndSubmit(
 					emailAddress,
 					blogName,
-					password
+					passwordForTestAccounts
 				);
 			} );
 
@@ -190,7 +190,6 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			const blogName = dataHelper.getNewBlogName();
 			const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 			const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-			const password = config.get( 'passwordForNewTestSignUps' );
 			const currencyValue = 'USD';
 			const expectedCurrencySymbol = '$';
 
@@ -279,7 +278,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				return await createYourAccountPage.enterAccountDetailsAndSubmit(
 					emailAddress,
 					blogName,
-					password
+					passwordForTestAccounts
 				);
 			} );
 
@@ -354,7 +353,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			const blogName = dataHelper.getNewBlogName();
 			const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 			const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-			const password = config.get( 'passwordForNewTestSignUps' );
+
 			const currencyValue = 'JPY';
 			const expectedCurrencySymbol = '¥';
 
@@ -413,7 +412,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				return await new CreateYourAccountPage( driver ).enterAccountDetailsAndSubmit(
 					emailAddress,
 					blogName,
-					password
+					passwordForTestAccounts
 				);
 			} );
 
@@ -482,7 +481,6 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			const blogName = dataHelper.getNewBlogName();
 			const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 			const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-			const password = config.get( 'passwordForNewTestSignUps' );
 			const currencyValue = 'GBP';
 			const expectedCurrencySymbol = '£';
 
@@ -541,7 +539,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				return await new CreateYourAccountPage( driver ).enterAccountDetailsAndSubmit(
 					emailAddress,
 					blogName,
-					password
+					passwordForTestAccounts
 				);
 			} );
 
@@ -610,7 +608,6 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			const siteName = dataHelper.getNewBlogName();
 			const expectedDomainName = `${ siteName }.live`;
 			const emailAddress = dataHelper.getEmailAddress( siteName, signupInboxId );
-			const password = config.get( 'passwordForNewTestSignUps' );
 			const testDomainRegistarDetails = dataHelper.getTestDomainRegistarDetails( emailAddress );
 			const currencyValue = 'EUR';
 			const expectedCurrencySymbol = '€';
@@ -647,7 +644,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				return await new CreateYourAccountPage( driver ).enterAccountDetailsAndSubmit(
 					emailAddress,
 					siteName,
-					password
+					passwordForTestAccounts
 				);
 			} );
 
@@ -782,7 +779,6 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			const siteName = dataHelper.getNewBlogName();
 			const expectedDomainName = `${ siteName }.live`;
 			const emailAddress = dataHelper.getEmailAddress( siteName, signupInboxId );
-			const password = config.get( 'passwordForNewTestSignUps' );
 			const testDomainRegistarDetails = dataHelper.getTestDomainRegistarDetails( emailAddress );
 			const currencyValue = 'CAD';
 			const expectedCurrencySymbol = 'C$';
@@ -833,7 +829,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				return await new CreateYourAccountPage( driver ).enterAccountDetailsAndSubmit(
 					emailAddress,
 					siteName,
-					password
+					passwordForTestAccounts
 				);
 			} );
 
@@ -951,7 +947,6 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 		let newBlogAddress = '';
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-		const password = config.get( 'passwordForNewTestSignUps' );
 
 		test.it( 'Ensure we are not logged in as anyone', async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -1007,7 +1002,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 							return await new CreateYourAccountPage( driver ).enterAccountDetailsAndSubmit(
 								emailAddress,
 								blogName,
-								password
+								passwordForTestAccounts
 							);
 						} );
 
@@ -1075,7 +1070,6 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			const blogName = dataHelper.getNewBlogName();
 			const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 			const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-			const password = config.get( 'passwordForNewTestSignUps' );
 			const currencyValue = 'AUD';
 			const expectedCurrencySymbol = 'A$';
 			let chosenThemeName = '';
@@ -1131,7 +1125,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				return await new CreateYourAccountPage( driver ).enterAccountDetailsAndSubmit(
 					emailAddress,
 					blogName,
-					password
+					passwordForTestAccounts
 				);
 			} );
 

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -50,6 +50,8 @@ const signupInboxId = config.get( 'signupInboxId' );
 const host = dataHelper.getJetpackHost();
 const locale = driverManager.currentLocale();
 const premiumPlanSlug = 'value_bundle';
+const dotLiveDomainSlug = 'dotlive_domain';
+const privateWhoisSlug = 'private_whois';
 
 let driver;
 
@@ -298,7 +300,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 					);
 					assert.equal( premiumPlanInCart, true, "The cart doesn't contain the premium plan" );
 					const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
-					assert.equal(
+					return assert.equal(
 						numberOfProductsInCart,
 						1,
 						"The cart doesn't contain the expected number of products"
@@ -419,7 +421,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 						);
 					}
 					const paymentButtonText = await securePaymentComponent.paymentButtonText();
-					assert(
+					return assert(
 						paymentButtonText.includes( expectedCurrencySymbol ),
 						`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
 					);
@@ -435,7 +437,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 					);
 					assert.equal( premiumPlanInCart, true, "The cart doesn't contain the premium plan" );
 					const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
-					assert.equal(
+					return assert.equal(
 						numberOfProductsInCart,
 						1,
 						"The cart doesn't contain the expected number of products"
@@ -519,16 +521,38 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			);
 
 			test.it(
-				'Can then see the secure payment page and enter/submit test payment details',
+				'Can then see the secure payment page with the correct products in the cart',
 				async function() {
-					const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 					const securePaymentComponent = new SecurePaymentComponent( driver );
-					await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
-					await securePaymentComponent.submitPaymentDetails();
-					await securePaymentComponent.waitForCreditCardPaymentProcessing();
-					return await securePaymentComponent.waitForPageToDisappear();
+					const domainInCart = await securePaymentComponent.cartContainsProduct(
+						dotLiveDomainSlug
+					);
+					assert.equal( domainInCart, true, "The cart doesn't contain the .live domain product" );
+					const privateWhoISInCart = await securePaymentComponent.cartContainsProduct(
+						privateWhoisSlug
+					);
+					assert.equal(
+						privateWhoISInCart,
+						true,
+						"The cart doesn't contain the private domain product"
+					);
+					const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
+					return assert.equal(
+						numberOfProductsInCart,
+						2,
+						"The cart doesn't contain the expected number of products"
+					);
 				}
 			);
+
+			test.it( 'Can enter/submit test payment details', async function() {
+				const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
+				const securePaymentComponent = new SecurePaymentComponent( driver );
+				await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
+				await securePaymentComponent.submitPaymentDetails();
+				await securePaymentComponent.waitForCreditCardPaymentProcessing();
+				return await securePaymentComponent.waitForPageToDisappear();
+			} );
 
 			test.it(
 				'Can see the secure check out thank you page and click "go to my domain" button to see the domain only settings page',

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -952,10 +952,17 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 		test.it(
 			'Can then see the secure payment page with the chosen theme in the cart',
 			async function() {
-				let products = await new SecurePaymentComponent( driver ).getProductsNames();
-				return assert(
+				const securePaymentComponent = new SecurePaymentComponent( driver );
+				let products = await securePaymentComponent.getProductsNames();
+				assert(
 					products[ 0 ].search( chosenThemeName ),
 					`First product in cart is not ${ chosenThemeName }`
+				);
+				const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
+				return assert.equal(
+					numberOfProductsInCart,
+					1,
+					"The cart doesn't contain the expected number of products"
 				);
 			}
 		);

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -49,11 +49,6 @@ const screenSize = driverManager.currentScreenSize();
 const signupInboxId = config.get( 'signupInboxId' );
 const host = dataHelper.getJetpackHost();
 const locale = driverManager.currentLocale();
-const personalPlanSlug = 'personal-bundle';
-const premiumPlanSlug = 'value_bundle';
-const businessPlanSlug = 'business-bundle';
-const dotLiveDomainSlug = 'dotlive_domain';
-const privateWhoisSlug = 'private_whois';
 
 let driver;
 
@@ -300,9 +295,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				async function() {
 					const securePaymentComponent = new SecurePaymentComponent( driver );
 					await eyesHelper.eyesScreenshot( driver, eyes, 'Secure Payment Page' );
-					const premiumPlanInCart = await securePaymentComponent.cartContainsProduct(
-						premiumPlanSlug
-					);
+					const premiumPlanInCart = await securePaymentComponent.containsPremiumPlan();
 					assert.equal( premiumPlanInCart, true, "The cart doesn't contain the premium plan" );
 					const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
 					return assert.equal(
@@ -457,9 +450,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				'Can then see the secure payment page with the expected products in the cart',
 				async function() {
 					const securePaymentComponent = new SecurePaymentComponent( driver );
-					const premiumPlanInCart = await securePaymentComponent.cartContainsProduct(
-						premiumPlanSlug
-					);
+					const premiumPlanInCart = await securePaymentComponent.containsPremiumPlan();
 					assert.equal( premiumPlanInCart, true, "The cart doesn't contain the premium plan" );
 					const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
 					return assert.equal(
@@ -587,9 +578,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				'Can then see the secure payment page with the expected products in the cart',
 				async function() {
 					const securePaymentComponent = new SecurePaymentComponent( driver );
-					const personalPlanInCart = await securePaymentComponent.cartContainsProduct(
-						personalPlanSlug
-					);
+					const personalPlanInCart = await securePaymentComponent.containsPersonalPlan();
 					assert.equal( personalPlanInCart, true, "The cart doesn't contain the personal plan" );
 					const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
 					return assert.equal(
@@ -683,13 +672,9 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				'Can then see the secure payment page with the correct products in the cart',
 				async function() {
 					const securePaymentComponent = new SecurePaymentComponent( driver );
-					const domainInCart = await securePaymentComponent.cartContainsProduct(
-						dotLiveDomainSlug
-					);
+					const domainInCart = await securePaymentComponent.containsDotLiveDomain();
 					assert.equal( domainInCart, true, "The cart doesn't contain the .live domain product" );
-					const privateWhoISInCart = await securePaymentComponent.cartContainsProduct(
-						privateWhoisSlug
-					);
+					const privateWhoISInCart = await securePaymentComponent.containsPrivateWhois();
 					assert.equal(
 						privateWhoISInCart,
 						true,
@@ -873,21 +858,15 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				'Can then see the secure payment page with the correct products in the cart',
 				async function() {
 					const securePaymentComponent = new SecurePaymentComponent( driver );
-					const domainInCart = await securePaymentComponent.cartContainsProduct(
-						dotLiveDomainSlug
-					);
+					const domainInCart = await securePaymentComponent.dotLiveDomainSlug();
 					assert.equal( domainInCart, true, "The cart doesn't contain the .live domain product" );
-					const privateWhoISInCart = await securePaymentComponent.cartContainsProduct(
-						privateWhoisSlug
-					);
+					const privateWhoISInCart = await securePaymentComponent.containsPrivateWhois();
 					assert.equal(
 						privateWhoISInCart,
 						true,
 						"The cart doesn't contain the private domain product"
 					);
-					const businessPlanInCart = await securePaymentComponent.cartContainsProduct(
-						businessPlanSlug
-					);
+					const businessPlanInCart = await securePaymentComponent.containsBusinessPlan();
 					assert.equal(
 						businessPlanInCart,
 						true,

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -768,7 +768,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 		}
 	);
 
-	test.describe(
+	test.describe.only(
 		'Sign up for a site on a business paid plan w/ domain name coming in via /create as business flow in CAD currency @parallel',
 		function() {
 			this.bailSuite( true );
@@ -850,7 +850,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				'Can then see the secure payment page with the correct products in the cart',
 				async function() {
 					const securePaymentComponent = new SecurePaymentComponent( driver );
-					const domainInCart = await securePaymentComponent.dotLiveDomainSlug();
+					const domainInCart = await securePaymentComponent.containsDotLiveDomain();
 					assert.equal( domainInCart, true, "The cart doesn't contain the .live domain product" );
 					const privateWhoISInCart = await securePaymentComponent.containsPrivateWhois();
 					assert.equal(

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -768,7 +768,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 		}
 	);
 
-	test.describe.only(
+	test.describe(
 		'Sign up for a site on a business paid plan w/ domain name coming in via /create as business flow in CAD currency @parallel',
 		function() {
 			this.bailSuite( true );

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -50,6 +50,7 @@ const signupInboxId = config.get( 'signupInboxId' );
 const host = dataHelper.getJetpackHost();
 const locale = driverManager.currentLocale();
 const premiumPlanSlug = 'value_bundle';
+const businessPlanSlug = 'business-bundle';
 const dotLiveDomainSlug = 'dotlive_domain';
 const privateWhoisSlug = 'private_whois';
 
@@ -688,15 +689,45 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			);
 
 			test.it(
-				'Can then see the secure payment page and enter/submit test payment details',
+				'Can then see the secure payment page with the correct products in the cart',
 				async function() {
 					const securePaymentComponent = new SecurePaymentComponent( driver );
-					await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
-					await securePaymentComponent.submitPaymentDetails();
-					await securePaymentComponent.waitForCreditCardPaymentProcessing();
-					return await securePaymentComponent.waitForPageToDisappear();
+					const domainInCart = await securePaymentComponent.cartContainsProduct(
+						dotLiveDomainSlug
+					);
+					assert.equal( domainInCart, true, "The cart doesn't contain the .live domain product" );
+					const privateWhoISInCart = await securePaymentComponent.cartContainsProduct(
+						privateWhoisSlug
+					);
+					assert.equal(
+						privateWhoISInCart,
+						true,
+						"The cart doesn't contain the private domain product"
+					);
+					const businessPlanInCart = await securePaymentComponent.cartContainsProduct(
+						businessPlanSlug
+					);
+					assert.equal(
+						businessPlanInCart,
+						true,
+						"The cart doesn't contain the business plan product"
+					);
+					const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
+					return assert.equal(
+						numberOfProductsInCart,
+						3,
+						"The cart doesn't contain the expected number of products"
+					);
 				}
 			);
+
+			test.it( 'Can enter/submit test payment details', async function() {
+				const securePaymentComponent = new SecurePaymentComponent( driver );
+				await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
+				await securePaymentComponent.submitPaymentDetails();
+				await securePaymentComponent.waitForCreditCardPaymentProcessing();
+				return await securePaymentComponent.waitForPageToDisappear();
+			} );
 
 			test.it( 'Can see the gsuite upsell page', async function() {
 				return await new GSuiteUpsellPage( driver ).declineEmail();

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -49,6 +49,7 @@ const screenSize = driverManager.currentScreenSize();
 const signupInboxId = config.get( 'signupInboxId' );
 const host = dataHelper.getJetpackHost();
 const locale = driverManager.currentLocale();
+const premiumPlanSlug = 'value_bundle';
 
 let driver;
 
@@ -287,12 +288,23 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				}
 			);
 
-			test.it( 'Can then see the secure payment page', async function() {
-				const securePaymentComponent = new SecurePaymentComponent( driver );
-				let displayed = await securePaymentComponent.displayed();
-				await eyesHelper.eyesScreenshot( driver, eyes, 'Secure Payment Page' );
-				return assert.equal( displayed, true, 'The secure payment page is not displayed' );
-			} );
+			test.it(
+				'Can then see the secure payment page with the premium plan in the cart',
+				async function() {
+					const securePaymentComponent = new SecurePaymentComponent( driver );
+					await eyesHelper.eyesScreenshot( driver, eyes, 'Secure Payment Page' );
+					const premiumPlanInCart = await securePaymentComponent.cartContainsProduct(
+						premiumPlanSlug
+					);
+					assert.equal( premiumPlanInCart, true, "The cart doesn't contain the premium plan" );
+					const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
+					assert.equal(
+						numberOfProductsInCart,
+						1,
+						"The cart doesn't contain the expected number of products"
+					);
+				}
+			);
 
 			test.it( 'Can enter and submit test payment details', async function() {
 				const testCreditCardDetails = dataHelper.getTestCreditCardDetails();


### PR DESCRIPTION
- Adds validation to cart contents on signup to make sure correct products are present
- Adds a variety of currencies (USD, GBP, EUR, CAD, AUD & JPY) to existing sign up specs
- Adds a new scenario for a personal plan signup which was missing from coverage