### PR TITLE
Try to fix login page flakiness

### DIFF
--- a/lib/pages/login-page.js
+++ b/lib/pages/login-page.js
@@ -32,17 +32,20 @@ export default class LoginPage extends BaseContainer {
 		driverHelper.waitTillPresentAndDisplayed( driver, userNameSelector );
 		driverHelper.setWhenSettable( driver, userNameSelector, username );
 
-		return driverHelper.isElementPresent( driver, wpcomLoginSelector ).then( isWpcom => {
-			if ( isWpcom ) {
-				driver.findElement( userNameSelector ).sendKeys( Key.ENTER );
-			}
+		return driverHelper
+			.isEventuallyPresentAndDisplayed( driver, wpcomLoginSelector, 1000 )
+			.then( isWpcom => {
+				if ( isWpcom ) {
+					driver.findElement( userNameSelector ).sendKeys( Key.ENTER );
+				}
 
-			if ( password ) {
-				driverHelper.setWhenSettable( driver, passwordSelector, password, { secureValue: true } );
-				driverHelper.clickWhenClickable( driver, submitSelector );
-			}
-			return driverHelper.waitTillNotPresent( driver, userNameSelector, this.explicitWaitMS * 2 );
-		} );
+				if ( password ) {
+					driverHelper.waitTillPresentAndDisplayed( driver, passwordSelector );
+					driverHelper.setWhenSettable( driver, passwordSelector, password, { secureValue: true } );
+					driverHelper.clickWhenClickable( driver, submitSelector );
+				}
+				return driverHelper.waitTillNotPresent( driver, userNameSelector, this.explicitWaitMS * 2 );
+			} );
 	}
 
 	use2FAMethod( twoFAMethod ) {

--- a/lib/pages/login-page.js
+++ b/lib/pages/login-page.js
@@ -1,7 +1,6 @@
 /** @format */
 
 import { By } from 'selenium-webdriver';
-import { Key } from 'selenium-webdriver';
 import config from 'config';
 
 import BaseContainer from '../base-container.js';

--- a/lib/pages/login-page.js
+++ b/lib/pages/login-page.js
@@ -33,10 +33,10 @@ export default class LoginPage extends BaseContainer {
 		driverHelper.setWhenSettable( driver, userNameSelector, username );
 
 		return driverHelper
-			.isEventuallyPresentAndDisplayed( driver, wpcomLoginSelector, 1000 )
+			.isEventuallyPresentAndDisplayed( driver, wpcomLoginSelector, 500 )
 			.then( isWpcom => {
 				if ( isWpcom ) {
-					driver.findElement( userNameSelector ).sendKeys( Key.ENTER );
+					driverHelper.clickWhenClickable( driver, submitSelector );
 				}
 
 				if ( password ) {


### PR DESCRIPTION
Sometimes `#login` randomly fails with `Timed out waiting for element with css selector of '#user_login, #usernameOrEmail' to NOT be present` error. Since `#login` is involved in almost every test - this error may affect entire test suite. 