### PR TITLE
Put all test artifacts into CI expected folders no matter is slack hook configured or not

### DIFF
--- a/lib/reporter/magellan-reporter.js
+++ b/lib/reporter/magellan-reporter.js
@@ -140,7 +140,7 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 					reportFiles
 						.filter( file => file.match( /xml$/i ) )
 						.forEach( reportPath =>
-							moveReports( slackClient, reportDir, reportPath, testRun.guid )
+							copyReports( slackClient, reportDir, reportPath, testRun.guid )
 						);
 				} );
 
@@ -173,25 +173,29 @@ function configGet( key ) {
 }
 
 // Move to /reports for CircleCI artifacts
-function moveReports( slackClient, reportDir, reportPath, guid ) {
+function copyReports( slackClient, reportDir, reportPath, guid ) {
 	if ( reportDir === './reports' ) {
 		return;
 	}
 	try {
-		fs.rename( `${ reportDir }/${ reportPath }`, `./reports/${ guid }_${ reportPath }`, moveErr => {
-			if ( ! moveErr ) {
-				return;
+		fs.copyFile(
+			`${ reportDir }/${ reportPath }`,
+			`./reports/${ guid }_${ reportPath }`,
+			moveErr => {
+				if ( ! moveErr ) {
+					return;
+				}
+				slackClient.send( {
+					icon_emoji: ':a8c:',
+					text: `Build <https://circleci.com/gh/${ process.env.CIRCLE_PROJECT_USERNAME }/${
+						process.env.CIRCLE_PROJECT_REPONAME
+					}/${ process.env.CIRCLE_BUILD_NUM }|#${
+						process.env.CIRCLE_BUILD_NUM
+					}> Moving file to /reports failed: '${ moveErr }'`,
+					username: 'e2e Test Runner',
+				} );
 			}
-			slackClient.send( {
-				icon_emoji: ':a8c:',
-				text: `Build <https://circleci.com/gh/${ process.env.CIRCLE_PROJECT_USERNAME }/${
-					process.env.CIRCLE_PROJECT_REPONAME
-				}/${ process.env.CIRCLE_BUILD_NUM }|#${
-					process.env.CIRCLE_BUILD_NUM
-				}> Moving file to /reports failed: '${ moveErr }'`,
-				username: 'e2e Test Runner',
-			} );
-		} );
+		);
 	} catch ( e ) {
 		console.log( `Error moving file, likely just timing race: ${ e.message }` );
 	}
@@ -248,7 +252,7 @@ function sendFailureNotif( slackClient, reportDir, testRun ) {
 		} catch ( e ) {
 			console.log( `Error reading report file, likely just timing race: ${ e.message }` );
 		}
-		moveReports( slackClient, reportDir, reportPath, testRun.guid );
+		copyReports( slackClient, reportDir, reportPath, testRun.guid );
 	} );
 
 	let fieldsObj = { Error: `${ failuresCount } failed tests` };

--- a/lib/reporter/magellan-reporter.js
+++ b/lib/reporter/magellan-reporter.js
@@ -33,16 +33,8 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 		screenshotDir = testRun.tempAssetPath + `/${ process.env.SCREENSHOTDIR }`;
 	}
 
-	fs.stat( './reports', err => {
-		if ( err && err.code === 'ENOENT' ) {
-			fs.mkdir( './reports' );
-		}
-	} );
-	fs.stat( finalScreenshotDir, err => {
-		if ( err && err.code === 'ENOENT' ) {
-			fs.mkdir( finalScreenshotDir );
-		}
-	} );
+	fs.mkdir( finalScreenshotDir, () => {} );
+	fs.mkdir( './reports', () => {} );
 
 	// Only enable Slack messages on the master branch
 	let slackClient = getSlackClient();

--- a/lib/reporter/magellan-reporter.js
+++ b/lib/reporter/magellan-reporter.js
@@ -27,21 +27,27 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 		finalScreenshotDir = `./${ process.env.SCREENSHOTDIR }`;
 	}
 
