### PR TITLE
Remove Upgrade Pricing Display A/B test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -61,7 +61,6 @@
     "skipThemesSelectionModal",
     "checklistThankYouForFreeUser",
     "checklistThankYouForPaidUser",
-    "upgradePricingDisplayV3",
     "redesignedSidebarBanner",
     "mobilePlansTablesOnSignup",
     "springSale30PercentOff",
@@ -69,7 +68,6 @@
     "multiyearSubscriptions"
   ],
   "overrideABTests": [
-    [ "upgradePricingDisplayV3_20180402", "original" ],
     [ "skipThemesSelectionModal_20170904", "show" ],
     [ "checklistThankYouForFreeUser_20171204", "hide" ],
     [ "checklistThankYouForPaidUser_20171204", "hide" ],


### PR DESCRIPTION
This PR will remove the configuration related to the upgrade pricing display test that is going to be closed soon.
https://github.com/Automattic/wp-calypso/pull/24624