### PR TITLE
[Domains] Add support for price strikethrough test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -66,7 +66,8 @@
     "mobilePlansTablesOnSignup",
     "springSale30PercentOff",
     "showMoneyBackGuarantee",
-    "multiyearSubscriptions"
+    "multiyearSubscriptions",
+    "signupDomainStrikethruPrice"
   ],
   "overrideABTests": [
     [ "upgradePricingDisplayV3_20180402", "original" ],
@@ -78,6 +79,7 @@
     [ "mobilePlansTablesOnSignup_20180330", "original" ],
     [ "springSale30PercentOff_20180413", "control" ],
     [ "showMoneyBackGuarantee_20180409", "no" ],
-    [ "multiyearSubscriptions_20180417", "hide" ]
+    [ "multiyearSubscriptions_20180417", "hide" ],
+    [ "signupDomainStrikethruPrice_20180504", "disabled" ]
   ]
 }


### PR DESCRIPTION
This adds support for Automattic/wp-calypso/pull/24608, which adds support for strikethrough domain name prices like so:

<img width="978" alt="Wordpress.com" src="https://user-images.githubusercontent.com/4044428/39535936-6b6f0d2a-4df2-11e8-943a-f52aff2e5020.png">

The A/B test is scheduled to begin this Friday (05/04).