### PR TITLE
Remove money back guarantee test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -65,7 +65,6 @@
     "redesignedSidebarBanner",
     "mobilePlansTablesOnSignup",
     "springSale30PercentOff",
-    "showMoneyBackGuarantee",
     "multiyearSubscriptions"
   ],
   "overrideABTests": [
@@ -77,7 +76,6 @@
     [ "businessPlanDescriptionAT_20170605", "original" ],
     [ "mobilePlansTablesOnSignup_20180330", "original" ],
     [ "springSale30PercentOff_20180413", "control" ],
-    [ "showMoneyBackGuarantee_20180409", "no" ],
     [ "multiyearSubscriptions_20180417", "hide" ]
   ]
 }


### PR DESCRIPTION
removed in https://github.com/Automattic/wp-calypso/pull/24607

This time with a branch, apologies for the original direct commit to `master` that I reverted.