### PR TITLE
Refactor #removeSites to not to exceed test timeouts

### DIFF
--- a/lib/flows/jetpack-connect-flow.js
+++ b/lib/flows/jetpack-connect-flow.js
@@ -1,6 +1,7 @@
 /** @format */
 
 import { By } from 'selenium-webdriver';
+import config from 'config';
 
 import LoginFlow from './login-flow';
 import SidebarComponent from '../components/sidebar-component';
@@ -70,16 +71,15 @@ export default class JetpackConnectFlow {
 		wpAdminJetpack.activateRecommendedFeatures();
 	}
 
-	removeSites() {
-		const loginFlow = new LoginFlow( this.driver, this.account );
-		loginFlow.loginAndSelectMySite();
-
-		this.sidebarComponent = new SidebarComponent( this.driver );
+	removeSites( timeout = config.get( 'mochaTimeoutMS' ) ) {
+		const timeStarted = Date.now();
+		new LoginFlow( this.driver, this.account ).loginAndSelectMySite();
 
 		const removeSites = () => {
-			return this.sidebarComponent.removeBrokenSite().then( removed => {
-				if ( ! removed ) {
-					// no sites left to remove
+			return new SidebarComponent( this.driver ).removeBrokenSite().then( removed => {
+				if ( ! removed || Date.now() - timeStarted > 0.8 * timeout ) {
+					// 80% of timeout
+					// no sites left to remove or removeSites taking too long
 					return;
 				}
 				// seems like it is not waiting for this

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -64,8 +64,7 @@ test.describe( `Jetpack Connect: (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can disconnect any expired sites', async function() {
-			const jnFlow = new JetpackConnectFlow( driver, 'jetpackConnectUser' );
-			return await jnFlow.removeSites();
+			return await new JetpackConnectFlow( driver, 'jetpackConnectUser' ).removeSites();
 		} );
 	} );
 


### PR DESCRIPTION
Jetpack disconnection flow sometimes failing due to exceeded timeouts. This PR adds check to prevent these failures.

Now, `#removeSites` will stop deleting sites if time spent will exceed 80% of Mocha timeout.