### PR TITLE
Switch to Premium Jetpack plans

### DIFF
--- a/specs/wp-plan-purchase-spec.js
+++ b/specs/wp-plan-purchase-spec.js
@@ -56,8 +56,9 @@ test.describe( `[${ host }] Plans: (${ screenSize }) @parallel @jetpack`, functi
 
 			test.it( 'Can Compare Plans', async function() {
 				this.plansPage = new PlansPage( driver );
+				await this.plansPage.openPlansTab();
+
 				if ( host === 'WPCOM' ) {
-					await this.plansPage.openPlansTab();
 					return await this.plansPage.waitForComparison();
 				}
 
@@ -66,13 +67,11 @@ test.describe( `[${ host }] Plans: (${ screenSize }) @parallel @jetpack`, functi
 				return assert( displayed, 'The Jetpack plans are NOT displayed' );
 			} );
 
-			if ( host === 'WPCOM' ) {
-				test.it( 'Can Verify Current Plan', async function() {
-					const planName = 'premium';
-					let present = await this.plansPage.confirmCurrentPlan( planName );
-					return assert( present, `Failed to detect correct plan (${ planName })` );
-				} );
-			}
+			test.it( 'Can Verify Current Plan', async function() {
+				const planName = 'premium';
+				let present = await this.plansPage.confirmCurrentPlan( planName );
+				return assert( present, `Failed to detect correct plan (${ planName })` );
+			} );
 		} );
 
 		//test.describe( 'Can purchase plans', function() {


### PR DESCRIPTION
This is a complementary PR for "Enable payment button tests for Jetpack sites" Trello task. 

I've added Premium plans to default sites for both of our Jetpack targets.