### PR TITLE
Fix failing jetpack tests

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -1,6 +1,6 @@
 /** @format */
 
-import { By, until } from 'selenium-webdriver';
+import { By, Key, until } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper.js';
 import BaseContainer from '../base-container.js';
 
@@ -19,7 +19,7 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 		await driverHelper.waitTillPresentAndDisplayed( driver, contentSelector );
 		let c = await driver.findElement( contentSelector ).getAttribute( 'class' );
 		if ( c.indexOf( 'focus-sidebar' ) < 0 ) {
-			await driverHelper.clickWhenClickable( driver, cogSelector );
+			return await driverHelper.clickWhenClickable( driver, cogSelector );
 		}
 	}
 
@@ -135,8 +135,10 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 	async addNewTag( tag ) {
 		const tagEntrySelector = By.css( 'input.token-field__input' );
 
-		await driverHelper.waitForFieldClearable( this.driver, tagEntrySelector, this.explicitWaitMS );
-		return await this.driver.findElement( tagEntrySelector ).sendKeys( tag + '\n' );
+		await driverHelper.waitForFieldClearable( this.driver, tagEntrySelector );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, tagEntrySelector );
+		await driverHelper.setWhenSettable( this.driver, tagEntrySelector, tag );
+		await this.driver.findElement( tagEntrySelector ).sendKeys( Key.ENTER );
 	}
 
 	async setCommentsForPost( allow = true ) {

--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -127,13 +127,11 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 		const tagEntrySelector = By.css( 'input.token-field__input' );
 
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, tagEntrySelector );
-
-		driverHelper.scrollIntoView( this.driver, tagEntrySelector );
-
+		await driverHelper.scrollIntoView( this.driver, tagEntrySelector );
 		await driverHelper.waitForFieldClearable( this.driver, tagEntrySelector );
-		// await driverHelper.setWhenSettable( this.driver, tagEntrySelector, tag );
-		await this.driver.findElement( tagEntrySelector ).sendKeys( tag );
-		return await this.driver.findElement( tagEntrySelector ).sendKeys( Key.ENTER );
+		let tagEntryElement = await this.driver.findElement( tagEntrySelector );
+		await tagEntryElement.sendKeys( tag );
+		return await tagEntryElement.sendKeys( Key.ENTER );
 	}
 
 	async setCommentsForPost( allow = true ) {
@@ -281,11 +279,11 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 		await driverHelper.waitTillPresentAndDisplayed( driver, headerSelector );
 		let c = await driver.findElement( headerSelector ).getAttribute( 'class' );
 		if ( expand && c.indexOf( 'is-expanded' ) < 0 ) {
-			driverHelper.scrollIntoView( driver, toggleSelector );
+			await driverHelper.scrollIntoView( driver, toggleSelector );
 			return await driverHelper.clickWhenClickable( driver, toggleSelector );
 		}
 		if ( ! expand && c.indexOf( 'is-expanded' ) > -1 ) {
-			driverHelper.scrollIntoView( driver, toggleSelector );
+			await driverHelper.scrollIntoView( driver, toggleSelector );
 			return await driverHelper.clickWhenClickable( driver, toggleSelector );
 		}
 	}

--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -107,21 +107,12 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 		const saveCategoryButtonSelector = By.css( 'div.dialog__action-buttons button.is-primary' );
 		const driver = this.driver;
 
-		await driverHelper.clickWhenClickable(
-			driver,
-			addNewCategoryButtonSelector,
-			this.explicitWaitMS
-		);
-		await driverHelper.waitForFieldClearable(
-			driver,
-			categoryNameInputSelector,
-			this.explicitWaitMS
-		);
+		await driverHelper.clickWhenClickable( driver, addNewCategoryButtonSelector );
+		await driverHelper.waitForFieldClearable( driver, categoryNameInputSelector );
 		driver.sleep( 500 );
 		await driverHelper.setWhenSettable( driver, categoryNameInputSelector, category );
 		await driverHelper.clickWhenClickable( driver, saveCategoryButtonSelector );
