### PR TITLE
Update email client with latest mailosaur api

### DIFF
--- a/lib/email-client.js
+++ b/lib/email-client.js
@@ -3,13 +3,13 @@
 // import webdriver from 'selenium-webdriver';
 import config from 'config';
 
-const emailWaitMS = config.get( 'emailWaitMS' );
+// const emailWaitMS = config.get( 'emailWaitMS' );
 
 export default class EmailClient {
 	constructor( mailboxId ) {
-		const apiKey = config.get( 'mailosaurAPIKey' );
-		const Mailosaur = require( 'mailosaur' )( apiKey, 'https://mailosaur.com/api/' );
-		this.mailbox = new Mailosaur.Mailbox( mailboxId );
+		const Mailosaur = require( 'mailosaur' );
+		this.mailbox = new Mailosaur( config.get( 'mailosaurAPIKey' ) );
+		this.mailboxId = mailboxId;
 	}
 
 	// deleteAllEmailByID( emailID ) {
@@ -37,14 +37,33 @@ export default class EmailClient {
 	// }
 
 	/**
-	 * Load emails for specific email address.
-	 * It is possible to pass an optional function which will return list of emails only if validator will return "true"
-	 * It's possible to pass a function to validate received emails. For example when you waiting for specific email - validator may check if expected email is present
+	 * Waits for latest email for specific email address.
+	 * Times out in under 10s if no email is received with error 204.
+	 * Rejects email that does not have html format.
 	 * @param {string} emailAddress - Email address from where to get emails
-	 * @param {function} validator - Optional function to validate received emails
 	 * @returns {Object} - Returns `object`
 	 */
-	async pollEmailsByRecipient( emailAddress, validator = () => true ) {
+	async waitForEmailByRecipient( emailAddress ) {
+		let email;
+
+		try {
+			email = await this.mailbox.messages.waitFor( this.mailboxId, {
+				sentTo: emailAddress,
+			} );
+		} catch ( err ) {
+			throw new Error(
+				`Mailosaur API did not receive email for ${ emailAddress } on time with ${ err }`
+			);
+		}
+		if ( ! email.html ) {
+			throw new Error( `Could not locate email for ${ emailAddress } with correct format` );
+		} else {
+			return email;
+		}
+	}
+
+	/*
+	 async pollEmailsByRecipient( emailAddress, validator = () => true ) {
 		const intervalMS = 1500;
 		let retries = emailWaitMS / intervalMS;
 		let emails;
@@ -67,4 +86,5 @@ export default class EmailClient {
 			}, timeout );
 		} );
 	}
+	*/
 }

--- a/lib/flows/sign-up-flow.js
+++ b/lib/flows/sign-up-flow.js
@@ -50,12 +50,10 @@ export default class SignUpFlow {
 
 	activateAccount() {
 		return this.emailClient
-			.pollEmailsByRecipient( this.emailAddress )
-			.then( emails => {
-				for ( let email of emails ) {
-					if ( email.subject.indexOf( 'Activate' ) > -1 ) {
-						return email.html.links[ 0 ].href;
-					}
+			.waitForEmailByRecipient( this.emailAddress )
+			.then( email => {
+				if ( email.subject.indexOf( 'Activate' ) > -1 ) {
+					return email.html.links[ 0 ].href;
 				}
 			} )
 			.then( activationLink => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8463,168 +8463,115 @@
       }
     },
     "mailosaur": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mailosaur/-/mailosaur-4.0.0.tgz",
-      "integrity": "sha1-GyDt2P/BO/DwOfNN3uvYwylqUsM=",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/mailosaur/-/mailosaur-5.0.3.tgz",
+      "integrity": "sha1-2TKWc4Wwl1kBqP9y+agkUhSznj4=",
       "requires": {
-        "bluebird": "3.5.1",
-        "request": "2.36.0"
+        "moment": "2.22.1",
+        "request": "2.87.0"
       },
       "dependencies": {
-        "asn1": {
-          "version": "0.1.11",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
-          "optional": true
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
         },
         "assert-plus": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
-          "optional": true
-        },
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-          "optional": true
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "aws-sign2": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
-          "optional": true
-        },
-        "boom": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
-          "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-          "requires": {
-            "hoek": "0.9.1"
-          }
-        },
-        "combined-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-          "optional": true,
-          "requires": {
-            "delayed-stream": "0.0.5"
-          }
-        },
-        "cryptiles": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
-          "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
-          "optional": true,
-          "requires": {
-            "boom": "0.4.2"
-          }
-        },
-        "delayed-stream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
-          "optional": true
-        },
-        "forever-agent": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-          "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "form-data": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-          "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
-          "optional": true,
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "requires": {
-            "async": "0.9.2",
-            "combined-stream": "0.0.7",
-            "mime": "1.2.11"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.17"
+          },
+          "dependencies": {
+            "combined-stream": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            }
           }
         },
-        "hawk": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
-          "integrity": "sha1-uQuxaYByhUEdp//LjdJZhQLTtS0=",
-          "optional": true,
-          "requires": {
-            "boom": "0.4.2",
-            "cryptiles": "0.2.2",
-            "hoek": "0.9.1",
-            "sntp": "0.2.4"
-          }
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
-        "hoek": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
+          }
         },
         "http-signature": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-          "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
-          "optional": true,
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "requires": {
-            "asn1": "0.1.11",
-            "assert-plus": "0.1.5",
-            "ctype": "0.5.3"
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
           }
         },
