### PR TITLE
Add payment button front end verification

### DIFF
--- a/lib/components/payment-button-front-end-component.js
+++ b/lib/components/payment-button-front-end-component.js
@@ -10,7 +10,7 @@ export default class PaymentButtonFrontEndComponent extends BaseContainer {
 		super( driver, by.css( '.jetpack-simple-payments-wrapper' ) );
 	}
 
-	clickPaymentButton() {
+	async clickPaymentButton() {
 		const payPalPayButtonSelector = by.css( '.paypal-button' );
 		this.driver.wait(
 			until.ableToSwitchToFrame( by.css( '.jetpack-simple-payments-button iframe' ) ),

--- a/lib/components/payment-button-front-end-component.js
+++ b/lib/components/payment-button-front-end-component.js
@@ -13,7 +13,7 @@ export default class PaymentButtonFrontEndComponent extends BaseContainer {
 	async clickPaymentButton() {
 		const payPalPayButtonSelector = by.css( '.paypal-button' );
 		this.driver.wait(
-			until.ableToSwitchToFrame( by.css( '.jetpack-simple-payments-button iframe' ) ),
+			until.ableToSwitchToFrame( by.css( '.xcomponent-component-frame' ) ),
 			this.explicitWaitMS,
 			'Could not locate the payment button iFrame.'
 		);

--- a/lib/components/payment-button-front-end-component.js
+++ b/lib/components/payment-button-front-end-component.js
@@ -10,7 +10,7 @@ export default class PaymentButtonFrontEndComponent extends BaseContainer {
 		super( driver, by.css( '.jetpack-simple-payments-wrapper' ) );
 	}
 
-	async clickPaymentButton() {
+	clickPaymentButton() {
 		const payPalPayButtonSelector = by.css( '.paypal-button' );
 		this.driver.wait(
 			until.ableToSwitchToFrame( by.css( '.jetpack-simple-payments-button iframe' ) ),

--- a/lib/components/payment-button-front-end-component.js
+++ b/lib/components/payment-button-front-end-component.js
@@ -1,0 +1,24 @@
+/** @format */
+
+import { By as by, until } from 'selenium-webdriver';
+import * as driverHelper from '../driver-helper.js';
+
+import BaseContainer from '../base-container.js';
+
+export default class PaymentButtonFrontEndComponent extends BaseContainer {
+	constructor( driver ) {
+		super( driver, by.css( '.jetpack-simple-payments-wrapper' ) );
+	}
+
+	async clickPaymentButton() {
+		const payPalPayButtonSelector = by.css( '.paypal-button' );
+		this.driver.wait(
+			until.ableToSwitchToFrame( by.css( '.jetpack-simple-payments-button iframe' ) ),
+			this.explicitWaitMS,
+			'Could not locate the payment button iFrame.'
+		);
+		driverHelper.waitTillPresentAndDisplayed( this.driver, payPalPayButtonSelector );
+		driverHelper.clickWhenClickable( this.driver, payPalPayButtonSelector );
+		return this.driver.switchTo().defaultContent();
+	}
+}

--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -387,21 +387,31 @@ export function waitForInfiniteListLoad( driver, elementSelector, { numElements 
 	} );
 }
 
-export function switchToWindow( driver, windowNunber ) {
-	driver.getAllWindowHandles().then( result => {
-		driver
-			.switchTo()
-			.window( result[ windowNunber ] )
-			.then( () => {
-				return true;
-			} );
+export function switchToWindowByIndex( driver, index ) {
+	return driver.getAllWindowHandles().then( handles => {
+		return driver.switchTo().window( handles[ index ] );
+	} );
+}
+export function numberOfOpenWindows( driver ) {
+	return driver.getAllWindowHandles().then( handles => {
+		return handles.length;
 	} );
 }
 
 export function closeCurrentWindow( driver ) {
-	driver.close().then( () => {
-		return true;
+	return driver.close();
+}
+
+export function ensurePopupsClosed( driver ) {
+	numberOfOpenWindows( driver ).then( numWindows => {
+		let windowIndex;
+		for ( windowIndex = 1; windowIndex < numWindows; windowIndex++ ) {
+			switchToWindowByIndex( driver, windowIndex ).then( () => {
+				closeCurrentWindow( driver );
+			} );
+		}
 	} );
+	return switchToWindowByIndex( driver, 0 );
 }
 
 export function refreshIfJNError( driver, timeout = 2000 ) {

--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -398,6 +398,20 @@ export function numberOfOpenWindows( driver ) {
 	} );
 }
 
+export function waitForNumberOfWindows( driver, numberWindows, waitOverride ) {
+	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
+
+	return driver.wait(
+		function() {
+			return driver.getAllWindowHandles().then( handles => {
+				return handles.length === numberWindows;
+			} );
+		},
+		timeoutWait,
+		`Timed out waiting for ${ numberWindows } browser windows`
+	);
+}
+
 export function closeCurrentWindow( driver ) {
 	return driver.close();
 }

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -294,7 +294,9 @@ export default class EditorPage extends BaseContainer {
 				by.css( '.editor-simple-payments-modal__form .form-toggle__switch' )
 			);
 		}
-		eyesHelper.eyesScreenshot( this.driver, eyes, 'Create New Payment Button' );
+		if ( eyes ) {
+			eyesHelper.eyesScreenshot( this.driver, eyes, 'Create New Payment Button' );
+		}
 		return driverHelper.clickWhenClickable(
 			this.driver,
 			by.css( '.editor-simple-payments-modal button.is-primary' )

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -245,6 +245,7 @@ export default class EditorPage extends BaseContainer {
 			title = 'Button',
 			description = 'Description',
 			price = '1.00',
+			currency = 'AUD',
 			allowQuantity = true,
 			email = 'test@wordpress.com',
 		} = {}
@@ -273,6 +274,12 @@ export default class EditorPage extends BaseContainer {
 			this.driver,
 			by.css( '.editor-simple-payments-modal__form #price' ),
 			price
+		);
+		driverHelper.clickWhenClickable(
+			this.driver,
+			by.css(
+				`.editor-simple-payments-modal__form .form-currency-input__select option[value="${ currency }"]`
+			)
 		);
 		if ( email ) {
 			driverHelper.setWhenSettable(

--- a/lib/pages/external/paypal-checkout-page.js
+++ b/lib/pages/external/paypal-checkout-page.js
@@ -1,0 +1,18 @@
+/** @format */
+
+import { By as by } from 'selenium-webdriver';
+import BaseContainer from '../../base-container.js';
+import * as driverHelper from '../../driver-helper';
+
+export default class PaypalCheckoutPage extends BaseContainer {
+	constructor( driver ) {
+		const priceSelector = by.css( '.formatCurrency' );
+		super( driver, priceSelector );
+		this.priceSelector = priceSelector;
+	}
+
+	priceDisplayed() {
+		driverHelper.waitTillPresentAndDisplayed( this.driver, this.priceSelector );
+		return this.driver.findElement( this.priceSelector ).getText();
+	}
+}

--- a/lib/pages/view-page-page.js
+++ b/lib/pages/view-page-page.js
@@ -61,11 +61,11 @@ export default class ViewPagePage extends BaseContainer {
 			} );
 	}
 
-	async paymentButtonDisplayed() {
+	paymentButtonDisplayed() {
 		return new PaymentButtonFrontEndComponent( this.driver ).displayed();
 	}
 
-	async clickPaymentButton() {
+	clickPaymentButton() {
 		return new PaymentButtonFrontEndComponent( this.driver ).clickPaymentButton();
 	}
 }

--- a/lib/pages/view-page-page.js
+++ b/lib/pages/view-page-page.js
@@ -3,6 +3,7 @@
 import { By } from 'selenium-webdriver';
 
 import BaseContainer from '../base-container.js';
+import PaymentButtonFrontEndComponent from '../components/payment-button-front-end-component';
 
 import * as driverHelper from '../driver-helper.js';
 
@@ -58,5 +59,13 @@ export default class ViewPagePage extends BaseContainer {
 			.then( imageElement => {
 				return driverHelper.imageVisible( this.driver, imageElement );
 			} );
+	}
+
+	async paymentButtonDisplayed() {
+		return new PaymentButtonFrontEndComponent( this.driver ).displayed();
+	}
+
+	async clickPaymentButton() {
+		return new PaymentButtonFrontEndComponent( this.driver ).clickPaymentButton();
 	}
 }

--- a/lib/pages/view-post-page.js
+++ b/lib/pages/view-post-page.js
@@ -5,6 +5,7 @@ import { By, until } from 'selenium-webdriver';
 import BaseContainer from '../base-container';
 
 import * as driverHelper from '../driver-helper';
+import PaymentButtonFrontEndComponent from '../components/payment-button-front-end-component';
 
 export default class ViewPostPage extends BaseContainer {
 	constructor( driver ) {
@@ -41,23 +42,12 @@ export default class ViewPostPage extends BaseContainer {
 		return driverHelper.isElementPresent( this.driver, By.css( '.contact-form' ) );
 	}
 
-	paymentButtonDisplayed() {
-		return driverHelper.isElementPresent(
-			this.driver,
-			By.css( '.jetpack-simple-payments-wrapper' )
-		);
+	async paymentButtonDisplayed() {
+		return new PaymentButtonFrontEndComponent( this.driver ).displayed();
 	}
 
-	clickPaymentButton() {
-		const payPalPayButtonSelector = By.css( '.paypal-button' );
-		this.driver.wait(
-			until.ableToSwitchToFrame( By.css( '.jetpack-simple-payments-button iframe' ) ),
-			this.explicitWaitMS,
-			'Could not locate the payment button iFrame.'
-		);
-		driverHelper.waitTillPresentAndDisplayed( this.driver, payPalPayButtonSelector );
-		driverHelper.clickWhenClickable( this.driver, payPalPayButtonSelector );
-		return this.driver.switchTo().defaultContent();
+	async clickPaymentButton() {
+		return new PaymentButtonFrontEndComponent( this.driver ).clickPaymentButton();
 	}
 
 	isPasswordProtected() {

--- a/lib/pages/view-post-page.js
+++ b/lib/pages/view-post-page.js
@@ -42,11 +42,11 @@ export default class ViewPostPage extends BaseContainer {
 		return driverHelper.isElementPresent( this.driver, By.css( '.contact-form' ) );
 	}
 
-	async paymentButtonDisplayed() {
+	paymentButtonDisplayed() {
 		return new PaymentButtonFrontEndComponent( this.driver ).displayed();
 	}
 
-	async clickPaymentButton() {
+	clickPaymentButton() {
 		return new PaymentButtonFrontEndComponent( this.driver ).clickPaymentButton();
 	}
 

--- a/lib/pages/view-post-page.js
+++ b/lib/pages/view-post-page.js
@@ -48,6 +48,18 @@ export default class ViewPostPage extends BaseContainer {
 		);
 	}
 
+	clickPaymentButton() {
+		const payPalPayButtonSelector = By.css( '.paypal-button' );
+		this.driver.wait(
+			until.ableToSwitchToFrame( By.css( '.jetpack-simple-payments-button iframe' ) ),
+			this.explicitWaitMS,
+			'Could not locate the payment button iFrame.'
+		);
+		driverHelper.waitTillPresentAndDisplayed( this.driver, payPalPayButtonSelector );
+		driverHelper.clickWhenClickable( this.driver, payPalPayButtonSelector );
+		return this.driver.switchTo().defaultContent();
+	}
+
 	isPasswordProtected() {
 		return driverHelper.isElementPresent( this.driver, By.css( 'form.post-password-form' ) );
 	}

--- a/lib/pages/view-post-page.js
+++ b/lib/pages/view-post-page.js
@@ -42,12 +42,12 @@ export default class ViewPostPage extends BaseContainer {
 		return driverHelper.isElementPresent( this.driver, By.css( '.contact-form' ) );
 	}
 
-	paymentButtonDisplayed() {
-		return new PaymentButtonFrontEndComponent( this.driver ).displayed();
+	async paymentButtonDisplayed() {
+		return await new PaymentButtonFrontEndComponent( this.driver ).displayed();
 	}
 
-	clickPaymentButton() {
-		return new PaymentButtonFrontEndComponent( this.driver ).clickPaymentButton();
+	async clickPaymentButton() {
+		return await new PaymentButtonFrontEndComponent( this.driver ).clickPaymentButton();
 	}
 
 	isPasswordProtected() {

--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -642,12 +642,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				);
 				let viewPagePage = new ViewPagePage( driver );
 				await viewPagePage.clickPaymentButton();
-				numberOfOpenBrowserWindows = await driverHelper.numberOfOpenWindows( driver );
-				assert.equal(
-					numberOfOpenBrowserWindows,
-					2,
-					'There are not two open browser windows after clicking the payment button'
-				);
+				await driverHelper.waitForNumberOfWindows( driver, 2 );
 				await driverHelper.switchToWindowByIndex( driver, 1 );
 				const paypalCheckoutPage = new PaypalCheckoutPage( driver );
 				const amountDisplayed = await paypalCheckoutPage.priceDisplayed();

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -1310,12 +1310,8 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				);
 				let viewPostPage = new ViewPostPage( driver );
 				await viewPostPage.clickPaymentButton();
-				numberOfOpenBrowserWindows = await driverHelper.numberOfOpenWindows( driver );
-				assert.equal(
-					numberOfOpenBrowserWindows,
-					2,
-					'There are not two open browser windows after clicking the payment button'
-				);
+				await driverHelper.waitForNumberOfWindows( driver, 2 );
+				await driverHelper.switchToWindowByIndex( driver, 1 );
 				await driverHelper.switchToWindowByIndex( driver, 1 );
 				const paypalCheckoutPage = new PaypalCheckoutPage( driver );
 				const amountDisplayed = await paypalCheckoutPage.priceDisplayed();

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -1246,6 +1246,12 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 	test.describe( 'Insert a payment button: @parallel', function() {
 		this.bailSuite( true );
 
+		test.before( async function() {
+			const testEnvironment = 'WordPress.com';
+			const testName = `Post Editor - Payment Button [${ global.browserName }] [${ screenSize }]`;
+			eyesHelper.eyesOpen( driver, eyes, testEnvironment, testName );
+		} );
+
 		test.it( 'Delete Cookies and Local Storage', async function() {
 			await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 		} );
@@ -1278,6 +1284,10 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			const viewPostPage = new ViewPostPage( driver );
 			let displayed = await viewPostPage.paymentButtonDisplayed();
 			assert.equal( displayed, true, 'The published post does not contain the payment button' );
+		} );
+
+		test.after( async function() {
+			await eyesHelper.eyesClose( eyes );
 		} );
 	} );
 

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -1243,56 +1243,41 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 		} );
 	} );
 
-	test.describe( 'Insert a payment button: @parallel @visdiff', function() {
+	test.describe( 'Insert a payment button: @parallel', function() {
 		this.bailSuite( true );
-
-		test.before( async function() {
-			let testEnvironment = 'WordPress.com';
-			let testName = `Post Editor - Payment Button [${ global.browserName }] [${ screenSize }]`;
-			eyesHelper.eyesOpen( driver, eyes, testEnvironment, testName );
-		} );
 
 		test.it( 'Delete Cookies and Local Storage', async function() {
 			await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 		} );
 
-		test.describe( 'Publish a New Post with a Payment Button', function() {
-			const originalBlogPostTitle = 'Payment Button: ' + dataHelper.randomPhrase();
-
-			test.it( 'Can log in', async function() {
-				this.loginFlow = new LoginFlow( driver );
-				return await this.loginFlow.loginAndStartNewPost();
-			} );
-
-			test.it( 'Can insert the payment button', async function() {
-				this.editorPage = new EditorPage( driver );
-				await this.editorPage.enterTitle( originalBlogPostTitle );
-				await this.editorPage.insertPaymentButton( eyes );
-
-				let errorShown = await this.editorPage.errorDisplayed();
-				return assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
-			} );
-
-			test.it( 'Can see the payment button inserted into the visual editor', async function() {
-				this.editorPage = new EditorPage( driver );
-				return await this.editorPage.ensurePaymentButtonDisplayedInPost();
-			} );
-
-			test.it( 'Can publish and view content', async function() {
-				let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
-				await postEditorToolbarComponent.ensureSaved();
-				await postEditorToolbarComponent.publishAndViewContent( { useConfirmStep: true } );
-			} );
-
-			test.it( 'Can see the payment button in our published post', async function() {
-				this.viewPostPage = new ViewPostPage( driver );
-				let displayed = await this.viewPostPage.paymentButtonDisplayed();
-				assert.equal( displayed, true, 'The published post does not contain the payment button' );
-			} );
+		test.it( 'Can log in', async function() {
+			return await new LoginFlow( driver ).loginAndStartNewPost();
 		} );
 
-		test.after( async function() {
-			await eyesHelper.eyesClose( eyes );
+		test.it( 'Can insert the payment button', async function() {
+			const blogPostTitle = 'Payment Button: ' + dataHelper.randomPhrase();
+			const editorPage = new EditorPage( driver );
+			await editorPage.enterTitle( blogPostTitle );
+			await editorPage.insertPaymentButton( eyes );
+
+			let errorShown = await editorPage.errorDisplayed();
+			return assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
+		} );
+
+		test.it( 'Can see the payment button inserted into the visual editor', async function() {
+			return await new EditorPage( driver ).ensurePaymentButtonDisplayedInPost();
+		} );
+
+		test.it( 'Can publish and view content', async function() {
+			const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+			await postEditorToolbarComponent.ensureSaved();
+			await postEditorToolbarComponent.publishAndViewContent( { useConfirmStep: true } );
+		} );
+
+		test.it( 'Can see the payment button in our published post', async function() {
+			const viewPostPage = new ViewPostPage( driver );
+			let displayed = await viewPostPage.paymentButtonDisplayed();
+			assert.equal( displayed, true, 'The published post does not contain the payment button' );
 		} );
 	} );
 

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -1245,7 +1245,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 		} );
 	} );
 
-	test.describe( 'Insert a payment button: @parallel', function() {
+	test.describe( 'Insert a payment button: @parallel @visdiff', function() {
 		this.bailSuite( true );
 
 		const paymentButtonDetails = {
@@ -1253,7 +1253,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			description: 'Description',
 			symbol: '$',
 			price: '1.99',
-			currency: 'AUD',
+			currency: 'USD',
 			allowQuantity: true,
 			email: 'test@wordpress.com',
 		};

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -1312,7 +1312,6 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				await viewPostPage.clickPaymentButton();
 				await driverHelper.waitForNumberOfWindows( driver, 2 );
 				await driverHelper.switchToWindowByIndex( driver, 1 );
-				await driverHelper.switchToWindowByIndex( driver, 1 );
 				const paypalCheckoutPage = new PaypalCheckoutPage( driver );
 				const amountDisplayed = await paypalCheckoutPage.priceDisplayed();
 				assert.equal(


### PR DESCRIPTION
Due to recent payment button issues, this enhances the payment button tests to be more comprehensive:

1. Adds a payment button front-end check that makes sure if shows and functions (opens paypal with the correct amount)
2. Uses two different currencies
3. Adds a payment button to a page as well as a post

Fixes #1030 