### PR TITLE
Dissmis GDPR banner on mobile devices

### DIFF
--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -1,10 +1,11 @@
 /** @format */
 
 import { By, until } from 'selenium-webdriver';
-import * as driverHelper from '../driver-helper.js';
 
 import BaseContainer from '../base-container.js';
 import DisconnectSurveyPage from '../pages/disconnect-survey-page.js';
+import * as driverHelper from '../driver-helper';
+import * as driverManager from '../driver-manager';
 
 export default class SidebarComponent extends BaseContainer {
 	constructor( driver, siteName = null ) {
@@ -13,6 +14,19 @@ export default class SidebarComponent extends BaseContainer {
 		this.settingsSelector = By.css( '.sites-navigation [data-tip-target="settings"] a' );
 		if ( siteName !== null ) {
 			this.selectSite( siteName );
+		}
+
+		if ( driverManager.currentScreenSize() === 'mobile' ) {
+			driverHelper
+				.isEventuallyPresentAndDisplayed( this.driver, By.css( '.gdpr-banner' ), 1000 )
+				.then( present => {
+					if ( present ) {
+						driverHelper.clickWhenClickable(
+							this.driver,
+							By.css( '.gdpr-banner__acknowledge-button' )
+						);
+					}
+				} );
 		}
 	}
 


### PR DESCRIPTION
Sometimes GDPR banner is covering some of the page elements which cause tests to fail.

To test:
run `BROWSERSIZE=mobile mocha specs -g 'Inviting new user as an Editor'`
Sometimes it fails because it miss-clicking on 'People' banner in sidebar