-		driver.sleep( 500 );
-		return await driverHelper.isElementPresent( driver, saveCategoryButtonSelector );
+		return await driverHelper.waitTillNotPresent( driver, saveCategoryButtonSelector );
 	}
 
 	async getCategoriesAndTags() {
@@ -135,10 +126,14 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 	async addNewTag( tag ) {
 		const tagEntrySelector = By.css( 'input.token-field__input' );
 
-		await driverHelper.waitForFieldClearable( this.driver, tagEntrySelector );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, tagEntrySelector );
-		await driverHelper.setWhenSettable( this.driver, tagEntrySelector, tag );
-		await this.driver.findElement( tagEntrySelector ).sendKeys( Key.ENTER );
+
+		driverHelper.scrollIntoView( this.driver, tagEntrySelector );
+
+		await driverHelper.waitForFieldClearable( this.driver, tagEntrySelector );
+		// await driverHelper.setWhenSettable( this.driver, tagEntrySelector, tag );
+		await this.driver.findElement( tagEntrySelector ).sendKeys( tag );
+		return await this.driver.findElement( tagEntrySelector ).sendKeys( Key.ENTER );
 	}
 
 	async setCommentsForPost( allow = true ) {
@@ -286,9 +281,11 @@ export default class PostEditorSidebarComponent extends BaseContainer {
 		await driverHelper.waitTillPresentAndDisplayed( driver, headerSelector );
 		let c = await driver.findElement( headerSelector ).getAttribute( 'class' );
 		if ( expand && c.indexOf( 'is-expanded' ) < 0 ) {
+			driverHelper.scrollIntoView( driver, toggleSelector );
 			return await driverHelper.clickWhenClickable( driver, toggleSelector );
 		}
 		if ( ! expand && c.indexOf( 'is-expanded' ) > -1 ) {
+			driverHelper.scrollIntoView( driver, toggleSelector );
 			return await driverHelper.clickWhenClickable( driver, toggleSelector );
 		}
 	}

--- a/lib/components/post-preview-component.js
+++ b/lib/components/post-preview-component.js
@@ -35,8 +35,7 @@ export default class PostPreviewComponent extends BaseContainer {
 
 	async tagDisplayed() {
 		await PostPreviewComponent.switchToIFrame( this.driver );
-		this.viewPostPage = new ViewPostPage( this.driver );
-		return await this.viewPostPage.tagDisplayed();
+		return await new ViewPostPage( this.driver ).tagDisplayed();
 	}
 
 	async imageDisplayed( fileDetails ) {

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -78,14 +78,10 @@ export default class SidebarComponent extends BaseContainer {
 	async ensureSidebarMenuVisible() {
 		let allSitesSelector = By.css( '.current-section a' );
 		let sidebarSelector = By.css( '.sidebar' );
-		let displayed = await driverHelper.isEventuallyPresentAndDisplayed(
-			this.driver,
-			sidebarSelector,
-			1000
-		);
+		let sidebarVisible = await this.driver.findElement( sidebarSelector ).isDisplayed();
 
-		if ( ! displayed ) {
-			await driverHelper.clickWhenClickable( this.driver, allSitesSelector, this.explicitWaitMS );
+		if ( ! sidebarVisible ) {
+			await driverHelper.clickWhenClickable( this.driver, allSitesSelector );
 		}
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, sidebarSelector );
 	}
@@ -190,11 +186,7 @@ export default class SidebarComponent extends BaseContainer {
 		const siteSwitcherNewSiteButton = By.css( '.site-selector__add-new-site .button svg' );
 		let present = await driverHelper.isElementPresent( this.driver, sidebarNewSiteButton );
 		if ( present ) {
-			return await driverHelper.clickWhenClickable(
-				this.driver,
-				sidebarNewSiteButton,
-				this.explicitWaitMS * 4
-			);
+			return await driverHelper.clickWhenClickable( this.driver, sidebarNewSiteButton );
 		}
 		await this.selectSiteSwitcher();
 
@@ -215,8 +207,7 @@ export default class SidebarComponent extends BaseContainer {
 		await this.ensureSidebarMenuVisible();
 		let foundSwitcher = await driverHelper.isEventuallyPresentAndDisplayed(
 			this.driver,
-			siteSwitcherSelector,
-			this.explicitWaitMS * 4
+			siteSwitcherSelector
 		);
 		if ( ! foundSwitcher ) {
 			// no site switcher, only one site

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -1,10 +1,10 @@
 /** @format */
 
 import { By, until } from 'selenium-webdriver';
-import * as driverHelper from '../driver-helper.js';
 
 import BaseContainer from '../base-container.js';
 import DisconnectSurveyPage from '../pages/disconnect-survey-page.js';
+import * as driverHelper from '../driver-helper.js';
 
 export default class SidebarComponent extends BaseContainer {
 	constructor( driver ) {
@@ -21,14 +21,14 @@ export default class SidebarComponent extends BaseContainer {
 	async selectPeople() {
 		let selector = By.css( '.sites-navigation [data-tip-target="people"] a' );
 
-		driverHelper.scrollIntoView( this.driver, selector );
+		await driverHelper.scrollIntoView( this.driver, selector );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 
 	async selectAddPerson() {
 		let selector = By.css( '.sites-navigation [data-tip-target="users"] a.sidebar__button' );
 
-		driverHelper.scrollIntoView( this.driver, selector );
+		await driverHelper.scrollIntoView( this.driver, selector );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -7,13 +7,10 @@ import BaseContainer from '../base-container.js';
 import DisconnectSurveyPage from '../pages/disconnect-survey-page.js';
 
 export default class SidebarComponent extends BaseContainer {
-	constructor( driver, siteName = null ) {
+	constructor( driver ) {
 		super( driver, By.css( '.sidebar' ) );
 		this.storeSelector = By.css( '.sites-navigation li a[href*=store]' );
 		this.settingsSelector = By.css( '.sites-navigation [data-tip-target="settings"] a' );
-		if ( siteName !== null ) {
-			this.selectSite( siteName );
-		}
 	}
 
 	async selectDomains() {

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -151,7 +151,9 @@ export default class SidebarComponent extends BaseContainer {
 	}
 
 	async selectPosts() {
-		const selector = By.css( '.sites-navigation [data-post-type="post"] a:not(.sidebar__button)' );
+		const selector = By.css(
+			'.sites-navigation [data-post-type="post"] a:not(.sidebar__button) span'
+		);
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -78,18 +78,16 @@ export default class SidebarComponent extends BaseContainer {
 	async ensureSidebarMenuVisible() {
 		let allSitesSelector = By.css( '.current-section a' );
 		let sidebarSelector = By.css( '.sidebar' );
-		return await this.driver
-			.findElement( sidebarSelector )
-			.isDisplayed()
-			.then(
-				async sidebarVisible =>
-					! sidebarVisible
-						? await driverHelper.clickWhenClickable( this.driver, allSitesSelector )
-						: false
-			)
-			.then(
-				async () => await driverHelper.waitTillPresentAndDisplayed( this.driver, sidebarSelector )
-			);
+		let displayed = await driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			sidebarSelector,
+			1000
+		);
+
+		if ( ! displayed ) {
+			await driverHelper.clickWhenClickable( this.driver, allSitesSelector, this.explicitWaitMS );
+		}
+		return await driverHelper.waitTillPresentAndDisplayed( this.driver, sidebarSelector );
 	}
 
 	async searchForSite( searchString ) {
@@ -192,7 +190,11 @@ export default class SidebarComponent extends BaseContainer {
 		const siteSwitcherNewSiteButton = By.css( '.site-selector__add-new-site .button svg' );
 		let present = await driverHelper.isElementPresent( this.driver, sidebarNewSiteButton );
 		if ( present ) {
-			return await driverHelper.clickWhenClickable( this.driver, sidebarNewSiteButton );
+			return await driverHelper.clickWhenClickable(
+				this.driver,
+				sidebarNewSiteButton,
+				this.explicitWaitMS * 4
+			);
 		}
 		await this.selectSiteSwitcher();
 
@@ -213,7 +215,8 @@ export default class SidebarComponent extends BaseContainer {
 		await this.ensureSidebarMenuVisible();
 		let foundSwitcher = await driverHelper.isEventuallyPresentAndDisplayed(
 			this.driver,
-			siteSwitcherSelector
+			siteSwitcherSelector,
+			this.explicitWaitMS * 4
 		);
 		if ( ! foundSwitcher ) {
 			// no site switcher, only one site

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -23,23 +23,15 @@ export default class SidebarComponent extends BaseContainer {
 
 	async selectPeople() {
 		let selector = By.css( '.sites-navigation [data-tip-target="people"] a' );
-		let selectorElement = await this.driver.findElement( selector );
 
-		await this.driver.executeScript(
-			'arguments[0].scrollIntoView( { block: "center", inline: "center" } )',
-			selectorElement
-		);
+		driverHelper.scrollIntoView( this.driver, selector );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 
 	async selectAddPerson() {
 		let selector = By.css( '.sites-navigation [data-tip-target="users"] a.sidebar__button' );
-		let selectorElement = await this.driver.findElement( selector );
 
-		await this.driver.executeScript(
-			'arguments[0].scrollIntoView( { block: "center", inline: "center" } )',
-			selectorElement
-		);
+		driverHelper.scrollIntoView( this.driver, selector );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -23,11 +23,23 @@ export default class SidebarComponent extends BaseContainer {
 
 	async selectPeople() {
 		let selector = By.css( '.sites-navigation [data-tip-target="people"] a' );
+		let selectorElement = await this.driver.findElement( selector );
+
+		await this.driver.executeScript(
+			'arguments[0].scrollIntoView( { block: "center", inline: "center" } )',
+			selectorElement
+		);
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 
 	async selectAddPerson() {
 		let selector = By.css( '.sites-navigation [data-tip-target="users"] a.sidebar__button' );
+		let selectorElement = await this.driver.findElement( selector );
+
+		await this.driver.executeScript(
+			'arguments[0].scrollIntoView( { block: "center", inline: "center" } )',
+			selectorElement
+		);
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 

--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -451,3 +451,12 @@ export function refreshIfJNError( driver, timeout = 2000 ) {
 
 	return refreshIfNeeded();
 }
+
+export async function scrollIntoView( driver, selector ) {
+	let selectorElement = await driver.findElement( selector );
+
+	return await driver.executeScript(
+		'arguments[0].scrollIntoView( { block: "center", inline: "center" } )',
+		selectorElement
+	);
+}

--- a/lib/email-client.js
+++ b/lib/email-client.js
@@ -44,7 +44,7 @@ export default class EmailClient {
 	 * @param {function} validator - Optional function to validate received emails
 	 * @returns {Object} - Returns `object`
 	 */
-	async pollEmailsByRecipient( emailAddress, validator = () => true ) {
+	async pollEmailsByRecipient( emailAddress, validator = emails => emails > 0 ) {
 		const intervalMS = 1500;
 		let retries = emailWaitMS / intervalMS;
 		let emails;

--- a/lib/email-client.js
+++ b/lib/email-client.js
@@ -44,7 +44,7 @@ export default class EmailClient {
 	 * @param {function} validator - Optional function to validate received emails
 	 * @returns {Object} - Returns `object`
 	 */
-	async pollEmailsByRecipient( emailAddress, validator = emails => emails > 0 ) {
+	async pollEmailsByRecipient( emailAddress, validator = emails => emails.length > 0 ) {
 		const intervalMS = 1500;
 		let retries = emailWaitMS / intervalMS;
 		let emails;

--- a/lib/flows/jetpack-connect-flow.js
+++ b/lib/flows/jetpack-connect-flow.js
@@ -71,30 +71,29 @@ export default class JetpackConnectFlow {
 		wpAdminJetpack.activateRecommendedFeatures();
 	}
 
-	removeSites( timeout = config.get( 'mochaTimeoutMS' ) ) {
+	async removeSites( timeout = config.get( 'mochaTimeoutMS' ) ) {
 		const timeStarted = Date.now();
-		new LoginFlow( this.driver, this.account ).loginAndSelectMySite();
+		await new LoginFlow( this.driver, this.account ).loginAndSelectMySite();
 
-		const removeSites = () => {
-			return new SidebarComponent( this.driver ).removeBrokenSite().then( removed => {
-				if ( ! removed || Date.now() - timeStarted > 0.8 * timeout ) {
-					// 80% of timeout
-					// no sites left to remove or removeSites taking too long
-					return;
-				}
-				// seems like it is not waiting for this
-				driverHelper.waitTillPresentAndDisplayed(
-					this.driver,
-					By.css( '.notice.is-success.is-dismissable' )
-				);
-				driverHelper.clickWhenClickable(
-					this.driver,
-					By.css( '.notice.is-dismissable .notice__dismiss' )
-				);
-				return removeSites();
-			} );
+		const removeSites = async () => {
+			let siteRemoved = await new SidebarComponent( this.driver ).removeBrokenSite();
+			if ( ! siteRemoved || Date.now() - timeStarted > 0.8 * timeout ) {
+				// 80% of timeout
+				// no sites left to remove or removeSites taking too long
+				return;
+			}
+			// seems like it is not waiting for this
+			await driverHelper.waitTillPresentAndDisplayed(
+				this.driver,
+				By.css( '.notice.is-success.is-dismissable' )
+			);
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( '.notice.is-dismissable .notice__dismiss' )
+			);
+			return await removeSites();
 		};
 
-		return removeSites();
+		return await removeSites();
 	}
 }

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -399,9 +399,9 @@ export default class EditorPage extends BaseContainer {
 	}
 
 	async titleShown() {
-		return await this.driver
-			.findElement( by.css( '.editor-title__input' ) )
-			.getAttribute( 'value' );
+		let titleSelector = by.css( '.editor-title__input' );
+		driverHelper.waitTillPresentAndDisplayed( this.driver, titleSelector );
+		return await this.driver.findElement( titleSelector ).getAttribute( 'value' );
 	}
 
 	async publishEnabled() {

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -400,7 +400,7 @@ export default class EditorPage extends BaseContainer {
 
 	async titleShown() {
 		let titleSelector = by.css( '.editor-title__input' );
-		driverHelper.waitTillPresentAndDisplayed( this.driver, titleSelector );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, titleSelector );
 		return await this.driver.findElement( titleSelector ).getAttribute( 'value' );
 	}
 

--- a/lib/pages/jetpack/jetpack-connect-page.js
+++ b/lib/pages/jetpack/jetpack-connect-page.js
@@ -14,14 +14,13 @@ export default class JetpackConnectPage extends BaseContainer {
 		}
 	}
 
-	addSiteUrl( url ) {
+	async addSiteUrl( url ) {
 		let urlInputSelector = By.css( '.jetpack-connect__site-address-container #siteUrl' );
 		let confirmButtonSelector = By.css(
 			'.jetpack-connect__main .jetpack-connect__connect-button:not([disabled])'
 		);
 
-		return driverHelper
-			.setWhenSettable( this.driver, urlInputSelector, url )
-			.then( () => driverHelper.clickWhenClickable( this.driver, confirmButtonSelector ) );
+		await driverHelper.setWhenSettable( this.driver, urlInputSelector, url );
+		return await driverHelper.clickWhenClickable( this.driver, confirmButtonSelector );
 	}
 }

--- a/lib/pages/posts-page.js
+++ b/lib/pages/posts-page.js
@@ -37,7 +37,11 @@ export default class PostsPage extends BaseContainer {
 		return driverHelper.isElementPresent( this.driver, PostsPage._getPostXpathSelector( title ) );
 	}
 	editPostWithTitle( title ) {
-		return driverHelper.clickWhenClickable( this.driver, PostsPage._getPostXpathSelector( title ) );
+		return driverHelper.clickWhenClickable(
+			this.driver,
+			PostsPage._getPostXpathSelector( title ),
+			this.explicitWaitMS * 2
+		);
 	}
 
 	successNoticeDisplayed() {

--- a/lib/pages/posts-page.js
+++ b/lib/pages/posts-page.js
@@ -34,7 +34,10 @@ export default class PostsPage extends BaseContainer {
 	}
 
 	isPostDisplayed( title ) {
-		return driverHelper.isElementPresent( this.driver, PostsPage._getPostXpathSelector( title ) );
+		return driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			PostsPage._getPostXpathSelector( title )
+		);
 	}
 	editPostWithTitle( title ) {
 		return driverHelper.clickWhenClickable(

--- a/lib/pages/themes-page.js
+++ b/lib/pages/themes-page.js
@@ -79,7 +79,7 @@ export default class ThemesPage extends BaseContainer {
 	async clickNewThemeMoreButton() {
 		const selector = by.css( '.is-actionable:not(.is-active) button' );
 
-		driverHelper.scrollIntoView( this.driver, selector );
+		await driverHelper.scrollIntoView( this.driver, selector );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 

--- a/lib/pages/themes-page.js
+++ b/lib/pages/themes-page.js
@@ -78,11 +78,8 @@ export default class ThemesPage extends BaseContainer {
 
 	async clickNewThemeMoreButton() {
 		const selector = by.css( '.is-actionable:not(.is-active) button' );
-		let moreButtonElement = await this.driver.findElement( selector );
-		await this.driver.executeScript(
-			'arguments[0].scrollIntoView( { block: "center", inline: "center" } )',
-			moreButtonElement
-		);
+
+		driverHelper.scrollIntoView( this.driver, selector );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -137,8 +137,9 @@ test.describe( `Jetpack Connect: (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can approve connection on the authorization page', async function() {
-			this.jetpackAuthorizePage = new JetpackAuthorizePage( driver );
-			return await this.jetpackAuthorizePage.approveConnection();
+			return await new JetpackAuthorizePage( driver, {
+				overrideABTests: false,
+			} ).approveConnection();
 		} );
 
 		test.it( 'Can click the free plan button', async function() {
@@ -272,7 +273,9 @@ test.describe( `Jetpack Connect: (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can start connection flow using JN site', async function() {
-				return await new JetpackConnectPage( driver ).addSiteUrl( jnFlow.url );
+				return await new JetpackConnectPage( driver, { overrideABTests: false } ).addSiteUrl(
+					jnFlow.url
+				);
 			} );
 
 			test.it( 'Can enter the Jetpack credentials and install Jetpack', async function() {

--- a/specs-jetpack-calypso/wp-jetpack-onboarding-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-onboarding-spec.js
@@ -98,7 +98,9 @@ test.describe( `Jetpack Onboarding: (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can approve connection on the authorization page', async function() {
-			return await new JetpackAuthorizePage( driver ).approveConnection();
+			return await new JetpackAuthorizePage( driver, {
+				overrideABTests: false,
+			} ).approveConnection();
 		} );
 
 		test.it( 'Can select continue on add contact form', async function() {
@@ -176,7 +178,9 @@ test.describe( `Jetpack Onboarding: (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can approve connection on the authorization page', async function() {
-			return await new JetpackAuthorizePage( driver ).approveConnection();
+			return await new JetpackAuthorizePage( driver, {
+				overrideABTests: false,
+			} ).approveConnection();
 		} );
 
 		test.it( 'Can enter address on business address page', async function() {
@@ -351,7 +355,9 @@ test.describe( `Jetpack Onboarding: (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can approve connection on the authorization page', async function() {
-				return await new JetpackAuthorizePage( driver ).approveConnection();
+				return await new JetpackAuthorizePage( driver, {
+					overrideABTests: false,
+				} ).approveConnection();
 			} );
 
 			test.it( 'Can click the free plan button', async function() {

--- a/specs-jetpack-calypso/wp-pressable-nux-spec.js
+++ b/specs-jetpack-calypso/wp-pressable-nux-spec.js
@@ -82,7 +82,9 @@ if ( host === 'PRESSABLE' ) {
 			} );
 
 			test.it( 'Can approve connection on the authorization page', async function() {
-				return await new JetpackAuthorizePage( driver ).approveConnection();
+				return await new JetpackAuthorizePage( driver, {
+					overrideABTests: false,
+				} ).approveConnection();
 			} );
 
 			test.it(

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -1149,7 +1149,10 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 					this.navbarComponent = new NavbarComponent( driver );
 					await this.navbarComponent.clickMySites();
 					const jetpackSiteName = dataHelper.getJetpackSiteName();
-					this.sidebarComponent = new SidebarComponent( driver, jetpackSiteName );
+					this.sidebarComponent = new SidebarComponent( driver );
+					if ( host !== 'WPCOM' ) {
+						await this.sidebarComponent.selectSite( jetpackSiteName );
+					}
 					await this.sidebarComponent.selectPosts();
 					return ( this.postsPage = new PostsPage( driver ) );
 				} );


### PR DESCRIPTION
Bunch of Jetpack tests started to fail due to different reasons:
- `JetpackConnect` user got ~120 disconnected sites, which causes "Switch site" button did not show up right away. 
- Setting up AB tests on `JetpackAuthorizePage` & `JetpackConnectPage` causes an unexpected page reload, which breaks the tests.
- Some other tests started to fail due to async/await changes

I might fix some of the test flakiness along the way