### PR TITLE
Domains: Remove domain strikethrough price test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -65,8 +65,7 @@
     "mobilePlansTablesOnSignup",
     "springSale30PercentOff",
     "showMoneyBackGuarantee",
-    "multiyearSubscriptions",
-    "signupDomainStrikethruPrice"
+    "multiyearSubscriptions"
   ],
   "overrideABTests": [
     [ "skipThemesSelectionModal_20170904", "show" ],
@@ -77,7 +76,6 @@
     [ "mobilePlansTablesOnSignup_20180330", "original" ],
     [ "springSale30PercentOff_20180413", "control" ],
     [ "showMoneyBackGuarantee_20180409", "no" ],
-    [ "multiyearSubscriptions_20180417", "hide" ],
-    [ "signupDomainStrikethruPrice_20180507", "disabled" ]
+    [ "multiyearSubscriptions_20180417", "hide" ]
   ]
 }


### PR DESCRIPTION
This change corresponds to the removal of the domain strikethrough feature here, which has since been deployed: Automattic/wp-calypso/pull/24930.