### PR TITLE
Update timestamp on multiyearSubscriptions test to reflect calypso repo

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -75,7 +75,7 @@
 		[ "checklistThankYouForPaidUser_20171204", "hide" ],
 		[ "mobilePlansTablesOnSignup_20180330", "original" ],
 		[ "springSale30PercentOff_20180413", "control" ],
-		[ "multiyearSubscriptions_20180417", "hide" ],
+		[ "multiyearSubscriptions_20180601", "hide" ],
 		[ "jetpackSignupGoogleTop_20180427", "original" ],
 		[ "domainSuggestionKrakenV321_20180524", "domainsbot" ],
 		[ "domainSearchTLDFilterPlacement_20180531", "belowFeatured" ]


### PR DESCRIPTION
Related to this PR: https://github.com/Automattic/wp-calypso/pull/25221