### PR TITLE
Domains: Add TLD filter placement A/B definition

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -65,7 +65,8 @@
 		"springSale30PercentOff",
 		"multiyearSubscriptions",
 		"jetpackSignupGoogleTop",
-		"domainSuggestionKrakenV321"
+		"domainSuggestionKrakenV321",
+		"domainSearchTLDFilterPlacement"
 	],
 	"overrideABTests": [
 		[ "businessPlanDescriptionAT_20170605", "original" ],
@@ -76,6 +77,7 @@
 		[ "springSale30PercentOff_20180413", "control" ],
 		[ "multiyearSubscriptions_20180417", "hide" ],
 		[ "jetpackSignupGoogleTop_20180427", "original" ],
-		[ "domainSuggestionKrakenV321_20180524", "domainsbot" ]
+		[ "domainSuggestionKrakenV321_20180524", "domainsbot" ],
+		[ "domainSearchTLDFilterPlacement_20180531", "belowFeatured" ]
 	]
 }


### PR DESCRIPTION
Adds A/B test definition introduced in Automattic/wp-calypso/pull/25057.