### PR TITLE
Fix failing invite tests

### DIFF
--- a/lib/pages/edit-team-member-page.js
+++ b/lib/pages/edit-team-member-page.js
@@ -1,6 +1,6 @@
 /** @format */
 
-import { By, until } from 'selenium-webdriver';
+import { By } from 'selenium-webdriver';
 import BaseContainer from '../base-container.js';
 
 import * as DriverHelper from '../driver-helper.js';
@@ -24,16 +24,21 @@ export default class EditTeamMemberPage extends BaseContainer {
 	}
 
 	changeToNewRole( roleName ) {
+		// Work out why we need to do this twice
+		// https://github.com/Automattic/wp-e2e-tests/issues/1185
 		DriverHelper.clickWhenClickable(
 			this.driver,
 			By.css( `select#roles option[value=${ roleName }]` )
 		);
-		DriverHelper.clickWhenClickable( this.driver, By.css( 'button.form-button.is-primary' ) );
-		return this.driver.wait(
-			until.elementLocated( By.css( '.is-success' ) ),
-			this.explicitWaitMS,
-			'Could not locate the success message'
+		DriverHelper.clickWhenClickable(
+			this.driver,
+			By.css( `select#roles option[value=${ roleName }]` )
 		);
+		DriverHelper.clickWhenClickable(
+			this.driver,
+			By.css( 'button.form-button.is-primary:not([disabled])' )
+		);
+		return DriverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.is-success' ) );
 	}
 
 	successNoticeDisplayed() {

--- a/lib/pages/invite-people-page.js
+++ b/lib/pages/invite-people-page.js
@@ -1,6 +1,6 @@
 /** @format */
 
-import { By, until } from 'selenium-webdriver';
+import { By } from 'selenium-webdriver';
 import BaseContainer from '../base-container.js';
 
 import SidebarComponent from '../components/sidebar-component.js';
@@ -11,60 +11,27 @@ import * as DriverHelper from '../driver-helper.js';
 export default class InvitePeoplePage extends BaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( 'select#role' ) );
-		this.sendButtonSelector = By.css( 'button.button.is-primary' );
-		this.noticeSelector = By.css( '.notice__text' );
 	}
 
 	inviteNewUser( email, role, message = '' ) {
-		const self = this;
-
 		if ( role === 'viewer' ) {
 			role = 'follower'; //the select input option uses follower for viewer
 		}
 
-		DriverHelper.setWhenSettable( self.driver, By.css( 'input.token-field__input' ), email );
-		DriverHelper.clickWhenClickable( self.driver, By.css( `select#role option[value=${ role }]` ) );
-		DriverHelper.setWhenSettable( self.driver, By.css( '#message' ), message );
+		const roleSelector = By.css( `select#role option[value=${ role }]` );
 
-		self.driver.wait(
-			function() {
-				return self.driver
-					.findElement( self.sendButtonSelector )
-					.getAttribute( 'disabled' )
-					.then( d => {
-						return d !== 'true';
-					} );
-			},
-			this.explicitWaitMS,
-			'The send invite button is still disabled after entering invitation details'
+		DriverHelper.setWhenSettable( this.driver, By.css( 'input.token-field__input' ), email );
+		DriverHelper.waitTillPresentAndDisplayed( this.driver, roleSelector );
+		DriverHelper.clickWhenClickable( this.driver, roleSelector );
+		DriverHelper.setWhenSettable( this.driver, By.css( '#message' ), message );
+		return DriverHelper.clickWhenClickable(
+			this.driver,
+			By.css( 'button.button.is-primary:not([disabled])' )
 		);
-
-		return DriverHelper.clickWhenClickable( self.driver, self.sendButtonSelector );
 	}
 
 	inviteSent() {
-		const self = this;
-
-		self.driver.wait(
-			function() {
-				return self.driver
-					.findElement( self.sendButtonSelector )
-					.getAttribute( 'disabled' )
-					.then( d => {
-						return d === 'true';
-					} );
-			},
-			this.explicitWaitMS,
-			'The send invite button is not disabled after sending the invitation'
-		);
-
-		self.driver.wait(
-			until.elementLocated( self.noticeSelector ),
-			this.explicitWaitMS * 2,
-			'The notice was not displayed'
-		);
-
-		return DriverHelper.isElementPresent( self.driver, self.noticeSelector );
+		return DriverHelper.isEventuallyPresentAndDisplayed( this.driver, By.css( '.notice__text' ) );
 	}
 
 	backToPeopleMenu() {

--- a/lib/pages/people-page.js
+++ b/lib/pages/people-page.js
@@ -14,8 +14,12 @@ export default class PeoplePage extends BaseContainer {
 		this.searchResultsLoadingSelector = By.css( '.people-profile.is-placeholder' );
 		this.peopleListItemSelector = By.css( '.people-list-item' );
 		this.successNoticeSelector = By.css( '.people-notices__notice.notice.is-success' );
-		this.mostRecentPendingInviteSelector = By.css( '.people-invites__pending .is-card-link:nth-of-type(1) .people-profile__username' );
-		this.goToRevokeInvitePageSelector = By.css( '.people-invites__pending .is-card-link:nth-of-type(1) .gridicons-chevron-right' );
+		this.mostRecentPendingInviteSelector = By.css(
+			'.people-invites__pending .is-card-link:nth-of-type(1) .people-profile__username'
+		);
+		this.goToRevokeInvitePageSelector = By.css(
+			'.people-invites__pending .is-card-link:nth-of-type(1) .gridicons-chevron-right'
+		);
 	}
 
 	selectTeam() {
@@ -210,7 +214,7 @@ export default class PeoplePage extends BaseContainer {
 	}
 
 	successNoticeDisplayed() {
-		return DriverHelper.isElementPresent( this.driver, this.successNoticeSelector );
+		return DriverHelper.isEventuallyPresentAndDisplayed( this.driver, this.successNoticeSelector );
 	}
 
 	inviteUser() {
@@ -221,6 +225,7 @@ export default class PeoplePage extends BaseContainer {
 	}
 
 	getMostRecentPendingInviteEmail() {
+		DriverHelper.waitTillPresentAndDisplayed( this.driver, this.mostRecentPendingInviteSelector );
 		return this.driver.findElement( this.mostRecentPendingInviteSelector ).getText();
 	}
 

--- a/lib/pages/people-page.js
+++ b/lib/pages/people-page.js
@@ -14,12 +14,6 @@ export default class PeoplePage extends BaseContainer {
 		this.searchResultsLoadingSelector = By.css( '.people-profile.is-placeholder' );
 		this.peopleListItemSelector = By.css( '.people-list-item' );
 		this.successNoticeSelector = By.css( '.people-notices__notice.notice.is-success' );
-		this.mostRecentPendingInviteSelector = By.css(
-			'.people-invites__pending .is-card-link:nth-of-type(1) .people-profile__username'
-		);
-		this.goToRevokeInvitePageSelector = By.css(
-			'.people-invites__pending .is-card-link:nth-of-type(1) .gridicons-chevron-right'
-		);
 	}
 
 	selectTeam() {
@@ -224,12 +218,17 @@ export default class PeoplePage extends BaseContainer {
 		);
 	}
 
-	getMostRecentPendingInviteEmail() {
-		DriverHelper.waitTillPresentAndDisplayed( this.driver, this.mostRecentPendingInviteSelector );
-		return this.driver.findElement( this.mostRecentPendingInviteSelector ).getText();
+	pendingInviteDisplayedFor( emailAddress ) {
+		return DriverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			By.css( `.people-invites__pending .people-profile__username[title="${ emailAddress }"]` )
+		);
 	}
 
-	goToRevokeInvitePage() {
-		return DriverHelper.clickWhenClickable( this.driver, this.goToRevokeInvitePageSelector );
+	goToRevokeInvitePage( emailAddress ) {
+		return DriverHelper.clickWhenClickable(
+			this.driver,
+			By.css( `.people-invites__pending .people-profile__username[title="${ emailAddress }"]` )
+		);
 	}
 }

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -103,11 +103,13 @@ testDescribe( `[${ host }] Invites:  (${ screenSize })`, function() {
 
 				this.peoplePage = new PeoplePage( driver );
 				await this.peoplePage.selectInvites();
-				let mostRecentPendingInviteEmail = await this.peoplePage.getMostRecentPendingInviteEmail();
+				let pendingInviteDisplayedForEmail = await this.peoplePage.pendingInviteDisplayedFor(
+					newInviteEmailAddress
+				);
 				return assert.equal(
-					mostRecentPendingInviteEmail,
-					newInviteEmailAddress,
-					'The email address on the pending invite does not match the latest invite sent'
+					pendingInviteDisplayedForEmail,
+					true,
+					`Could not locate a pending invite for the email address '${ newInviteEmailAddress }'`
 				);
 			} );
 
@@ -271,68 +273,70 @@ testDescribe( `[${ host }] Invites:  (${ screenSize })`, function() {
 		} );
 	} );
 
-	test.describe( 'Inviting New User as an Editor And Revoke Invite: @parallel @jetpack', function() {
-		this.bailSuite( true );
-		const inviteInboxId = config.get( 'inviteInboxId' );
-		const newUserName = 'e2eflowtestingeditor' + new Date().getTime().toString();
-		const newInviteEmailAddress = dataHelper.getEmailAddress( newUserName, inviteInboxId );
-		let acceptInviteURL = '';
+	test.describe(
+		'Inviting New User as an Editor And Revoke Invite: @parallel @jetpack',
+		function() {
+			this.bailSuite( true );
+			const inviteInboxId = config.get( 'inviteInboxId' );
+			const newUserName = 'e2eflowtestingeditor' + new Date().getTime().toString();
+			const newInviteEmailAddress = dataHelper.getEmailAddress( newUserName, inviteInboxId );
+			let acceptInviteURL = '';
 
-		test.before( async function() {
-			await driverManager.clearCookiesAndDeleteLocalStorage( driver );
-		} );
-
-		test.describe( 'Can Invite a New User as an Editor, then revoke the invite', function() {
-			// Can log in and select People
 			test.before( async function() {
-				this.loginFlow = new LoginFlow( driver );
-				await this.loginFlow.loginAndSelectPeople();
-				this.peoplePage = new PeoplePage( driver );
-				let displayed = await this.peoplePage.displayed();
-				return assert.equal( displayed, true, 'The people page is not displayed' );
+				await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 			} );
 
-			test.it(
-				'Can choose invite user on People page which shows the Invite People page',
-				async function() {
+			test.describe( 'Can Invite a New User as an Editor, then revoke the invite', function() {
+				// Can log in and select People
+				test.before( async function() {
+					this.loginFlow = new LoginFlow( driver );
+					await this.loginFlow.loginAndSelectPeople();
 					this.peoplePage = new PeoplePage( driver );
-					await this.peoplePage.inviteUser();
-					this.invitePeoplePage = new InvitePeoplePage( driver );
-					let displayed = await this.invitePeoplePage.displayed();
-					return assert.equal( displayed, true, 'The invite people page is not displayed' );
-				}
-			);
+					let displayed = await this.peoplePage.displayed();
+					return assert.equal( displayed, true, 'The people page is not displayed' );
+				} );
 
-			test.it( 'Can invite a new user as an editor', async function() {
-				return await this.invitePeoplePage.inviteNewUser(
-					newInviteEmailAddress,
-					'editor',
-					'Automated e2e testing'
+				test.it(
+					'Can choose invite user on People page which shows the Invite People page',
+					async function() {
+						this.peoplePage = new PeoplePage( driver );
+						await this.peoplePage.inviteUser();
+						this.invitePeoplePage = new InvitePeoplePage( driver );
+						let displayed = await this.invitePeoplePage.displayed();
+						return assert.equal( displayed, true, 'The invite people page is not displayed' );
+					}
 				);
-			} );
 
-			test.it( 'Sends an invite', async function() {
-				let sent = await this.invitePeoplePage.inviteSent();
-				return assert.equal( sent, true, 'The sent confirmation message was not displayed' );
-			} );
+				test.it( 'Can invite a new user as an editor', async function() {
+					return await this.invitePeoplePage.inviteNewUser(
+						newInviteEmailAddress,
+						'editor',
+						'Automated e2e testing'
+					);
+				} );
 
-			test.it( 'Can see pending invite', async function() {
-				await this.invitePeoplePage.backToPeopleMenu();
+				test.it( 'Sends an invite', async function() {
+					let sent = await this.invitePeoplePage.inviteSent();
+					return assert.equal( sent, true, 'The sent confirmation message was not displayed' );
+				} );
 
-				this.peoplePage = new PeoplePage( driver );
-				await this.peoplePage.selectInvites();
-				let mostRecentPendingInviteEmail = await this.peoplePage.getMostRecentPendingInviteEmail();
-				return assert.equal(
-					mostRecentPendingInviteEmail,
-					newInviteEmailAddress,
-					'The email address on the pending invite does not match the latest invite sent'
-				);
-			} );
+				test.it( 'Can see pending invite', async function() {
+					await this.invitePeoplePage.backToPeopleMenu();
 
-			test.it(
-				'Can revoke the pending invite',
-				async function() {
-					await this.peoplePage.goToRevokeInvitePage();
+					this.peoplePage = new PeoplePage( driver );
+					await this.peoplePage.selectInvites();
+					let pendingInviteDisplayedForEmail = await this.peoplePage.pendingInviteDisplayedFor(
+						newInviteEmailAddress
+					);
+					return assert.equal(
+						pendingInviteDisplayedForEmail,
+						true,
+						`Could not locate a pending invite for the email address '${ newInviteEmailAddress }'`
+					);
+				} );
+
+				test.it( 'Can revoke the pending invite', async function() {
+					await this.peoplePage.goToRevokeInvitePage( newInviteEmailAddress );
 					this.revokePage = new RevokePage( driver );
 					await this.revokePage.revokeUser();
 
@@ -340,58 +344,60 @@ testDescribe( `[${ host }] Invites:  (${ screenSize })`, function() {
 					return assert.equal( sent, true, 'The sent confirmation message was not displayed' );
 				} );
 
-			test.describe( 'Can see an invitation email received for the invite', function() {
-				test.before( function() {
-					this.emailClient = new EmailClient( inviteInboxId );
-				} );
+				test.describe( 'Can see an invitation email received for the invite', function() {
+					test.before( function() {
+						this.emailClient = new EmailClient( inviteInboxId );
+					} );
 
-				test.it( 'Can see a single confirmation message', async function() {
-					let emails = await this.emailClient.pollEmailsByRecipient( newInviteEmailAddress );
-					return assert.equal( emails.length, 1, 'The number of invite emails is not equal to 1' );
-				} );
+					test.it( 'Can see a single confirmation message', async function() {
+						let emails = await this.emailClient.pollEmailsByRecipient( newInviteEmailAddress );
+						return assert.equal(
+							emails.length,
+							1,
+							'The number of invite emails is not equal to 1'
+						);
+					} );
 
-				test.it( 'Can capture the Accept Invite link from the email', async function() {
-					let emails = await this.emailClient.pollEmailsByRecipient( newInviteEmailAddress );
-					let links = emails[ 0 ].html.links;
-					for ( let link of links ) {
-						if ( link.href.includes( 'accept-invite' ) ) {
-							acceptInviteURL = dataHelper.adjustInviteLinkToCorrectEnvironment( link.href );
+					test.it( 'Can capture the Accept Invite link from the email', async function() {
+						let emails = await this.emailClient.pollEmailsByRecipient( newInviteEmailAddress );
+						let links = emails[ 0 ].html.links;
+						for ( let link of links ) {
+							if ( link.href.includes( 'accept-invite' ) ) {
+								acceptInviteURL = dataHelper.adjustInviteLinkToCorrectEnvironment( link.href );
+							}
 						}
-					}
-					return assert.notEqual(
-						acceptInviteURL,
-						'',
-						'Could not locate the accept invite URL in the invite email'
-					);
-				} );
-
-				test.describe( 'Can open the invite page and see it has been revoked', function() {
-					test.before( async function() {
-						await driverManager.ensureNotLoggedIn( driver );
+						return assert.notEqual(
+							acceptInviteURL,
+							'',
+							'Could not locate the accept invite URL in the invite email'
+						);
 					} );
 
-					test.it( 'Can visit invite link', async function() {
-						await driver.get( acceptInviteURL );
-						this.acceptInvitePage = new AcceptInvitePage( driver );
-					} );
+					test.describe( 'Can open the invite page and see it has been revoked', function() {
+						test.before( async function() {
+							await driverManager.ensureNotLoggedIn( driver );
+						} );
 
-					test.describe( 'Can see the page that indicates the invite has been revoked', function() {
-						test.it(
-							'Can see the revoked invite error',
-							async function() {
-								this.inviteErrorPage = new InviteErrorPage( driver );
-								let displayed = await this.inviteErrorPage.inviteErrorTitleDisplayed();
-								assert.equal(
-										displayed,
-										true,
-										'The invite was not successfully revoked'
-									);
-							} );
+						test.it( 'Can visit invite link', async function() {
+							await driver.get( acceptInviteURL );
+							this.acceptInvitePage = new AcceptInvitePage( driver );
+						} );
+
+						test.describe(
+							'Can see the page that indicates the invite has been revoked',
+							function() {
+								test.it( 'Can see the revoked invite error', async function() {
+									this.inviteErrorPage = new InviteErrorPage( driver );
+									let displayed = await this.inviteErrorPage.inviteErrorTitleDisplayed();
+									assert.equal( displayed, true, 'The invite was not successfully revoked' );
+								} );
+							}
+						);
 					} );
 				} );
 			} );
-		} );
-	} );
+		}
+	);
 
 	test.xdescribe( 'Inviting New User as a Follower: @parallel @jetpack', function() {
 		this.bailSuite( true );
@@ -437,11 +443,13 @@ testDescribe( `[${ host }] Invites:  (${ screenSize })`, function() {
 
 					this.peoplePage = new PeoplePage( driver );
 					await this.peoplePage.selectInvites();
-					let mostRecentPendingInviteEmail = await this.peoplePage.getMostRecentPendingInviteEmail();
+					let pendingInviteDisplayedForEmail = await this.peoplePage.pendingInviteDisplayedFor(
+						newInviteEmailAddress
+					);
 					return assert.equal(
-						mostRecentPendingInviteEmail,
-						newInviteEmailAddress,
-						'The email address on the pending invite does not match the latest invite sent'
+						pendingInviteDisplayedForEmail,
+						true,
+						`Could not locate a pending invite for the email address '${ newInviteEmailAddress }'`
 					);
 				} );
 
@@ -659,11 +667,13 @@ testDescribe( `[${ host }] Invites:  (${ screenSize })`, function() {
 
 							this.peoplePage = new PeoplePage( driver );
 							await this.peoplePage.selectInvites();
-							let mostRecentPendingInviteEmail = await this.peoplePage.getMostRecentPendingInviteEmail();
+							let pendingInviteDisplayedForEmail = await this.peoplePage.pendingInviteDisplayedFor(
+								newInviteEmailAddress
+							);
 							return assert.equal(
-								mostRecentPendingInviteEmail,
-								newInviteEmailAddress,
-								'The email address on the pending invite does not match the latest invite sent'
+								pendingInviteDisplayedForEmail,
+								true,
+								`Could not locate a pending invite for the email address '${ newInviteEmailAddress }'`
 							);
 						} );
 
@@ -916,11 +926,13 @@ testDescribe( `[${ host }] Invites:  (${ screenSize })`, function() {
 
 							this.peoplePage = new PeoplePage( driver );
 							await this.peoplePage.selectInvites();
-							let mostRecentPendingInviteEmail = await this.peoplePage.getMostRecentPendingInviteEmail();
+							let pendingInviteDisplayedForEmail = await this.peoplePage.pendingInviteDisplayedFor(
+								newInviteEmailAddress
+							);
 							return assert.equal(
-								mostRecentPendingInviteEmail,
-								newInviteEmailAddress,
-								'The email address on the pending invite does not match the latest invite sent'
+								pendingInviteDisplayedForEmail,
+								true,
+								`Could not locate a pending invite for the email address '${ newInviteEmailAddress }'`
 							);
 						} );
 


### PR DESCRIPTION
This should fix the failing invite tests

A few issues here:
1. Invites were being revoked by being first on list of pending which doesn't work as we use shared accounts and parallel runs - now revokes specifically by email address
2. A workaround for #1185 - I really don't know why that is necessary but don't have hours to investigate right now