-        "mime": {
-          "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-          "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        },
-        "oauth-sign": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
-          "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
-          "optional": true
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "qs": {
-          "version": "0.6.6",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
-          "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "request": {
-          "version": "2.36.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
-          "integrity": "sha1-KMbAQmLHuf/dIbklU3RRfubZQ/U=",
+          "version": "2.87.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
           "requires": {
-            "aws-sign2": "0.5.0",
-            "forever-agent": "0.5.2",
-            "form-data": "0.1.4",
-            "hawk": "1.0.0",
-            "http-signature": "0.10.1",
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime": "1.2.11",
-            "node-uuid": "1.4.8",
-            "oauth-sign": "0.3.0",
-            "qs": "0.6.6",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.1",
             "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3"
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
           }
-        },
-        "sntp": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
-          "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
-          "optional": true,
-          "requires": {
-            "hoek": "0.9.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "optional": true
         }
       }
     },
@@ -9096,6 +9043,11 @@
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
+    },
+    "moment": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
+      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "grunt-shell": "^1.1.2",
     "junit-viewer": "4.9.6",
     "lodash": "^4.13.1",
-    "mailosaur": "4.0.0",
+    "mailosaur": "5.0.3",
     "mocha": "github:Automattic/mocha#90a9db1",
     "node-slack-upload": "1.2.1",
     "parallel-mocha": "~0.0.7",

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -77,8 +77,8 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can see an invitation email received for the invite', async function() {
-			let emails = await emailClient.pollEmailsByRecipient( newInviteEmailAddress );
-			let links = emails[ 0 ].html.links;
+			let email = await emailClient.waitForEmailByRecipient( newInviteEmailAddress );
+			let links = email.html.links;
 			let link = links.find( l => l.href.includes( 'accept-invite' ) );
 			acceptInviteURL = dataHelper.adjustInviteLinkToCorrectEnvironment( link.href );
 			return assert.notEqual(
@@ -188,8 +188,8 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can see an invitation email received for the invite', async function() {
-				let emails = await emailClient.pollEmailsByRecipient( newInviteEmailAddress );
-				let links = emails[ 0 ].html.links;
+				let email = await emailClient.waitForEmailByRecipient( newInviteEmailAddress );
+				let links = email.html.links;
 				let link = links.find( l => l.href.includes( 'accept-invite' ) );
 				acceptInviteURL = dataHelper.adjustInviteLinkToCorrectEnvironment( link.href );
 				return assert.notEqual(
@@ -242,8 +242,8 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can see an invitation email received for the invite', async function() {
-			let emails = await emailClient.pollEmailsByRecipient( newInviteEmailAddress );
-			let links = emails[ 0 ].html.links;
+			let email = await emailClient.waitForEmailByRecipient( newInviteEmailAddress );
+			let links = email.html.links;
 			let link = links.find( l => l.href.includes( 'accept-invite' ) );
 			acceptInviteURL = dataHelper.adjustInviteLinkToCorrectEnvironment( link.href );
 			return assert.notEqual(
@@ -362,8 +362,8 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				} );
 
 				test.it( 'Can see an invitation email received for the invite', async function() {
-					let emails = await emailClient.pollEmailsByRecipient( newInviteEmailAddress );
-					let links = emails[ 0 ].html.links;
+					let email = await emailClient.waitForEmailByRecipient( newInviteEmailAddress );
+					let links = email.html.links;
 					let link = links.find( l => l.href.includes( 'accept-invite' ) );
 					acceptInviteURL = dataHelper.adjustInviteLinkToCorrectEnvironment( link.href );
 					return assert.notEqual(
@@ -489,8 +489,8 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can see an invitation email received for the invite', async function() {
-				let emails = await emailClient.pollEmailsByRecipient( newInviteEmailAddress );
-				let links = emails[ 0 ].html.links;
+				let email = await emailClient.waitForEmailByRecipient( newInviteEmailAddress );
+				let links = email.html.links;
 				let link = links.find( l => l.href.includes( 'accept-invite' ) );
 				acceptInviteURL = dataHelper.adjustInviteLinkToCorrectEnvironment( link.href );
 				return assert.notEqual(

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -159,15 +159,9 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 
 			test.it( 'Can see email containing magic link', async function() {
 				const emailClient = new EmailClient( signupInboxId );
-				const validator = emails =>
-					emails.find( email => email.subject.includes( 'WordPress.com' ) );
-				let emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
-				//Disabled due to a/b test on activation email. See https://github.com/Automattic/wp-e2e-tests/issues/819
-				//assert.equal( emails.length, 2, 'The number of newly registered emails is not equal to 2 (activation and magic link)' );
-				for ( let email of emails ) {
-					if ( email.subject.includes( 'WordPress.com' ) ) {
-						return ( magicLoginLink = email.html.links[ 0 ].href );
-					}
+				let email = await emailClient.waitForEmailByRecipient( emailAddress );
+				if ( email.subject.includes( 'WordPress.com' ) ) {
+					return ( magicLoginLink = email.html.links[ 0 ].href );
 				}
 				return assert(
 					magicLoginLink !== undefined,


### PR DESCRIPTION
Updated with latest Mailosaur API 5.0.3 (#1017) 

It therefore replaces `pollForEmailsByReceipient` with `waitForEmailByReceipient` for native wait ability and requires no need for timeout as Mailosaur returns a `204` if there's no email in <10s.

This potentially also fixes the race condition wherein emails were rejected by `validator` allowing them to exit polling on the first try.

Also added format check to reject potential emails that do not have any `html` formatting (_which is required for all emails from us anyway_).