-	fs.stat( './reports', function( err ) {
+	const reportDir = testRun.tempAssetPath + '/reports';
+	let screenshotDir = testRun.tempAssetPath + '/screenshots';
+	if ( process.env.SCREENSHOTDIR ) {
+		screenshotDir = testRun.tempAssetPath + `/${ process.env.SCREENSHOTDIR }`;
+	}
+
+	fs.stat( './reports', err => {
 		if ( err && err.code === 'ENOENT' ) {
-			fs.mkdir( './reports', function() {} );
+			fs.mkdir( './reports' );
 		}
 	} );
-	fs.stat( finalScreenshotDir, function( err ) {
+	fs.stat( finalScreenshotDir, err => {
 		if ( err && err.code === 'ENOENT' ) {
-			fs.mkdir( finalScreenshotDir, function() {} );
+			fs.mkdir( finalScreenshotDir );
 		}
 	} );
 
 	// Only enable Slack messages on the master branch
 	let slackClient = getSlackClient();
 
-	source.on( 'message', function( msg ) {
+	source.on( 'message', msg => {
 		if ( msg.type === 'worker-status' ) {
 			const passCondition = msg.passed;
 			const failCondition =
@@ -52,11 +58,6 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 				duration: test.runningTime,
 				err: {},
 			};
-			const reportDir = testRun.tempAssetPath + '/reports';
-			let screenshotDir = testRun.tempAssetPath + '/screenshots';
-			if ( process.env.SCREENSHOTDIR ) {
-				screenshotDir = testRun.tempAssetPath + `/${ process.env.SCREENSHOTDIR }`;
-			}
 
 			// If the test failed on the final retry, send Slack notifications
 			if ( failCondition ) {
@@ -64,16 +65,10 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 				sendFailureNotif( slackClient, reportDir, testRun );
 
 				// Screenshots
-				fs.readdir( screenshotDir, function( dirErr, files ) {
-					if ( dirErr ) {
-						return 1;
-					}
+				fs.readdir( screenshotDir, ( dirErr, files ) => {
+					if ( dirErr ) return 1;
 
-					files.forEach( function( screenshotPath ) {
-						if ( ! screenshotPath.match( /png$/i ) ) {
-							return;
-						}
-
+					files.filter( file => file.match( /png$/i ) ).forEach( screenshotPath => {
 						// Send screenshot to Slack on master branch only
 						if (
 							config.has( 'slackTokenForScreenshots' ) &&
@@ -86,7 +81,7 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 
 							try {
 								fs.createReadStream( `${ screenshotDir }/${ screenshotPath }` ).pipe(
-									pngitxt.get( 'url', function( url ) {
+									pngitxt.get( 'url', url => {
 										slackUpload.uploadFile(
 											{
 												file: fs.createReadStream( `${ screenshotDir }/${ screenshotPath }` ),
@@ -95,9 +90,8 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 												channels: slackChannel,
 											},
 											err => {
-												if ( ! err ) {
-													return;
-												}
+												if ( ! err ) return;
+
 												slackClient.send( {
 													icon_emoji: ':a8c:',
 													text: `Build <https://circleci.com/gh/${
@@ -109,12 +103,6 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 												} );
 											}
 										);
-										moveScreenshots(
-											slackClient,
-											screenshotDir,
-											screenshotPath,
-											finalScreenshotDir
-										);
 									} )
 								);
 							} catch ( e ) {
@@ -123,6 +111,7 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 								);
 							}
 						}
+						copyScreenshots( slackClient, screenshotDir, screenshotPath, finalScreenshotDir );
 					} );
 				} );
 			}
@@ -145,32 +134,25 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 				}
 
 				// Reports
-				fs.readdir( reportDir, function( dirErr, reportFiles ) {
-					if ( dirErr ) {
-						return 1;
-					}
+				fs.readdir( reportDir, ( dirErr, reportFiles ) => {
+					if ( dirErr ) return 1;
 
-					reportFiles.forEach( function( reportPath ) {
-						if ( ! reportPath.match( /xml$/i ) ) {
-							return;
-						}
-						moveReports( slackClient, reportDir, reportPath, testRun.guid );
-					} );
+					reportFiles
+						.filter( file => file.match( /xml$/i ) )
+						.forEach( reportPath =>
+							moveReports( slackClient, reportDir, reportPath, testRun.guid )
+						);
 				} );
 
 				// Screenshots
-				fs.readdir( screenshotDir, function( dirErr, screenshotFiles ) {
-					if ( dirErr ) {
-						return 1;
-					}
+				fs.readdir( screenshotDir, ( dirErr, screenshotFiles ) => {
+					if ( dirErr ) return 1;
 
-					screenshotFiles.forEach( function( screenshotPath ) {
-						if ( ! screenshotPath.match( /png$/i ) ) {
-							return;
-						}
-
-						moveScreenshots( slackClient, screenshotDir, screenshotPath, finalScreenshotDir );
-					} );
+					screenshotFiles
+						.filter( file => file.match( /png$/i ) )
+						.forEach( screenshotFile =>
+							copyScreenshots( slackClient, screenshotDir, screenshotFile, finalScreenshotDir )
+						);
 				} );
 			}
 		}
@@ -216,9 +198,9 @@ function moveReports( slackClient, reportDir, reportPath, guid ) {
 }
 
 // Move to /screenshots for CircleCI artifacts
-function moveScreenshots( slackClient, dir, path, finalScreenshotDir ) {
+function copyScreenshots( slackClient, dir, path, finalScreenshotDir ) {
 	try {
-		fs.rename( `${ dir }/${ path }`, `${ finalScreenshotDir }/${ path }`, moveErr => {
+		fs.copyFile( `${ dir }/${ path }`, `${ finalScreenshotDir }/${ path }`, moveErr => {
 			if ( ! moveErr ) {
 				return;
 			}
@@ -243,7 +225,7 @@ function getSlackClient() {
 		let slackHook = configGet( 'slackHook' );
 		return slack( slackHook );
 	}
-	return { send: function() {} };
+	return { send: () => {} };
 }
 
 function sendFailureNotif( slackClient, reportDir, testRun ) {


### PR DESCRIPTION
Due to current Magellan reporter & test artifact(screenshots & reports) capturing implementation we need to store these artifacts into test-specific temp folders. CircleCI expecting to see them in default folders: `./screenshots` & `./reports`. To make artifacts visible in CircleCI we are moving these files into default folders in `magellan-reporter`. But that moving code is was executed _only_ for slack-activated environments(e.g. where slack reporting was enabled) 

This PR makes sure we copy these artifacts no matter how slack notifications are set up.
