### PR TITLE
[Domains] Tweak start date for strikethrough test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -80,6 +80,6 @@
     [ "springSale30PercentOff_20180413", "control" ],
     [ "showMoneyBackGuarantee_20180409", "no" ],
     [ "multiyearSubscriptions_20180417", "hide" ],
-    [ "signupDomainStrikethruPrice_20180504", "disabled" ]
+    [ "signupDomainStrikethruPrice_20180507", "disabled" ]
   ]
 }


### PR DESCRIPTION
This changes the A/B test start date to 2018-05-07 from 2018-05-04. Corresponding Calypso PR is Automattic/wp-calypso/pull/24670.