### PR TITLE
Update invite spec

### DIFF
--- a/lib/async-base-container.js
+++ b/lib/async-base-container.js
@@ -46,7 +46,10 @@ export default class AsyncBaseContainer {
 	async _expectInit() {
 		await this.waitForPage();
 		await this.checkForUnknownABTestKeys();
-		return await this.checkForConsoleErrors();
+		await this.checkForConsoleErrors();
+		if ( typeof this._postInit === 'function' ) {
+			await this._postInit();
+		}
 	}
 
 	async waitForPage() {

--- a/lib/components/nav-bar-component.js
+++ b/lib/components/nav-bar-component.js
@@ -5,7 +5,7 @@ import * as driverHelper from '../driver-helper.js';
 
 import AsyncBaseContainer from '../async-base-container';
 
-export default class NavbarComponent extends AsyncBaseContainer {
+export default class NavBarComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, by.css( '.masterbar' ) );
 	}

--- a/lib/components/navbar-component.js
+++ b/lib/components/navbar-component.js
@@ -3,9 +3,9 @@
 import { By as by } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper.js';
 
-import BaseContainer from '../base-container.js';
+import AsyncBaseContainer from '../async-base-container';
 
-export default class NavbarComponent extends BaseContainer {
+export default class NavbarComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, by.css( '.masterbar' ) );
 	}

--- a/lib/components/no-sites-component.js
+++ b/lib/components/no-sites-component.js
@@ -2,9 +2,9 @@
 
 import { By } from 'selenium-webdriver';
 
-import BaseContainer from '../base-container.js';
+import AsyncBaseContainer from '../async-base-container';
 
-export default class NoSitesComponent extends BaseContainer {
+export default class NoSitesComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.empty-content' ) );
 	}

--- a/lib/components/notices-component.js
+++ b/lib/components/notices-component.js
@@ -1,28 +1,27 @@
 /** @format */
 
-import { By, until } from 'selenium-webdriver';
+import { By } from 'selenium-webdriver';
 
 import config from 'config';
 
-import BaseContainer from '../base-container.js';
+import * as driverHelper from '../driver-helper.js';
 
-export default class NoticesComponent extends BaseContainer {
+import AsyncBaseContainer from '../async-base-container';
+
+export default class NoticesComponent extends AsyncBaseContainer {
 	constructor( driver ) {
-		const longExplicitWaitMS = config.get( 'explicitWaitMS' ) * 3;
-		const expectedElementSelector = By.css( '#notices' );
-		driver.wait(
-			until.elementLocated( expectedElementSelector ),
-			longExplicitWaitMS,
-			`Could not locate the notices component after: ${ longExplicitWaitMS }ms`
-		);
-		super( driver, expectedElementSelector );
+		super( driver, By.css( '#notices' ), null, config.get( 'explicitWaitMS' ) * 3 );
 	}
 
 	async inviteMessageTitle() {
-		return await this.driver.findElement( By.css( '.invite-message__title' ) ).getText();
+		const selector = By.css( '.invite-message__title' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
+		return await this.driver.findElement( selector ).getText();
 	}
 
 	async followMessageTitle() {
-		return await this.driver.findElement( By.css( '#notices .notice__text' ) ).getText();
+		const selector = By.css( '#notices .notice__text' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
+		return await this.driver.findElement( selector ).getText();
 	}
 }

--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -4,11 +4,11 @@ import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper.js';
 import * as driverManager from '../driver-manager.js';
 
-import BaseContainer from '../base-container.js';
+import AsyncBaseContainer from '../async-base-container';
 import PostPreviewComponent from './post-preview-component.js';
 import EditorConfirmationSidebarComponent from './editor-confirmation-sidebar-component';
 
-export default class PostEditorToolbarComponent extends BaseContainer {
+export default class PostEditorToolbarComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.editor-ground-control' ) );
 		this.publishButtonSelector = By.css( '.editor-publish-button' );

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -90,7 +90,7 @@ export default class LoginFlow {
 
 		await this.login();
 
-		let readerPage = new ReaderPage( this.driver, true );
+		const readerPage = await ReaderPage.Visit( this.driver );
 		await readerPage.waitForPage();
 
 		let navbarComponent = new NavbarComponent( this.driver );
@@ -138,7 +138,7 @@ export default class LoginFlow {
 	async loginAndSelectMySite( site = null ) {
 		await this.login();
 
-		let readerPage = new ReaderPage( this.driver, true );
+		const readerPage = await ReaderPage.Visit( this.driver );
 		await readerPage.waitForPage();
 
 		let navbarComponent = new NavbarComponent( this.driver );

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -96,7 +96,7 @@ export default class LoginFlow {
 		const navbarComponent = await NavBarComponent.Expect( this.driver );
 		await navbarComponent.clickCreateNewPost( { siteURL: siteURL } );
 
-		this.editorPage = new EditorPage( this.driver );
+		this.editorPage = await EditorPage.Expect( this.driver );
 
 		let urlDisplayed = await this.driver.getCurrentUrl();
 		return await this.editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
@@ -108,7 +108,7 @@ export default class LoginFlow {
 		let sidebarComponent = new SidebarComponent( this.driver );
 		await sidebarComponent.selectAddNewPage();
 
-		this.editorPage = new EditorPage( this.driver );
+		this.editorPage = await EditorPage.Expect( this.driver );
 
 		let urlDisplayed = await this.driver.getCurrentUrl();
 		return await this.editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -8,7 +8,7 @@ import StatsPage from '../pages/stats-page.js';
 import StoreDashboardPage from '../pages/woocommerce/store-dashboard-page';
 
 import SidebarComponent from '../components/sidebar-component.js';
-import NavbarComponent from '../components/navbar-component.js';
+import NavBarComponent from '../components/nav-bar-component.js';
 
 import * as eyesHelper from '../eyes-helper';
 import * as dataHelper from '../data-helper';
@@ -93,7 +93,7 @@ export default class LoginFlow {
 		const readerPage = await ReaderPage.Visit( this.driver );
 		await readerPage.waitForPage();
 
-		const navbarComponent = await NavbarComponent.Expect( this.driver );
+		const navbarComponent = await NavBarComponent.Expect( this.driver );
 		await navbarComponent.clickCreateNewPost( { siteURL: siteURL } );
 
 		this.editorPage = new EditorPage( this.driver );
@@ -141,7 +141,7 @@ export default class LoginFlow {
 		const readerPage = await ReaderPage.Visit( this.driver );
 		await readerPage.waitForPage();
 
-		const navbarComponent = await NavbarComponent.Expect( this.driver );
+		const navbarComponent = await NavBarComponent.Expect( this.driver );
 		await navbarComponent.clickMySites();
 
 		if (

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -93,7 +93,7 @@ export default class LoginFlow {
 		const readerPage = await ReaderPage.Visit( this.driver );
 		await readerPage.waitForPage();
 
-		let navbarComponent = new NavbarComponent( this.driver );
+		const navbarComponent = await NavbarComponent.Expect( this.driver );
 		await navbarComponent.clickCreateNewPost( { siteURL: siteURL } );
 
 		this.editorPage = new EditorPage( this.driver );
@@ -141,7 +141,7 @@ export default class LoginFlow {
 		const readerPage = await ReaderPage.Visit( this.driver );
 		await readerPage.waitForPage();
 
-		let navbarComponent = new NavbarComponent( this.driver );
+		const navbarComponent = await NavbarComponent.Expect( this.driver );
 		await navbarComponent.clickMySites();
 
 		if (

--- a/lib/flows/sign-up-flow.js
+++ b/lib/flows/sign-up-flow.js
@@ -38,25 +38,21 @@ export default class SignUpFlow {
 		const signupProcessingPage = await SignupProcessingPage.Expect( this.driver );
 		await signupProcessingPage.waitForContinueButtonToBeEnabled();
 		await signupProcessingPage.continueAlong();
-		const readerPage = new ReaderPage( this.driver );
+		const readerPage = await ReaderPage.Expect( this.driver );
 		await readerPage.displayed();
 		global.__TEMPJETPACKHOST__ = false;
 	}
 
-	activateAccount() {
-		return this.emailClient
-			.pollEmailsByRecipient( this.emailAddress )
-			.then( emails => {
-				for ( let email of emails ) {
-					if ( email.subject.indexOf( 'Activate' ) > -1 ) {
-						return email.html.links[ 0 ].href;
-					}
-				}
-			} )
-			.then( activationLink => {
-				this.driver.get( activationLink );
-				let readerPage = new ReaderPage( this.driver, true );
-				return readerPage.waitForPage();
-			} );
+	async activateAccount() {
+		let activationLink;
+		const emails = await this.emailClient.pollEmailsByRecipient( this.emailAddress );
+		for ( let email of emails ) {
+			if ( email.subject.indexOf( 'Activate' ) > -1 ) {
+				activationLink = email.html.links[ 0 ].href;
+			}
+		}
+		await this.driver.get( activationLink );
+		const readerPage = await ReaderPage.Expect( this.driver );
+		return await readerPage.waitForPage();
 	}
 }

--- a/lib/pages/accept-invite-page.js
+++ b/lib/pages/accept-invite-page.js
@@ -2,13 +2,12 @@
 
 import { By } from 'selenium-webdriver';
 
-import BaseContainer from '../base-container.js';
+import AsyncBaseContainer from '../async-base-container';
 import * as DriverHelper from '../driver-helper.js';
 
-export default class AcceptInvitePage extends BaseContainer {
+export default class AcceptInvitePage extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.invite-accept' ) );
-		driver.executeScript( 'localStorage.setItem( "debug", "calypso:invite-accept:*" )' );
 	}
 
 	getEmailPreFilled() {
@@ -16,32 +15,20 @@ export default class AcceptInvitePage extends BaseContainer {
 	}
 
 	async enterUsernameAndPasswordAndSignUp( username, password ) {
-		const userNameSelector = By.css( '#username' );
-		const passwordSelector = By.css( '#password' );
-		const submitSelector = By.css( '.signup-form__submit' );
-
-		await DriverHelper.setWhenSettable( this.driver, userNameSelector, username );
-		await DriverHelper.setWhenSettable( this.driver, passwordSelector, password, true );
-		return await DriverHelper.clickWhenClickable( this.driver, submitSelector );
+		await DriverHelper.setWhenSettable( this.driver, By.css( '#username' ), username );
+		await DriverHelper.setWhenSettable( this.driver, By.css( '#password' ), password, true );
+		return await DriverHelper.clickWhenClickable( this.driver, By.css( '.signup-form__submit' ) );
 	}
 
-	getHeaderInviteText() {
-		return this.driver.findElement( By.css( '.invite-header__invited-you-text' ) ).getText();
+	async getHeaderInviteText() {
+		return await this.driver.findElement( By.css( '.invite-header__invited-you-text' ) ).getText();
 	}
 
 	async waitUntilNotVisible() {
-		const driver = this.driver;
-		const explicitWaitMS = this.explicitWaitMS;
-		const userNameSelector = By.css( '#username' );
-
-		return await driver.wait(
-			function() {
-				return DriverHelper.isElementPresent( driver, userNameSelector ).then( function( present ) {
-					return ! present;
-				} );
-			},
-			explicitWaitMS,
-			'The accept invite signup form is still displayed after submitting the form'
+		return await DriverHelper.waitTillNotPresent(
+			this.driver,
+			By.css( '#username' ),
+			this.explicitWaitMS * 2
 		);
 	}
 }

--- a/lib/pages/edit-team-member-page.js
+++ b/lib/pages/edit-team-member-page.js
@@ -1,11 +1,11 @@
 /** @format */
 
 import { By } from 'selenium-webdriver';
-import BaseContainer from '../base-container.js';
+import AsyncBaseContainer from '../async-base-container';
 
 import * as DriverHelper from '../driver-helper.js';
 
-export default class EditTeamMemberPage extends BaseContainer {
+export default class EditTeamMemberPage extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.edit-team-member-form' ) );
 	}
@@ -18,27 +18,16 @@ export default class EditTeamMemberPage extends BaseContainer {
 		);
 	}
 
-	removeSelectedUser() {
-		DriverHelper.clickWhenClickable( this.driver, By.css( '.delete-user__remove-user' ) );
-		return DriverHelper.clickWhenClickable( this.driver, By.css( '.dialog button.is-primary' ) );
-	}
-
-	changeToNewRole( roleName ) {
-		// Work out why we need to do this twice
-		// https://github.com/Automattic/wp-e2e-tests/issues/1185
-		DriverHelper.clickWhenClickable(
+	async changeToNewRole( roleName ) {
+		await DriverHelper.clickWhenClickable(
 			this.driver,
 			By.css( `select#roles option[value=${ roleName }]` )
 		);
-		DriverHelper.clickWhenClickable(
-			this.driver,
-			By.css( `select#roles option[value=${ roleName }]` )
-		);
-		DriverHelper.clickWhenClickable(
+		await DriverHelper.clickWhenClickable(
 			this.driver,
 			By.css( 'button.form-button.is-primary:not([disabled])' )
 		);
-		return DriverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.is-success' ) );
+		return await DriverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.is-success' ) );
 	}
 
 	async successNoticeDisplayed() {

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -61,12 +61,11 @@ export default class EditorPage extends AsyncBaseContainer {
 	}
 
 	async uploadMedia( fileDetails ) {
-		const self = this;
 		const newFile = fileDetails.file;
 
-		await self.chooseInsertMediaOption();
-		await self.sendFile( newFile );
-		return await self.driver.sleep( 1000 );
+		await this.chooseInsertMediaOption();
+		await this.sendFile( newFile );
+		return await this.driver.sleep( 1000 );
 	}
 
 	async sendFile( file ) {
@@ -262,7 +261,7 @@ export default class EditorPage extends AsyncBaseContainer {
 	async waitUntilImageInserted( fileDetails ) {
 		const newImageName = fileDetails.imageName;
 		await this.driver.wait(
-			until.ableToSwitchToFrame( self.editorFrameName ),
+			until.ableToSwitchToFrame( this.editorFrameName ),
 			this.explicitWaitMS,
 			'Could not locate the editor iFrame.'
 		);
@@ -270,7 +269,7 @@ export default class EditorPage extends AsyncBaseContainer {
 			this.driver,
 			by.css( 'img[alt="' + newImageName + '"]' )
 		);
-		return await self.driver.switchTo().defaultContent();
+		return await this.driver.switchTo().defaultContent();
 	}
 
 	async waitUntilFeaturedImageInserted() {

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -319,7 +319,7 @@ export default class EditorPage extends AsyncBaseContainer {
 
 	async waitForTitle() {
 		return await driverHelper.waitTillNotPresent(
-			this.editor,
+			this.driver,
 			by.css( '.editor-title.is-loading' )
 		);
 	}

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -4,41 +4,30 @@ import webdriver from 'selenium-webdriver';
 
 import * as driverHelper from '../driver-helper.js';
 import * as driverManager from '../driver-manager.js';
-// import * as slackNotifier from '../slack-notifier.js';
 import * as eyesHelper from '../eyes-helper.js';
 
 const by = webdriver.By;
 const until = webdriver.until;
 
-import BaseContainer from '../base-container.js';
+import AsyncBaseContainer from '../async-base-container';
 
-export default class EditorPage extends BaseContainer {
+export default class EditorPage extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, by.css( '.post-editor' ) );
 		this.editorFrameName = by.css( '.mce-edit-area iframe' );
-		const contentSelector = by.css( 'div.is-section-post-editor' );
-		const cogSelector = by.css( 'button.editor-ground-control__toggle-sidebar' );
-		this.fileNameInputSelector = webdriver.By.css(
-			'.media-library__upload-button input[type="file"]'
-		);
-
-		driverHelper.waitTillPresentAndDisplayed( driver, contentSelector );
-		driver
-			.findElement( contentSelector )
-			.getAttribute( 'class' )
-			.then( c => {
-				if ( c.indexOf( 'focus-content' ) < 0 ) {
-					driverHelper.clickWhenClickable( driver, cogSelector );
-				}
-			} );
-
-		this.waitForPage();
-		this.ensureEditorShown();
 	}
 
-	async ensureEditorShown() {
-		const driver = this.driver;
-		return await driverHelper.waitTillPresentAndDisplayed( driver, this.editorFrameName );
+	async _postInit() {
+		const contentSelector = by.css( 'div.is-section-post-editor' );
+		const cogSelector = by.css( 'button.editor-ground-control__toggle-sidebar' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, contentSelector );
+		const contentElement = await this.driver.findElement( contentSelector );
+		const classes = await contentElement.getAttribute( 'class' );
+		if ( classes.indexOf( 'focus-content' ) < 0 ) {
+			await driverHelper.clickWhenClickable( this.driver, cogSelector );
+		}
+		await this.waitForPage();
+		return await driverHelper.waitTillPresentAndDisplayed( this.driver, this.editorFrameName );
 	}
 
 	async enterTitle( blogPostTitle ) {
@@ -81,13 +70,16 @@ export default class EditorPage extends BaseContainer {
 	}
 
 	async sendFile( file ) {
+		const fileNameInputSelector = webdriver.By.css(
+			'.media-library__upload-button input[type="file"]'
+		);
 		const driver = this.driver;
 
 		await driverHelper.waitTillPresentAndDisplayed(
 			driver,
 			by.className( 'media-library__upload-button' )
 		);
-		let fileNameInput = await driver.findElement( this.fileNameInputSelector );
+		let fileNameInput = await driver.findElement( fileNameInputSelector );
 		await fileNameInput.sendKeys( file );
 		await driverHelper.elementIsNotPresent( driver, '.media-library__list-item.is-transient' );
 		await driverHelper.elementIsNotPresent( driver, '.media-library .notice.is-error' );

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -101,103 +101,52 @@ export default class EditorPage extends AsyncBaseContainer {
 	}
 
 	async openImageDetails() {
-		const driver = this.driver;
-		let editSelector = by.css( 'button[data-e2e-button="edit"]' );
-		driver.wait(
-			until.elementLocated( editSelector ),
-			this.explicitWaitMS,
-			'Could not locate the edit button in the media library'
-		);
-		const editButton = await driver.findElement( editSelector );
-		driver.wait(
-			until.elementIsEnabled( editButton ),
-			this.explicitWaitMS,
-			'The edit button is not enabled'
-		);
-		return await editButton.click();
+		const editSelector = by.css( 'button[data-e2e-button="edit"]:not([disabled])' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, editSelector );
+		return await driverHelper.clickWhenClickable( this.driver, editSelector );
 	}
 
 	async selectEditImage() {
-		const driver = this.driver;
-		let editSelector = by.css( '.editor-media-modal-detail__edit' );
+		let editSelector = by.css( '.editor-media-modal-detail__edit:not([disabled])' );
 		if ( driverManager.currentScreenSize() === 'mobile' ) {
-			editSelector = by.css( '.is-mobile .editor-media-modal-detail__edit' );
+			editSelector = by.css( '.is-mobile .editor-media-modal-detail__edit:not([disabled])' );
 		}
-		driver.wait(
-			until.elementLocated( editSelector ),
-			this.explicitWaitMS,
-			'Could not locate the edit image button'
-		);
-		const editImageButton = await driver.findElement( editSelector );
-		driver.wait(
-			until.elementIsEnabled( editImageButton ),
-			this.explicitWaitMS,
-			'The edit image button is not enabled'
-		);
-		return await editImageButton.click();
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, editSelector );
+		return await driverHelper.clickWhenClickable( this.driver, editSelector );
 	}
 
 	async waitForImageEditor() {
-		const driver = this.driver;
-		const imageEditorPlaceholderSelector = by.css( '.image-editor__canvas.is-placeholder' );
-		return driver.wait(
-			async function() {
-				let present = await driverHelper.isElementPresent( driver, imageEditorPlaceholderSelector );
-				return ! present;
-			},
-			this.explicitWaitMS,
-			'The image editor placeholder element was still present when it should have disappeared by now.'
+		return await driverHelper.waitTillNotPresent(
+			this.driver,
+			'.image-editor__canvas.is-placeholder'
 		);
 	}
 
 	async dismissImageEditor() {
-		const driver = this.driver;
-		let cancelSelector = by.css( 'button[data-e2e-button="cancel"]' );
-		const cancelButton = await driver.findElement( cancelSelector );
-		driver.wait(
-			until.elementIsEnabled( cancelButton ),
-			this.explicitWaitMS,
-			'The edit image button is not enabled'
-		);
-		return await cancelButton.click();
+		const cancelSelector = by.css( 'button[data-e2e-button="cancel"]:not([disabled])' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, cancelSelector );
+		return await driverHelper.clickWhenClickable( this.driver, cancelSelector );
 	}
 
 	async dismissImageDetails() {
-		const driver = this.driver;
-		let backSelector = by.css( '.editor-media-modal-detail .header-cake__back' );
-		driver.wait(
-			until.elementLocated( backSelector ),
-			this.explicitWaitMS,
-			'Could not locate the Media Library back button'
-		);
-		const backButton = await driver.findElement( backSelector );
-		driver.wait(
-			until.elementIsEnabled( backButton ),
-			this.explicitWaitMS,
-			'The back button is not enabled'
-		);
-		return await backButton.click();
+		const backSelector = by.css( '.editor-media-modal-detail .header-cake__back:not([disabled])' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, backSelector );
+		return await driverHelper.clickWhenClickable( this.driver, backSelector );
 	}
 
-	async selectImageByNumber( count ) {
-		const driver = this.driver;
-
-		driver.wait(
-			until.elementLocated( by.className( 'media-library__upload-button' ) ),
-			this.explicitWaitMS,
-			'Could not locate the media library upload button.'
+	async selectFirstImage() {
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			by.css( '.media-library__upload-button' )
 		);
-		driver.wait(
-			until.elementsLocated( by.css( '.media-library__list-item:not(.is-placeholder)' ) ),
-			this.explicitWaitMS,
-			'Could not locate image elements.'
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			by.css( '.media-library__list-item:not(.is-placeholder)' )
 		);
-		let elements = await driver.findElements( by.className( 'media-library__list-item' ) );
-		await elements[ count ].click();
-		return driver.wait(
-			until.elementLocated( by.css( '.media-library__list-item.is-selected' ) ),
-			this.explicitWaitMS,
-			'Could not locate the selected media item.'
+		await driverHelper.clickWhenClickable( this.driver, by.css( '.media-library__list-item' ) );
+		return await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			by.css( '.media-library__list-item.is-selected' )
 		);
 	}
 
@@ -249,7 +198,7 @@ export default class EditorPage extends AsyncBaseContainer {
 			by.css( '.editor-simple-payments-modal__form #price' ),
 			price
 		);
-		driverHelper.clickWhenClickable(
+		await driverHelper.clickWhenClickable(
 			this.driver,
 			by.css(
 				`.editor-simple-payments-modal__form .form-currency-input__select option[value="${ currency }"]`
@@ -278,56 +227,48 @@ export default class EditorPage extends AsyncBaseContainer {
 	}
 
 	async enterPostImage( fileDetails ) {
-		const self = this;
 		const newImageName = fileDetails.imageName;
 		const newFile = fileDetails.file;
 
-		await self.chooseInsertMediaOption();
-		await self.sendFile( newFile );
-		let imageUploadedSelector = webdriver.By.css( 'img[alt="' + newImageName + '"]' );
-		await self.driver.wait(
-			until.elementLocated( imageUploadedSelector ),
-			this.explicitWaitMS,
-			'Could not locate the uploaded image in the media library'
-		);
+		await this.chooseInsertMediaOption();
+		await this.sendFile( newFile );
+		const imageUploadedSelector = webdriver.By.css( 'img[alt="' + newImageName + '"]' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, imageUploadedSelector );
 		return await driverHelper.clickWhenClickable(
-			self.driver,
+			this.driver,
 			by.css( 'button[data-e2e-button="confirm"]' )
 		);
 	}
 
 	async deleteMedia() {
-		let deleteSelector = by.css( '.editor-media-modal__delete' );
-		let acceptSelector = by.css( 'button[data-e2e-button="accept"]' );
-
-		await driverHelper.clickWhenClickable( this.driver, deleteSelector );
-		return await driverHelper.clickWhenClickable( this.driver, acceptSelector );
+		await driverHelper.clickWhenClickable( this.driver, by.css( '.editor-media-modal__delete' ) );
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			by.css( 'button[data-e2e-button="accept"]' )
+		);
 	}
 
 	async dismissMediaModal() {
-		const driver = this.driver;
-		const cancelSelector = by.css( 'button[data-e2e-button="cancel"]' );
-		let button = await driver.findElement( cancelSelector );
-		await button.click();
-		return driver.wait(
-			driverHelper.elementIsNotPresent( this.driver, '.dialog__backdrop.is-full-screen' ),
-			this.explicitWaitMS,
-			'Dialog is still present'
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			by.css( 'button[data-e2e-button="cancel"]' )
+		);
+		return await driverHelper.waitTillNotPresent(
+			this.driver,
+			by.css( '.dialog__backdrop.is-full-screen' )
 		);
 	}
 
 	async waitUntilImageInserted( fileDetails ) {
-		const self = this;
 		const newImageName = fileDetails.imageName;
-		await self.driver.wait(
+		await this.driver.wait(
 			until.ableToSwitchToFrame( self.editorFrameName ),
-			self.explicitWaitMS,
+			this.explicitWaitMS,
 			'Could not locate the editor iFrame.'
 		);
-		await self.driver.wait(
-			until.elementLocated( by.css( 'img[alt="' + newImageName + '"]' ) ),
-			this.explicitWaitMS,
-			'Could not locate image in editor, check it is visible'
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			by.css( 'img[alt="' + newImageName + '"]' )
 		);
 		return await self.driver.switchTo().defaultContent();
 	}
@@ -378,33 +319,24 @@ export default class EditorPage extends AsyncBaseContainer {
 	}
 
 	async waitForTitle() {
-		const driver = this.driver;
-		const titleLoadingSelector = by.css( '.editor-title.is-loading' );
-		driver.wait(
-			async function() {
-				let present = await driverHelper.isElementPresent( driver, titleLoadingSelector );
-				return ! present;
-			},
-			this.explicitWaitMS,
-			'The title is loading element was still present when it should have disappeared by now.'
+		return await driverHelper.waitTillNotPresent(
+			this.editor,
+			by.css( '.editor-title.is-loading' )
 		);
 	}
 
 	async titleShown() {
 		let titleSelector = by.css( '.editor-title__input' );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, titleSelector );
-		return await this.driver.findElement( titleSelector ).getAttribute( 'value' );
+		const element = await this.driver.findElement( titleSelector );
+		return await element.getAttribute( 'value' );
 	}
 
 	async publishEnabled() {
-		const publishSelector = by.css( '.editor-publish-button' );
-		let d = await this.driver.findElement( publishSelector ).getAttribute( 'disabled' );
-		return d !== 'true';
-	}
-
-	async emailVerificationNoticeDisplayed() {
-		const emailVerificationSelector = by.css( '.editor-ground-control__email-verification-notice' );
-		return await driverHelper.isElementPresent( this.driver, emailVerificationSelector );
+		return await driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			'.editor-publish-button:not([disabled])'
+		);
 	}
 
 	async postIsScheduled() {

--- a/lib/pages/invite-error-page.js
+++ b/lib/pages/invite-error-page.js
@@ -1,18 +1,16 @@
 /** @format */
 
 import { By } from 'selenium-webdriver';
-import BaseContainer from '../base-container.js';
+import AsyncBaseContainer from '../async-base-container';
 
 import * as DriverHelper from '../driver-helper.js';
 
-export default class InviteErrorPage extends BaseContainer {
+export default class InviteErrorPage extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.empty-content__illustration' ) );
-		this.inviteErrorTitleSelector = By.css( '.empty-content__title' );
-		this.inviteErrorMessageSelector = By.css( '.empty-content__line' );
 	}
 
 	inviteErrorTitleDisplayed() {
-		return DriverHelper.isElementPresent( this.driver, this.inviteErrorTitleSelector );
+		return DriverHelper.isElementPresent( this.driver, By.css( '.empty-content__title' ) );
 	}
 }

--- a/lib/pages/invite-people-page.js
+++ b/lib/pages/invite-people-page.js
@@ -1,14 +1,14 @@
 /** @format */
 
 import { By } from 'selenium-webdriver';
-import BaseContainer from '../base-container.js';
+import AsyncBaseContainer from '../async-base-container';
 
 import SidebarComponent from '../components/sidebar-component.js';
 import NavbarComponent from '../components/navbar-component.js';
 
 import * as DriverHelper from '../driver-helper.js';
 
-export default class InvitePeoplePage extends BaseContainer {
+export default class InvitePeoplePage extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( 'select#role' ) );
 	}

--- a/lib/pages/invite-people-page.js
+++ b/lib/pages/invite-people-page.js
@@ -4,7 +4,7 @@ import { By } from 'selenium-webdriver';
 import AsyncBaseContainer from '../async-base-container';
 
 import SidebarComponent from '../components/sidebar-component.js';
-import NavbarComponent from '../components/navbar-component.js';
+import NavBarComponent from '../components/nav-bar-component.js';
 
 import * as DriverHelper from '../driver-helper.js';
 
@@ -38,7 +38,7 @@ export default class InvitePeoplePage extends AsyncBaseContainer {
 	}
 
 	async backToPeopleMenu() {
-		const navbarComponent = await NavbarComponent.Expect( this.driver );
+		const navbarComponent = await NavBarComponent.Expect( this.driver );
 		await navbarComponent.clickMySites();
 
 		let sideBarComponent = new SidebarComponent( this.driver );

--- a/lib/pages/invite-people-page.js
+++ b/lib/pages/invite-people-page.js
@@ -38,7 +38,7 @@ export default class InvitePeoplePage extends AsyncBaseContainer {
 	}
 
 	async backToPeopleMenu() {
-		let navbarComponent = new NavbarComponent( this.driver );
+		const navbarComponent = await NavbarComponent.Expect( this.driver );
 		await navbarComponent.clickMySites();
 
 		let sideBarComponent = new SidebarComponent( this.driver );

--- a/lib/pages/people-page.js
+++ b/lib/pages/people-page.js
@@ -1,6 +1,6 @@
 /** @format */
 
-import { By, until } from 'selenium-webdriver';
+import { By } from 'selenium-webdriver';
 import AsyncBaseContainer from '../async-base-container';
 
 import * as DriverHelper from '../driver-helper.js';
@@ -56,6 +56,7 @@ export default class PeoplePage extends AsyncBaseContainer {
 		);
 	}
 
+	// TODO: Remove this https://github.com/Automattic/wp-e2e-tests/issues/1264
 	async viewerDisplayed( username ) {
 		let viewers = await this.driver.findElements(
 			By.css( '.people-list-item .people-profile__username' )
@@ -70,11 +71,7 @@ export default class PeoplePage extends AsyncBaseContainer {
 		return false;
 	}
 
-	/**
-	 * Removes the given user from the currently displayed list
-	 * @param {string} username The username to remove
-	 * @returns {Object} Returns `object`.
-	 */
+	// TODO: Remove this https://github.com/Automattic/wp-e2e-tests/issues/1264
 	async removeUserByName( username ) {
 		let viewers = await this.driver.findElements( By.css( '.people-list-item' ) );
 
@@ -100,41 +97,17 @@ export default class PeoplePage extends AsyncBaseContainer {
 		return await this.waitForSearchResults();
 	}
 
-	ensureSearchOpened() {
-		this.driver
-			.findElement( this.searchButtonSelector )
-			.getAttribute( 'class' )
-			.then( classNames => {
-				if ( classNames.includes( 'is-open' ) === false ) {
-					return DriverHelper.clickWhenClickable( this.driver, this.searchButtonSelector );
-				}
-			} );
-		return this.driver.wait(
-			until.elementLocated( this.searchInputSelector ),
-			this.explicitWaitMS,
-			'Could not locate the person search input field'
-		);
+	async ensureSearchOpened() {
+		const searchElement = await this.driver.findElement( this.searchButtonSelector );
+		const classNames = await searchElement.getAttribute( 'class' );
+		if ( classNames.includes( 'is-open' ) === false ) {
+			await DriverHelper.clickWhenClickable( this.driver, this.searchButtonSelector );
+		}
+		return await DriverHelper.waitTillPresentAndDisplayed( this.driver, this.searchInputSelector );
 	}
 
-	waitForSearchResults() {
-		const driver = this.driver;
-		const searchResultsLoadingSelector = this.searchResultsLoadingSelector;
-		return driver.wait(
-			function() {
-				return DriverHelper.isElementPresent( driver, searchResultsLoadingSelector ).then(
-					present => {
-						return ! present;
-					}
-				);
-			},
-			this.explicitWaitMS,
-			'The search results are still loading when they should have finished.'
-		);
-	}
-
-	async cancelSearch() {
-		const cancelSelector = By.css( 'div[aria-label="Close Search"] svg' );
-		return await DriverHelper.clickWhenClickable( this.driver, cancelSelector );
+	async waitForSearchResults() {
+		return await DriverHelper.waitTillNotPresent( this.driver, this.searchResultsLoadingSelector );
 	}
 
 	async numberSearchResults() {
@@ -146,18 +119,7 @@ export default class PeoplePage extends AsyncBaseContainer {
 		return await DriverHelper.clickWhenClickable( this.driver, this.peopleListItemSelector );
 	}
 
-	async removeOnlyEmailFollowerDisplayed() {
-		await DriverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.people-list-item__remove-button' )
-		);
-		return await DriverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.dialog button.is-primary' )
-		);
-	}
-
-	successNoticeDisplayed() {
+	async successNoticeDisplayed() {
 		return DriverHelper.isEventuallyPresentAndDisplayed( this.driver, this.successNoticeSelector );
 	}
 
@@ -168,7 +130,7 @@ export default class PeoplePage extends AsyncBaseContainer {
 		);
 	}
 
-	pendingInviteDisplayedFor( emailAddress ) {
+	async pendingInviteDisplayedFor( emailAddress ) {
 		return DriverHelper.isEventuallyPresentAndDisplayed(
 			this.driver,
 			By.css( `.people-invites__pending .people-profile__username[title="${ emailAddress }"]` )

--- a/lib/pages/people-page.js
+++ b/lib/pages/people-page.js
@@ -1,11 +1,11 @@
 /** @format */
 
 import { By, until } from 'selenium-webdriver';
-import BaseContainer from '../base-container.js';
+import AsyncBaseContainer from '../async-base-container';
 
 import * as DriverHelper from '../driver-helper.js';
 
-export default class PeoplePage extends BaseContainer {
+export default class PeoplePage extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.people-selector__infinite-list' ) );
 		this.searchButtonSelector = By.css( '.section-nav__panel div.search' );

--- a/lib/pages/posts-page.js
+++ b/lib/pages/posts-page.js
@@ -1,54 +1,44 @@
 /** @format */
 
 import { By } from 'selenium-webdriver';
-import BaseContainer from '../base-container.js';
+import AsyncBaseContainer from '../async-base-container';
 
 import * as driverHelper from '../driver-helper';
 
-export default class PostsPage extends BaseContainer {
+export default class PostsPage extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.posts' ) );
 	}
 
-	waitForPosts() {
-		const driver = this.driver;
+	async waitForPosts() {
 		const resultsLoadingSelector = By.css( '.posts__post-list .is-placeholder:not(.post)' );
-		driver.wait(
-			function() {
-				return driverHelper
-					.isElementPresent( driver, resultsLoadingSelector )
-					.then( function( present ) {
-						return ! present;
-					} );
-			},
-			this.explicitWaitMS,
-			'The posts loading element was still present when it should have disappeared by now.'
-		);
+		return await driverHelper.waitTillNotPresent( this.driver, resultsLoadingSelector );
 	}
 
-	waitForPostTitled( title ) {
-		return driverHelper.waitTillPresentAndDisplayed(
+	async waitForPostTitled( title ) {
+		return await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,
 			PostsPage._getPostXpathSelector( title )
 		);
 	}
 
-	isPostDisplayed( title ) {
-		return driverHelper.isEventuallyPresentAndDisplayed(
+	async isPostDisplayed( title ) {
+		return await driverHelper.isEventuallyPresentAndDisplayed(
 			this.driver,
 			PostsPage._getPostXpathSelector( title )
 		);
 	}
-	editPostWithTitle( title ) {
-		return driverHelper.clickWhenClickable(
+
+	async editPostWithTitle( title ) {
+		return await driverHelper.clickWhenClickable(
 			this.driver,
 			PostsPage._getPostXpathSelector( title ),
 			this.explicitWaitMS * 2
 		);
 	}
 
-	successNoticeDisplayed() {
-		return driverHelper.isEventuallyPresentAndDisplayed(
+	async successNoticeDisplayed() {
+		return await driverHelper.isEventuallyPresentAndDisplayed(
 			this.driver,
 			By.css( '.notice.is-success' )
 		);

--- a/lib/pages/private-site-login-page.js
+++ b/lib/pages/private-site-login-page.js
@@ -2,12 +2,12 @@
 
 import webdriver from 'selenium-webdriver';
 
-import BaseContainer from '../base-container.js';
+import AsyncBaseContainer from '../async-base-container';
 
 const by = webdriver.By;
 
-export default class PrivateSiteLoginPage extends BaseContainer {
-	constructor( driver, visit = false, url = null ) {
-		super( driver, by.css( '.private-login' ), visit, url );
+export default class PrivateSiteLoginPage extends AsyncBaseContainer {
+	constructor( driver, url ) {
+		super( driver, by.css( '.private-login' ), url );
 	}
 }

--- a/lib/pages/reader-page.js
+++ b/lib/pages/reader-page.js
@@ -4,18 +4,17 @@ import { By as by } from 'selenium-webdriver';
 import config from 'config';
 import URL from 'url';
 
-import BaseContainer from '../base-container.js';
+import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 import * as dataHelper from '../data-helper';
 import * as eyesHelper from '../eyes-helper';
 
-export default class ReaderPage extends BaseContainer {
-	constructor( driver, visit = false ) {
-		let url = dataHelper.configGet( 'calypsoBaseURL' ) + '/read';
-		if ( dataHelper.isRunningOnLiveBranch() ) {
-			url = url + '?branch=' + config.get( 'branchName' );
+export default class ReaderPage extends AsyncBaseContainer {
+	constructor( driver, url ) {
+		if ( ! url ) {
+			url = ReaderPage.getReaderURL();
 		}
-		super( driver, by.css( '.is-section-reader' ), visit, url );
+		super( driver, by.css( '.is-section-reader' ), url );
 	}
 
 	async siteOfLatestPost() {
@@ -23,26 +22,6 @@ export default class ReaderPage extends BaseContainer {
 			.findElement( by.css( '.reader-visit-link' ) )
 			.getAttribute( 'href' );
 		return URL.parse( href ).host;
-	}
-
-	likeLatestPost() {
-		return driverHelper.clickWhenClickable(
-			this.driver,
-			by.css( '.reader-post-card .like-button' )
-		);
-	}
-
-	latestPostIsLiked() {
-		return this.driver
-			.findElement( by.css( '.reader-post-card .like-button' ) )
-			.getAttribute( 'class' )
-			.then( classNames => {
-				return classNames.includes( 'is-liked' );
-			} );
-	}
-
-	latestPostTitle() {
-		return this.driver.findElement( by.css( '.reader-post-card__title' ) ).getText();
 	}
 
 	async commentOnLatestPost( comment, eyes ) {
@@ -56,10 +35,11 @@ export default class ReaderPage extends BaseContainer {
 		return await driverHelper.clickWhenClickable( this.driver, by.css( '.comments__form button' ) );
 	}
 
-	waitForModeratedCommentToAppear() {
-		return driverHelper.waitTillPresentAndDisplayed(
-			this.driver,
-			by.css( '.comments__comment-moderation' )
-		);
+	static getReaderURL() {
+		let url = dataHelper.configGet( 'calypsoBaseURL' ) + '/read';
+		if ( dataHelper.isRunningOnLiveBranch() ) {
+			url = url + '?branch=' + config.get( 'branchName' );
+		}
+		return url;
 	}
 }

--- a/lib/pages/revoke-page.js
+++ b/lib/pages/revoke-page.js
@@ -1,31 +1,27 @@
 /** @format */
 
-import { By, until } from 'selenium-webdriver';
-import BaseContainer from '../base-container.js';
+import { By } from 'selenium-webdriver';
+
+import AsyncBaseContainer from '../async-base-container';
 
 import * as DriverHelper from '../driver-helper.js';
 
-export default class RevokePage extends BaseContainer {
+export default class RevokePage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.people-invite-details__clear-revoke [type]' ) );
-		this.revokeButtonSelector = By.css( '.people-invite-details__clear-revoke [type]' );
-		this.noticeSelector = By.css( '.notice__text' );
+		super( driver, By.css( '.people-invite-details__clear-revoke' ) );
 	}
 
 	async revokeUser() {
-		const self = this;
-		return await DriverHelper.clickWhenClickable( self.driver, self.revokeButtonSelector );
+		return await DriverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.people-invite-details__clear-revoke [type]' )
+		);
 	}
 
 	async revokeSent() {
-		const self = this;
-
-		await self.driver.wait(
-			until.elementLocated( self.noticeSelector ),
-			this.explicitWaitMS * 2,
-			'The notice was not displayed'
+		return await DriverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			By.css( '.notice.is-success' )
 		);
-
-		return await DriverHelper.isElementPresent( self.driver, self.noticeSelector );
 	}
 }

--- a/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -17,7 +17,7 @@ import ReaderPage from '../lib/pages/reader-page.js';
 import SecurePaymentComponent from '../lib/components/secure-payment-component.js';
 import ShoppingCartWidgetComponent from '../lib/components/shopping-cart-widget-component.js';
 import SidebarComponent from '../lib/components/sidebar-component.js';
-import NavbarComponent from '../lib/components/navbar-component.js';
+import NavBarComponent from '../lib/components/nav-bar-component.js';
 
 import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar';
 
@@ -81,7 +81,7 @@ test.describe( `[${ host }] Jetpack Plans: (${ screenSize }) @jetpack`, function
 		test.after( async function() {
 			await ReaderPage.Visit( driver );
 
-			this.navbarComponent = new NavbarComponent( driver );
+			this.navbarComponent = await NavBarComponent.Expect( driver );
 			await this.navbarComponent.clickMySites();
 
 			this.statsPage = new StatsPage( driver, true );

--- a/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -79,7 +79,7 @@ test.describe( `[${ host }] Jetpack Plans: (${ screenSize }) @jetpack`, function
 
 		// Remove all items from basket for clean up
 		test.after( async function() {
-			this.readerPage = new ReaderPage( driver, true );
+			await ReaderPage.Visit( driver );
 
 			this.navbarComponent = new NavbarComponent( driver );
 			await this.navbarComponent.clickMySites();

--- a/specs-jetpack-calypso/wp-pressable-nux-spec.js
+++ b/specs-jetpack-calypso/wp-pressable-nux-spec.js
@@ -14,7 +14,7 @@ import PressableNUXFlow from '../lib/flows/pressable-nux-flow';
 import ReaderPage from '../lib/pages/reader-page';
 import SidebarComponent from '../lib/components/sidebar-component';
 import StatsPage from '../lib/pages/stats-page';
-import NavbarComponent from '../lib/components/navbar-component';
+import NavBarComponent from '../lib/components/nav-bar-component';
 import JetpackConnectFlow from '../lib/flows/jetpack-connect-flow';
 import LoginFlow from '../lib/flows/login-flow';
 
@@ -100,7 +100,8 @@ if ( host === 'PRESSABLE' ) {
 
 			test.it( 'Can open Rewind activity page', async function() {
 				await ReaderPage.Visit( driver );
-				await new NavbarComponent( driver ).clickMySites();
+				const navBarComponent = await NavBarComponent.Expect( driver );
+				await navBarComponent.clickMySites();
 				const sidebarComponent = new SidebarComponent( driver );
 				await sidebarComponent.selectSiteSwitcher();
 				await sidebarComponent.searchForSite( this.siteName );

--- a/specs-jetpack-calypso/wp-pressable-nux-spec.js
+++ b/specs-jetpack-calypso/wp-pressable-nux-spec.js
@@ -99,7 +99,7 @@ if ( host === 'PRESSABLE' ) {
 			} );
 
 			test.it( 'Can open Rewind activity page', async function() {
-				await new ReaderPage( driver, true ).displayed();
+				await ReaderPage.Visit( driver );
 				await new NavbarComponent( driver ).clickMySites();
 				const sidebarComponent = new SidebarComponent( driver );
 				await sidebarComponent.selectSiteSwitcher();

--- a/specs-visdiff/wp-calypso-visdiff.js
+++ b/specs-visdiff/wp-calypso-visdiff.js
@@ -116,7 +116,7 @@ test.describe( `Calypso Visual Diff (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can view the blog posts list', async function() {
-			this.postsPage = new PostsPage( driver );
+			this.postsPage = await PostsPage.Expect( driver );
 			await this.postsPage.waitForPosts();
 			await eyesHelper.eyesScreenshot( driver, eyes, 'Blog Posts List' );
 		} );

--- a/specs-visdiff/wp-calypso-visdiff.js
+++ b/specs-visdiff/wp-calypso-visdiff.js
@@ -63,7 +63,7 @@ test.describe( `Calypso Visual Diff (${ screenSize })`, function() {
 		test.it( 'Can edit a default page', async function() {
 			const defaultPageTitle = 'About';
 			await this.pagesPage.editPageWithTitle( defaultPageTitle );
-			this.editorPage = new EditorPage( driver );
+			this.editorPage = await EditorPage.Expect( driver );
 			await this.editorPage.waitForTitle();
 			let titleShown = await this.editorPage.titleShown();
 			assert.equal( titleShown, defaultPageTitle, 'The page title shown was unexpected' );
@@ -124,7 +124,7 @@ test.describe( `Calypso Visual Diff (${ screenSize })`, function() {
 		test.it( 'Can edit the default post', async function() {
 			const defaultPostTitle = 'The Journey Begins';
 			await this.postsPage.editPostWithTitle( defaultPostTitle );
-			this.editorPage = new EditorPage( driver );
+			this.editorPage = await EditorPage.Expect( driver );
 			await this.editorPage.waitForTitle();
 			let titleShown = await this.editorPage.titleShown();
 			assert.equal( titleShown, defaultPostTitle, 'The post title shown was unexpected' );

--- a/specs-visdiff/wp-calypso-visdiff.js
+++ b/specs-visdiff/wp-calypso-visdiff.js
@@ -86,7 +86,7 @@ test.describe( `Calypso Visual Diff (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Close editor', async function() {
-			this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+			this.postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 			return await this.postEditorToolbarComponent.closeEditor();
 		} );
 
@@ -167,7 +167,7 @@ test.describe( `Calypso Visual Diff (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Close editor', async function() {
-			this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+			this.postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 			return await this.postEditorToolbarComponent.closeEditor();
 		} );
 

--- a/specs-visdiff/wp-calypso-visdiff.js
+++ b/specs-visdiff/wp-calypso-visdiff.js
@@ -132,7 +132,7 @@ test.describe( `Calypso Visual Diff (${ screenSize })`, function() {
 
 		test.it( 'Can open the editor media modal', async function() {
 			await this.editorPage.chooseInsertMediaOption();
-			await this.editorPage.selectImageByNumber( 0 );
+			await this.editorPage.selectFirstImage();
 			await eyesHelper.eyesScreenshot( driver, eyes, 'Editor Media Modal' );
 		} );
 

--- a/specs-woocommerce/wp-woocommerce-spec.js
+++ b/specs-woocommerce/wp-woocommerce-spec.js
@@ -44,7 +44,7 @@ test.describe(
 		test.before( async function() {
 			this.loginFlow = new LoginFlow( driver, 'wooCommerceUser' );
 			await this.loginFlow.login();
-			this.navBarComponent = new NavBarComponent( driver );
+			this.navBarComponent = await NavBarComponent.Expect( driver );
 			await this.navBarComponent.clickMySites();
 		} );
 

--- a/specs-woocommerce/wp-woocommerce-spec.js
+++ b/specs-woocommerce/wp-woocommerce-spec.js
@@ -8,7 +8,7 @@ import * as driverManager from '../lib/driver-manager';
 import * as mediaHelper from '../lib/media-helper';
 import * as dataHelper from '../lib/data-helper';
 
-import NavBarComponent from '../lib/components/navbar-component';
+import NavBarComponent from '../lib/components/nav-bar-component';
 import SidebarComponent from '../lib/components/sidebar-component';
 import StoreSidebarComponent from '../lib/components/store-sidebar-component';
 import StoreSettingsPage from '../lib/pages/woocommerce/store-settings-page';

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -107,9 +107,8 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 		test.it( 'User has been added as Editor', async function() {
 			await PostsPage.Expect( driver );
 
-			const invitesMessageTitleDisplayed = await new NoticesComponent(
-				driver
-			).inviteMessageTitle();
+			const noticesComponent = await NoticesComponent.Expect( driver );
+			const invitesMessageTitleDisplayed = await noticesComponent.inviteMessageTitle();
 			return assert(
 				invitesMessageTitleDisplayed.includes( 'Editor' ),
 				`The invite message '${ invitesMessageTitleDisplayed }' does not include 'Editor'`
@@ -288,7 +287,8 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can see user has been added as a Viewer', async function() {
-				let followMessageDisplayed = await new NoticesComponent( driver ).followMessageTitle();
+				const noticesComponent = await NoticesComponent.Expect( driver );
+				let followMessageDisplayed = await noticesComponent.followMessageTitle();
 				assert.equal(
 					true,
 					followMessageDisplayed.includes( 'viewer' ),
@@ -417,9 +417,8 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 
 			test.it( 'Can see a notice welcoming the new user as an contributor', async function() {
 				await PostsPage.Expect( driver );
-				let invitesMessageTitleDisplayed = await new NoticesComponent(
-					driver
-				).inviteMessageTitle();
+				const noticesComponent = await NoticesComponent.Expect( driver );
+				let invitesMessageTitleDisplayed = await noticesComponent.inviteMessageTitle();
 				return assert(
 					invitesMessageTitleDisplayed.includes( 'Contributor' ),
 					`The invite message '${ invitesMessageTitleDisplayed }' does not include 'Contributor'`

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -231,7 +231,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			} );
 
 			test.it( 'As an anonymous user I can not see a private site', async function() {
-				return await new PrivateSiteLoginPage.Visit( driver, siteUrl );
+				return await PrivateSiteLoginPage.Visit( driver, siteUrl );
 			} );
 
 			test.it( 'Can log in and navigate to Invite People page', async function() {
@@ -429,7 +429,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			} );
 
 			test.it( 'New user can submit the new post for review as pending status', async function() {
-				const postEditorToolbar = new PostEditorToolbarComponent( driver );
+				const postEditorToolbar = await PostEditorToolbarComponent.Expect( driver );
 				await postEditorToolbar.ensureSaved();
 				await postEditorToolbar.submitForReview();
 				await postEditorToolbar.waitForIsPendingStatus();
@@ -482,7 +482,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				await editorPage.enterTitle( publishPostTitle );
 				await editorPage.enterContent( postQuote );
 
-				const postEditorToolbar = new PostEditorToolbarComponent( driver );
+				const postEditorToolbar = await PostEditorToolbarComponent.Expect( driver );
 				await postEditorToolbar.ensureSaved();
 				return await postEditorToolbar.publishAndViewContent( { useConfirmStep: true } );
 			} );

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -431,7 +431,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				await navbarComponent.dismissGuidedTours();
 				await navbarComponent.clickCreateNewPost();
 
-				const editorPage = new EditorPage( driver );
+				const editorPage = await EditorPage.Expect( driver );
 				let urlDisplayed = await driver.getCurrentUrl();
 				await editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
 				await editorPage.enterTitle( reviewPostTitle );
@@ -486,7 +486,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				const navBarComponent = await NavBarComponent.Expect( driver );
 				await navBarComponent.clickCreateNewPost();
 
-				const editorPage = new EditorPage( driver );
+				const editorPage = await EditorPage.Expect( driver );
 				let urlDisplayed = await driver.getCurrentUrl();
 				await editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
 				await editorPage.enterTitle( publishPostTitle );

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -93,7 +93,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			await driverManager.ensureNotLoggedIn( driver );
 
 			await driver.get( acceptInviteURL );
-			const acceptInvitePage = new AcceptInvitePage( driver );
+			const acceptInvitePage = await AcceptInvitePage.Expect( driver );
 
 			let actualEmailAddress = await acceptInvitePage.getEmailPreFilled();
 			let headerInviteText = await acceptInvitePage.getHeaderInviteText();
@@ -208,7 +208,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				await driverManager.ensureNotLoggedIn( driver );
 
 				await driver.get( acceptInviteURL );
-				await new AcceptInvitePage( driver ).displayed();
+				await AcceptInvitePage.Expect( driver );
 
 				let displayed = await new InviteErrorPage( driver ).inviteErrorTitleDisplayed();
 				return assert( displayed, 'The invite was not successfully revoked' );
@@ -275,7 +275,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				await driverManager.ensureNotLoggedIn( driver );
 
 				await driver.get( acceptInviteURL );
-				const acceptInvitePage = new AcceptInvitePage( driver );
+				const acceptInvitePage = await AcceptInvitePage.Expect( driver );
 
 				let actualEmailAddress = await acceptInvitePage.getEmailPreFilled();
 				let headerInviteText = await acceptInvitePage.getHeaderInviteText();
@@ -403,7 +403,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				await driverManager.ensureNotLoggedIn( driver );
 
 				await driver.get( acceptInviteURL );
-				const acceptInvitePage = new AcceptInvitePage( driver );
+				const acceptInvitePage = await AcceptInvitePage.Expect( driver );
 
 				let actualEmailAddress = await acceptInvitePage.getEmailPreFilled();
 				let headerInviteText = await acceptInvitePage.getHeaderInviteText();

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -144,7 +144,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			await driverManager.ensureNotLoggedIn( driver );
 			const loginPage = await LoginPage.Visit( driver );
 			await loginPage.login( newUserName, password );
-			await new ReaderPage( driver ).displayed();
+			await ReaderPage.Expect( driver );
 
 			await new NavbarComponent( driver ).clickMySites();
 			const displayed = await new NoSitesComponent( driver ).displayed();
@@ -295,7 +295,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 					`The follow message '${ followMessageDisplayed }' does not include 'viewer'`
 				);
 
-				await new ReaderPage( driver ).displayed();
+				await ReaderPage.Expect( driver );
 				return await ViewBlogPage.Visit( driver, siteUrl );
 			} );
 
@@ -326,7 +326,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				const loginPage = await LoginPage.Visit( driver );
 				await loginPage.login( newUserName, password );
 
-				await new ReaderPage( driver, true ).displayed();
+				await ReaderPage.Expect( driver );
 				let displayed = await new PrivateSiteLoginPage( driver, true, siteUrl ).displayed();
 				assert.equal(
 					displayed,
@@ -482,7 +482,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 
 				const loginPage = await LoginPage.Visit( driver );
 				await loginPage.login( newUserName, password );
-				await new ReaderPage( driver ).displayed();
+				await ReaderPage.Expect( driver );
 				await new NavbarComponent( driver ).clickCreateNewPost();
 
 				const editorPage = new EditorPage( driver );

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -20,7 +20,7 @@ import PrivateSiteLoginPage from '../lib/pages/private-site-login-page.js';
 import EditorPage from '../lib/pages/editor-page.js';
 
 import NoticesComponent from '../lib/components/notices-component.js';
-import NavbarComponent from '../lib/components/navbar-component.js';
+import NavBarComponent from '../lib/components/nav-bar-component.js';
 import NoSitesComponent from '../lib/components/no-sites-component.js';
 import PostEditorToolbarComponent from '../lib/components/post-editor-toolbar-component.js';
 
@@ -146,9 +146,9 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			await loginPage.login( newUserName, password );
 			await ReaderPage.Expect( driver );
 
-			await new NavbarComponent( driver ).clickMySites();
-			const displayed = await new NoSitesComponent( driver ).displayed();
-			return assert( displayed, 'The no sites page is not displayed' );
+			const navBarComponent = await NavBarComponent.Expect( driver );
+			await navBarComponent.clickMySites();
+			return await NoSitesComponent.Expect( driver );
 		} );
 	} );
 
@@ -427,7 +427,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			} );
 
 			test.it( 'New user can create a new post', async function() {
-				const navbarComponent = new NavbarComponent( driver );
+				const navbarComponent = await NavBarComponent.Expect( driver );
 				await navbarComponent.dismissGuidedTours();
 				await navbarComponent.clickCreateNewPost();
 
@@ -483,7 +483,8 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				const loginPage = await LoginPage.Visit( driver );
 				await loginPage.login( newUserName, password );
 				await ReaderPage.Expect( driver );
-				await new NavbarComponent( driver ).clickCreateNewPost();
+				const navBarComponent = await NavBarComponent.Expect( driver );
+				await navBarComponent.clickCreateNewPost();
 
 				const editorPage = new EditorPage( driver );
 				let urlDisplayed = await driver.getCurrentUrl();

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -58,7 +58,8 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 
 		test.it( 'Can log in and navigate to Invite People page', async function() {
 			await new LoginFlow( driver ).loginAndSelectPeople();
-			await new PeoplePage( driver ).inviteUser();
+			const peoplePage = await PeoplePage.Expect( driver );
+			return await peoplePage.inviteUser();
 		} );
 
 		test.it( 'Can invite a new user as an editor and see its pending', async function() {
@@ -71,9 +72,9 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			await invitePeoplePage.inviteSent();
 			await invitePeoplePage.backToPeopleMenu();
 
-			const peoplePage = new PeoplePage( driver );
+			const peoplePage = await PeoplePage.Expect( driver );
 			await peoplePage.selectInvites();
-			await peoplePage.pendingInviteDisplayedFor( newInviteEmailAddress );
+			return await peoplePage.pendingInviteDisplayedFor( newInviteEmailAddress );
 		} );
 
 		test.it( 'Can see an invitation email received for the invite', async function() {
@@ -106,8 +107,10 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 		test.it( 'User has been added as Editor', async function() {
 			await new PostsPage( driver ).displayed();
 
-			let invitesMessageTitleDisplayed = await new NoticesComponent( driver ).inviteMessageTitle();
-			assert(
+			const invitesMessageTitleDisplayed = await new NoticesComponent(
+				driver
+			).inviteMessageTitle();
+			return assert(
 				invitesMessageTitleDisplayed.includes( 'Editor' ),
 				`The invite message '${ invitesMessageTitleDisplayed }' does not include 'Editor'`
 			);
@@ -117,10 +120,10 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			await driverManager.ensureNotLoggedIn( driver );
 			await new LoginFlow( driver ).loginAndSelectPeople();
 
-			const peoplePage = new PeoplePage( driver );
+			const peoplePage = await PeoplePage.Expect( driver );
 			await peoplePage.selectTeam();
 			await peoplePage.searchForUser( newUserName );
-			let numberPeopleShown = await peoplePage.numberSearchResults();
+			const numberPeopleShown = await peoplePage.numberSearchResults();
 			assert.equal(
 				numberPeopleShown,
 				1,
@@ -129,8 +132,8 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 
 			await peoplePage.selectOnlyPersonDisplayed();
 			await new EditTeamMemberPage( driver ).removeUserAndDeleteContent();
-			let displayed = await peoplePage.successNoticeDisplayed();
-			assert.equal(
+			const displayed = await peoplePage.successNoticeDisplayed();
+			return assert.equal(
 				displayed,
 				true,
 				'The deletion successful notice was not shown on the people page.'
@@ -144,8 +147,8 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			await new ReaderPage( driver ).displayed();
 
 			await new NavbarComponent( driver ).clickMySites();
-			let displayed = await new NoSitesComponent( driver ).displayed();
-			assert( displayed, 'The no sites page is not displayed' );
+			const displayed = await new NoSitesComponent( driver ).displayed();
+			return assert( displayed, 'The no sites page is not displayed' );
 		} );
 	} );
 
@@ -158,12 +161,13 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			let acceptInviteURL = '';
 
 			test.before( async function() {
-				await driverManager.clearCookiesAndDeleteLocalStorage( driver );
+				return await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 			} );
 
 			test.it( 'Can log in and navigate to Invite People page', async function() {
 				await new LoginFlow( driver ).loginAndSelectPeople();
-				await new PeoplePage( driver ).inviteUser();
+				const peoplePage = await PeoplePage.Expect( driver );
+				return await peoplePage.inviteUser();
 			} );
 
 			test.it( 'Can Invite a New User as an Editor, then revoke the invite', async function() {
@@ -176,7 +180,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				await invitePeoplePage.inviteSent();
 				await invitePeoplePage.backToPeopleMenu();
 
-				const peoplePage = new PeoplePage( driver );
+				const peoplePage = await PeoplePage.Expect( driver );
 				await peoplePage.selectInvites();
 				await peoplePage.pendingInviteDisplayedFor( newInviteEmailAddress );
 
@@ -207,7 +211,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				await new AcceptInvitePage( driver ).displayed();
 
 				let displayed = await new InviteErrorPage( driver ).inviteErrorTitleDisplayed();
-				assert( displayed, 'The invite was not successfully revoked' );
+				return assert( displayed, 'The invite was not successfully revoked' );
 			} );
 		}
 	);
@@ -223,17 +227,21 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			let acceptInviteURL = '';
 
 			test.before( async function() {
-				await driverManager.clearCookiesAndDeleteLocalStorage( driver );
+				return await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 			} );
 
 			test.it( 'As an anonymous user I can not see a private site', async function() {
 				let displayed = await new PrivateSiteLoginPage( driver, true, siteUrl ).displayed();
-				assert( displayed, `The private site log in page was not displayed for:'${ siteUrl }'` );
+				return assert(
+					displayed,
+					`The private site log in page was not displayed for:'${ siteUrl }'`
+				);
 			} );
 
 			test.it( 'Can log in and navigate to Invite People page', async function() {
 				await new LoginFlow( driver, 'privateSiteUser' ).loginAndSelectPeople();
-				await new PeoplePage( driver ).inviteUser();
+				const peoplePage = await PeoplePage.Expect( driver );
+				return await peoplePage.inviteUser();
 			} );
 
 			test.it( 'Can invite a new user as an editor and see its pending', async function() {
@@ -246,7 +254,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				await invitePeoplePage.inviteSent();
 				await invitePeoplePage.backToPeopleMenu();
 
-				const peoplePage = new PeoplePage( driver );
+				const peoplePage = await PeoplePage.Expect( driver );
 				await peoplePage.selectInvites();
 				return await peoplePage.pendingInviteDisplayedFor( newInviteEmailAddress );
 			} );
@@ -294,7 +302,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				await driverManager.ensureNotLoggedIn( driver );
 				await new LoginFlow( driver, 'privateSiteUser' ).loginAndSelectPeople();
 
-				const peoplePage = new PeoplePage( driver );
+				const peoplePage = await PeoplePage.Expect( driver );
 				await peoplePage.selectViewers();
 				let displayed = await peoplePage.viewerDisplayed( newUserName );
 				assert(
@@ -328,7 +336,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 
 			test.after( async function() {
 				await new LoginFlow( driver, 'privateSiteUser' ).loginAndSelectPeople();
-				const peoplePage = new PeoplePage( driver );
+				const peoplePage = await PeoplePage.Expect( driver );
 
 				await peoplePage.selectViewers();
 				let displayed = await peoplePage.viewerDisplayed( newUserName );
@@ -355,12 +363,13 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			let acceptInviteURL = '';
 
 			test.before( async function() {
-				await driverManager.clearCookiesAndDeleteLocalStorage( driver );
+				return await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 			} );
 
 			test.it( 'Can log in and navigate to Invite People page', async function() {
 				await new LoginFlow( driver ).loginAndSelectPeople();
-				await new PeoplePage( driver ).inviteUser();
+				const peoplePage = await PeoplePage.Expect( driver );
+				return await peoplePage.inviteUser();
 			} );
 
 			test.it( 'Can invite a new user as an editor and see its pending', async function() {
@@ -373,9 +382,9 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				await invitePeoplePage.inviteSent();
 				await invitePeoplePage.backToPeopleMenu();
 
-				const peoplePage = new PeoplePage( driver );
+				const peoplePage = await PeoplePage.Expect( driver );
 				await peoplePage.selectInvites();
-				await peoplePage.pendingInviteDisplayedFor( newInviteEmailAddress );
+				return await peoplePage.pendingInviteDisplayedFor( newInviteEmailAddress );
 			} );
 
 			test.it( 'Can see an invitation email received for the invite', async function() {
@@ -440,7 +449,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			test.it( 'As the original user, can see new user added to site', async function() {
 				await driverManager.ensureNotLoggedIn( driver );
 				await new LoginFlow( driver ).loginAndSelectPeople();
-				const peoplePage = new PeoplePage( driver );
+				const peoplePage = await PeoplePage.Expect( driver );
 				await peoplePage.selectTeam();
 				await peoplePage.searchForUser( newUserName );
 				let numberPeopleShown = await peoplePage.numberSearchResults();
@@ -454,7 +463,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			test.it(
 				'As the original user, I can change the contributor user to an author user',
 				async function() {
-					const peoplePage = new PeoplePage( driver );
+					const peoplePage = await PeoplePage.Expect( driver );
 
 					await peoplePage.selectOnlyPersonDisplayed();
 					const editTeamMemberPage = new EditTeamMemberPage( driver );

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -130,7 +130,8 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			);
 
 			await peoplePage.selectOnlyPersonDisplayed();
-			await new EditTeamMemberPage( driver ).removeUserAndDeleteContent();
+			const editTeamMemberPage = await EditTeamMemberPage.Expect( driver );
+			await editTeamMemberPage.removeUserAndDeleteContent();
 			const displayed = await peoplePage.successNoticeDisplayed();
 			return assert.equal(
 				displayed,
@@ -457,7 +458,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 					const peoplePage = await PeoplePage.Expect( driver );
 
 					await peoplePage.selectOnlyPersonDisplayed();
-					const editTeamMemberPage = new EditTeamMemberPage( driver );
+					const editTeamMemberPage = await EditTeamMemberPage.Expect( driver );
 					await editTeamMemberPage.changeToNewRole( 'author' );
 					let displayed = await editTeamMemberPage.successNoticeDisplayed();
 					return assert(

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -62,7 +62,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can invite a new user as an editor and see its pending', async function() {
-			const invitePeoplePage = new InvitePeoplePage( driver );
+			const invitePeoplePage = await InvitePeoplePage.Expect( driver );
 			await invitePeoplePage.inviteNewUser(
 				newInviteEmailAddress,
 				'editor',
@@ -167,7 +167,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can Invite a New User as an Editor, then revoke the invite', async function() {
-				const invitePeoplePage = new InvitePeoplePage( driver );
+				const invitePeoplePage = await InvitePeoplePage.Expect( driver );
 				await invitePeoplePage.inviteNewUser(
 					newInviteEmailAddress,
 					'editor',
@@ -237,7 +237,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can invite a new user as an editor and see its pending', async function() {
-				const invitePeoplePage = new InvitePeoplePage( driver );
+				const invitePeoplePage = await InvitePeoplePage.Expect( driver );
 				await invitePeoplePage.inviteNewUser(
 					newInviteEmailAddress,
 					'viewer',
@@ -364,7 +364,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can invite a new user as an editor and see its pending', async function() {
-				const invitePeoplePage = new InvitePeoplePage( driver );
+				const invitePeoplePage = await InvitePeoplePage.Expect( driver );
 				await invitePeoplePage.inviteNewUser(
 					newInviteEmailAddress,
 					'contributor',

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -185,9 +185,9 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				await peoplePage.pendingInviteDisplayedFor( newInviteEmailAddress );
 
 				await peoplePage.goToRevokeInvitePage( newInviteEmailAddress );
-				const revokePage = new RevokePage( driver );
-				await revokePage.revokeUser();
 
+				const revokePage = await RevokePage.Expect( driver );
+				await revokePage.revokeUser();
 				let sent = await revokePage.revokeSent();
 				return assert( sent, 'The sent confirmation message was not displayed' );
 			} );
@@ -210,7 +210,8 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				await driver.get( acceptInviteURL );
 				await AcceptInvitePage.Expect( driver );
 
-				let displayed = await new InviteErrorPage( driver ).inviteErrorTitleDisplayed();
+				const inviteErrorPage = await InviteErrorPage.Expect( driver );
+				let displayed = await inviteErrorPage.inviteErrorTitleDisplayed();
 				return assert( displayed, 'The invite was not successfully revoked' );
 			} );
 		}

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -105,7 +105,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 		} );
 
 		test.it( 'User has been added as Editor', async function() {
-			await new PostsPage( driver ).displayed();
+			await PostsPage.Expect( driver );
 
 			const invitesMessageTitleDisplayed = await new NoticesComponent(
 				driver
@@ -416,7 +416,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can see a notice welcoming the new user as an contributor', async function() {
-				await new PostsPage( driver );
+				await PostsPage.Expect( driver );
 				let invitesMessageTitleDisplayed = await new NoticesComponent(
 					driver
 				).inviteMessageTitle();

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -231,11 +231,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			} );
 
 			test.it( 'As an anonymous user I can not see a private site', async function() {
-				let displayed = await new PrivateSiteLoginPage( driver, true, siteUrl ).displayed();
-				return assert(
-					displayed,
-					`The private site log in page was not displayed for:'${ siteUrl }'`
-				);
+				return await new PrivateSiteLoginPage.Visit( driver, siteUrl );
 			} );
 
 			test.it( 'Can log in and navigate to Invite People page', async function() {
@@ -327,12 +323,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				await loginPage.login( newUserName, password );
 
 				await ReaderPage.Expect( driver );
-				let displayed = await new PrivateSiteLoginPage( driver, true, siteUrl ).displayed();
-				assert.equal(
-					displayed,
-					true,
-					`The private site log in page was not displayed for:'${ siteUrl }'`
-				);
+				return await PrivateSiteLoginPage.Visit( driver, siteUrl );
 			} );
 
 			test.after( async function() {

--- a/specs/wp-log-in-out-spec.js
+++ b/specs/wp-log-in-out-spec.js
@@ -19,7 +19,7 @@ import WPHomePage from '../lib/pages/wp-home-page';
 // import MagicLoginPage from '../lib/pages/magic-login-page';
 // import LoginPage from '../lib/pages/login-page';
 
-import NavbarComponent from '../lib/components/navbar-component.js';
+import NavBarComponent from '../lib/components/nav-bar-component.js';
 import LoggedOutMasterbarComponent from '../lib/components/logged-out-masterbar-component';
 
 import LoginFlow from '../lib/flows/login-flow.js';
@@ -82,7 +82,7 @@ test.describe(
 
 			test.describe( 'Can Log Out', function() {
 				test.it( 'Can view profile to log out', async function() {
-					let navbarComponent = new NavbarComponent( driver );
+					let navbarComponent = await NavBarComponent.Expect( driver );
 					await navbarComponent.clickProfileLink();
 				} );
 

--- a/specs/wp-log-in-out-spec.js
+++ b/specs/wp-log-in-out-spec.js
@@ -62,9 +62,7 @@ test.describe(
 				} );
 
 				test.it( 'Can see Reader Page after logging in', async function() {
-					let readerPage = new ReaderPage( driver );
-					let displayed = await readerPage.displayed();
-					assert.equal( displayed, true, 'The reader page is not displayed after log in' );
+					return await ReaderPage.Expect( driver );
 				} );
 			} );
 
@@ -77,8 +75,7 @@ test.describe(
 					} );
 
 					test.it( 'Can return to Reader', async () => {
-						let readerPage = new ReaderPage( driver, true );
-						return await readerPage.displayed();
+						return await ReaderPage.Visit( driver );
 					} );
 				} );
 			}

--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -95,7 +95,7 @@ test.describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, func
 
 		test.after( async function() {
 			// Empty the cart
-			await new ReaderPage( driver, true ).displayed();
+			await ReaderPage.Visit( driver );
 			await new NavbarComponent( driver ).clickMySites();
 			await new StatsPage( driver, true ).displayed();
 			await new SidebarComponent( driver ).selectDomains();
@@ -160,7 +160,7 @@ test.describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, func
 
 		test.after( async function() {
 			// Empty the cart
-			await new ReaderPage( driver, true ).displayed();
+			await ReaderPage.Visit( driver );
 			await new NavbarComponent( driver ).clickMySites();
 			await new StatsPage( driver, true ).displayed();
 			await new SidebarComponent( driver ).selectDomains();

--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -96,7 +96,8 @@ test.describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, func
 		test.after( async function() {
 			// Empty the cart
 			await ReaderPage.Visit( driver );
-			await new NavbarComponent( driver ).clickMySites();
+			const navBarComponent = await NavbarComponent.Expect( driver );
+			await navBarComponent.clickMySites();
 			await new StatsPage( driver, true ).displayed();
 			await new SidebarComponent( driver ).selectDomains();
 			await new DomainsPage( driver ).displayed();

--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -15,7 +15,7 @@ import FindADomainComponent from '../lib/components/find-a-domain-component.js';
 import SecurePaymentComponent from '../lib/components/secure-payment-component.js';
 import ShoppingCartWidgetComponent from '../lib/components/shopping-cart-widget-component.js';
 import SidebarComponent from '../lib/components/sidebar-component.js';
-import NavbarComponent from '../lib/components/navbar-component.js';
+import NavBarComponent from '../lib/components/nav-bar-component.js';
 import MyOwnDomainPage from '../lib/pages/domain-my-own-page';
 import MapADomainComponent from '../lib/components/map-a-domain-component';
 import MapADomainPage from '../lib/pages/domain-map-page';
@@ -96,7 +96,7 @@ test.describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, func
 		test.after( async function() {
 			// Empty the cart
 			await ReaderPage.Visit( driver );
-			const navBarComponent = await NavbarComponent.Expect( driver );
+			const navBarComponent = await NavBarComponent.Expect( driver );
 			await navBarComponent.clickMySites();
 			await new StatsPage( driver, true ).displayed();
 			await new SidebarComponent( driver ).selectDomains();
@@ -162,7 +162,8 @@ test.describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, func
 		test.after( async function() {
 			// Empty the cart
 			await ReaderPage.Visit( driver );
-			await new NavbarComponent( driver ).clickMySites();
+			const navBarComponent = await NavBarComponent.Expect( driver );
+			await navBarComponent.clickMySites();
 			await new StatsPage( driver, true ).displayed();
 			await new SidebarComponent( driver ).selectDomains();
 			await new DomainsPage( driver ).displayed();

--- a/specs/wp-media-upload-spec.js
+++ b/specs/wp-media-upload-spec.js
@@ -35,7 +35,7 @@ test.describe( `[${ host }] Editor: Media Upload (${ screenSize }) @parallel @je
 			await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 			const loginFlow = new LoginFlow( driver );
 			await loginFlow.loginAndStartNewPage();
-			editorPage = new EditorPage( driver );
+			editorPage = await EditorPage.Expect( driver );
 			await editorPage.displayed();
 		} );
 

--- a/specs/wp-media-upload-spec.js
+++ b/specs/wp-media-upload-spec.js
@@ -142,7 +142,7 @@ test.describe( `[${ host }] Editor: Media Upload (${ screenSize }) @parallel @je
 				test.it( 'Can delete uploaded image', async function() {
 					await editorSidebar.expandFeaturedImage();
 					await editorSidebar.openFeaturedImageDialog();
-					await editorPage.selectImageByNumber( 0 );
+					await editorPage.selectFirstImage();
 					await editorPage.deleteMedia();
 				} );
 

--- a/specs/wp-notifications-spec.js
+++ b/specs/wp-notifications-spec.js
@@ -14,7 +14,7 @@ import LoginFlow from '../lib/flows/login-flow.js';
 import ViewSitePage from '../lib/pages/view-site-page.js';
 import ViewPostPage from '../lib/pages/view-post-page.js';
 
-import NavbarComponent from '../lib/components/navbar-component.js';
+import NavBarComponent from '../lib/components/nav-bar-component.js';
 import NotificationsComponent from '../lib/components/notifications-component.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
@@ -86,7 +86,7 @@ test.describe( `[${ host }] Notifications: (${ screenSize }) @parallel @visdiff`
 	} );
 
 	test.it( 'Can open notifications tab with keyboard shortcut', async function() {
-		const navBarComponent = new NavbarComponent( driver );
+		const navBarComponent = await NavBarComponent.Expect( driver );
 		await navBarComponent.openNotificationsShortcut();
 		const present = await navBarComponent.confirmNotificationsOpen();
 		return assert( present, 'Notifications tab is not open' );
@@ -94,7 +94,7 @@ test.describe( `[${ host }] Notifications: (${ screenSize }) @parallel @visdiff`
 
 	test.it( 'Can see the notification of the comment', async function() {
 		const expectedContent = `${ commentingUser } commented on ${ commentedPostTitle }\n${ comment }`;
-		const navBarComponent = new NavbarComponent( driver );
+		const navBarComponent = await NavBarComponent.Expect( driver );
 		await navBarComponent.openNotifications();
 		const notificationsComponent = new NotificationsComponent( driver );
 		await notificationsComponent.selectComments();

--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -58,7 +58,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can enter page title, content and image', async function() {
-			const editorPage = new EditorPage( driver );
+			const editorPage = await EditorPage.Expect( driver );
 			await editorPage.enterTitle( pageTitle );
 			await editorPage.enterContent( pageQuote + '\n' );
 			await editorPage.enterPostImage( fileDetails );
@@ -229,7 +229,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can enter page title and content', async function() {
-			const editorPage = new EditorPage( driver );
+			const editorPage = await EditorPage.Expect( driver );
 			await editorPage.enterTitle( pageTitle );
 			await editorPage.enterContent( pageQuote );
 			const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
@@ -323,11 +323,11 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can enter page title and content and set to password protected', async function() {
-				let editorPage = new EditorPage( driver );
+				let editorPage = await EditorPage.Expect( driver );
 				await editorPage.enterTitle( pageTitle );
 				const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 				await postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
-				editorPage = new EditorPage( driver );
+				editorPage = await EditorPage.Expect( driver );
 				await editorPage.enterContent( pageQuote );
 				const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
 				await postEditorToolbarComponent.ensureSaved();
@@ -607,7 +607,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		test.it( 'Can insert the payment button', async function() {
 			const pageTitle = 'Payment Button Page: ' + dataHelper.randomPhrase();
 
-			const editorPage = new EditorPage( driver );
+			const editorPage = await EditorPage.Expect( driver );
 			await editorPage.enterTitle( pageTitle );
 			await editorPage.insertPaymentButton( null, paymentButtonDetails );
 
@@ -616,7 +616,8 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can see the payment button inserted into the visual editor', async function() {
-			return await new EditorPage( driver ).ensurePaymentButtonDisplayedInPost();
+			const editorPage = await EditorPage.Expect( driver );
+			return await editorPage.ensurePaymentButtonDisplayedInPost();
 		} );
 
 		test.it( 'Can publish and view content', async function() {

--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -78,7 +78,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 			const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 			await postEditorSidebarComponent.hideComponentIfNecessary();
 
-			const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+			const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 			await postEditorToolbarComponent.ensureSaved();
 			await postEditorToolbarComponent.launchPreview();
 		} );
@@ -120,7 +120,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can publish and preview published content', async function() {
-			const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+			const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 			await postEditorToolbarComponent.publishThePost( { useConfirmStep: true } );
 		} );
 
@@ -161,7 +161,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can view content', async function() {
-			const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+			const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 			await postEditorToolbarComponent.displayed();
 			await postEditorToolbarComponent.viewPublishedPostOrPage();
 		} );
@@ -232,20 +232,20 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 			const editorPage = await EditorPage.Expect( driver );
 			await editorPage.enterTitle( pageTitle );
 			await editorPage.enterContent( pageQuote );
-			const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+			const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 			return await postEditorToolbarComponent.ensureSaved();
 		} );
 
 		test.it( 'Can set visibility to private which immediately publishes it', async function() {
 			const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 			await postEditorSidebarComponent.setVisibilityToPrivate();
-			const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+			const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 			return await postEditorToolbarComponent.waitForSuccessViewPostNotice();
 		} );
 
 		if ( host === 'WPCOM' ) {
 			test.it( 'Can view content', async function() {
-				const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+				const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 				await postEditorToolbarComponent.viewPublishedPostOrPage();
 			} );
 
@@ -288,7 +288,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		} else {
 			// Jetpack tests
 			test.it( 'Open published page', async function() {
-				const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+				const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 				await postEditorToolbarComponent.viewPublishedPostOrPage();
 			} );
 
@@ -329,12 +329,12 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				await postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
 				editorPage = await EditorPage.Expect( driver );
 				await editorPage.enterContent( pageQuote );
-				const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+				const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 				await postEditorToolbarComponent.ensureSaved();
 			} );
 
 			test.it( 'Can publish and view content', async function() {
-				const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+				const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 				await postEditorToolbarComponent.publishAndViewContent( { useConfirmStep: true } );
 			} );
 		} );
@@ -621,7 +621,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can publish and view content', async function() {
-			const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+			const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 			await postEditorToolbarComponent.ensureSaved();
 			await postEditorToolbarComponent.publishAndViewContent( { useConfirmStep: true } );
 		} );

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -78,7 +78,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 			test.describe( 'Create, Preview and Post', function() {
 				test.it( 'Can enter post title, content and image', async function() {
-					let editorPage = new EditorPage( driver );
+					let editorPage = await EditorPage.Expect( driver );
 					await editorPage.enterTitle( blogPostTitle );
 					await editorPage.enterContent( blogPostQuote + '\n' );
 					await editorPage.enterPostImage( fileDetails );
@@ -368,7 +368,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 		} );
 	} );
 
-	test.describe( 'Basic Public Post @canary @parallel @jetpack', function() {
+	test.describe.only( 'Basic Public Post @canary @parallel @jetpack', function() {
 		this.bailSuite( true );
 
 		test.it( 'Delete Cookies and Local Storage', async function() {
@@ -386,7 +386,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can enter post title and content', async function() {
-				this.editorPage = new EditorPage( driver );
+				this.editorPage = await EditorPage.Expect( driver );
 				await this.editorPage.enterTitle( blogPostTitle );
 				await this.editorPage.enterContent( blogPostQuote + '\n' );
 
@@ -430,7 +430,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can enter post title and content', async function() {
-			let editorPage = new EditorPage( driver );
+			let editorPage = await EditorPage.Expect( driver );
 			await editorPage.enterTitle( blogPostTitle );
 			await editorPage.enterContent( blogPostQuote + '\n' );
 
@@ -479,7 +479,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can enter post title and content', async function() {
-				this.editorPage = new EditorPage( driver );
+				this.editorPage = await EditorPage.Expect( driver );
 				await this.editorPage.enterTitle( blogPostTitle );
 				await this.editorPage.enterContent( blogPostQuote + '\n' );
 
@@ -497,7 +497,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 					await postEditorSidebarComponent.chooseFutureDate();
 					publishDate = await postEditorSidebarComponent.getSelectedPublishDate();
 					await postEditorSidebarComponent.closeStatusSection();
-					let editorPage = new EditorPage( driver );
+					let editorPage = await EditorPage.Expect( driver );
 					await editorPage.waitForPage();
 					postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
 					await postEditorToolbarComponent.ensureSaved( { clickSave: true } );
@@ -516,7 +516,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				await editorConfirmationSidebarComponent.confirmAndPublish();
 				let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
 				await postEditorToolbarComponent.waitForPostSucessNotice();
-				let postEditorPage = new EditorPage( driver );
+				let postEditorPage = await EditorPage.Expect( driver );
 				let isScheduled = await postEditorPage.postIsScheduled();
 				assert( isScheduled, 'The newly scheduled post is not showing in the editor as scheduled' );
 			} );
@@ -539,7 +539,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can enter post title and content', async function() {
-				let editorPage = new EditorPage( driver );
+				let editorPage = await EditorPage.Expect( driver );
 				await editorPage.enterTitle( blogPostTitle );
 				await editorPage.enterContent( blogPostQuote );
 			} );
@@ -672,11 +672,11 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can enter post title and content and set to password protected', async function() {
-				this.editorPage = new EditorPage( driver );
+				this.editorPage = await EditorPage.Expect( driver );
 				await this.editorPage.enterTitle( blogPostTitle );
 				this.postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 				await this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
-				this.editorPage = new EditorPage( driver );
+				this.editorPage = await EditorPage.Expect( driver );
 				await this.editorPage.enterContent( blogPostQuote );
 				this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
 				await this.postEditorToolbarComponent.ensureSaved();
@@ -1089,7 +1089,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can enter post title and content', async function() {
-				const editorPage = new EditorPage( driver );
+				const editorPage = await EditorPage.Expect( driver );
 				await editorPage.enterTitle( blogPostTitle );
 				return await editorPage.enterContent( blogPostQuote );
 			} );
@@ -1130,7 +1130,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can enter post title and content', async function() {
-				this.editorPage = new EditorPage( driver );
+				this.editorPage = await EditorPage.Expect( driver );
 				await this.editorPage.enterTitle( originalBlogPostTitle );
 				await this.editorPage.enterContent( blogPostQuote );
 				let errorShown = await this.editorPage.errorDisplayed();
@@ -1167,7 +1167,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						`The blog post titled '${ originalBlogPostTitle }' is not displayed in the list of posts`
 					);
 					await this.postsPage.editPostWithTitle( originalBlogPostTitle );
-					return ( this.editorPage = new EditorPage( driver ) );
+					return ( this.editorPage = await EditorPage.Expect( driver ) );
 				} );
 
 				test.it( 'Can see the post title', async function() {
@@ -1226,7 +1226,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can insert the contact form', async function() {
-				this.editorPage = new EditorPage( driver );
+				this.editorPage = await EditorPage.Expect( driver );
 				await this.editorPage.enterTitle( originalBlogPostTitle );
 				await this.editorPage.insertContactForm();
 
@@ -1235,7 +1235,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can see the contact form inserted into the visual editor', async function() {
-				this.editorPage = new EditorPage( driver );
+				this.editorPage = await EditorPage.Expect( driver );
 				return await this.editorPage.ensureContactFormDisplayedInPost();
 			} );
 
@@ -1287,7 +1287,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 		test.it( 'Can insert the payment button', async function() {
 			const blogPostTitle = 'Payment Button: ' + dataHelper.randomPhrase();
 
-			const editorPage = new EditorPage( driver );
+			const editorPage = await EditorPage.Expect( driver );
 			await editorPage.enterTitle( blogPostTitle );
 			await editorPage.insertPaymentButton( eyes, paymentButtonDetails );
 
@@ -1296,7 +1296,8 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can see the payment button inserted into the visual editor', async function() {
-			return await new EditorPage( driver ).ensurePaymentButtonDisplayedInPost();
+			const editorPage = await EditorPage.Expect( driver );
+			return await editorPage.ensurePaymentButtonDisplayedInPost();
 		} );
 
 		test.it( 'Can publish and view content', async function() {
@@ -1364,7 +1365,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can enter post title and content', async function() {
-				this.editorPage = new EditorPage( driver );
+				this.editorPage = await EditorPage.Expect( driver );
 				await this.editorPage.enterTitle( originalBlogPostTitle );
 				await this.editorPage.enterContent( blogPostQuote );
 

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -110,7 +110,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 					test.it( 'Verify categories and tags present after save', async function() {
 						let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
-						let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+						const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 						await postEditorSidebarComponent.hideComponentIfNecessary();
 						await postEditorToolbarComponent.ensureSaved();
 						await postEditorSidebarComponent.displayComponentIfNecessary();
@@ -167,7 +167,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 								let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 								await postEditorSidebarComponent.hideComponentIfNecessary();
 
-								this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+								this.postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 								await this.postEditorToolbarComponent.ensureSaved();
 								await this.postEditorToolbarComponent.launchPreview();
 								this.postPreviewComponent = new PostPreviewComponent( driver );
@@ -225,7 +225,9 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 							test.describe( 'Publish and Preview Published Content', function() {
 								test.it( 'Can publish and view content', async function() {
-									let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+									const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect(
+										driver
+									);
 									await postEditorToolbarComponent.publishThePost( { useConfirmStep: true } );
 								} );
 
@@ -288,7 +290,9 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 							test.describe( 'View Published Content', function() {
 								test.it( 'Can publish and view content', async function() {
-									let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+									const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect(
+										driver
+									);
 									await postEditorToolbarComponent.viewPublishedPostOrPage();
 								} );
 
@@ -395,7 +399,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can publish and view content', async function() {
-				const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+				const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 				await postEditorToolbarComponent.ensureSaved();
 				return await postEditorToolbarComponent.publishAndViewContent( { useConfirmStep: true } );
 			} );
@@ -439,7 +443,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can publish and view content', async function() {
-			let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+			const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 			await postEditorToolbarComponent.ensureSaved();
 			await postEditorToolbarComponent.publishThePost( { useConfirmStep: true } );
 			return await postEditorToolbarComponent.waitForSuccessViewPostNotice();
@@ -490,7 +494,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			test.it(
 				'Can schedule content for a future date (first day of second week next month)',
 				async function() {
-					let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+					let postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 					await postEditorToolbarComponent.ensureSaved( { clickSave: true } );
 					let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 					await postEditorSidebarComponent.expandStatusSection();
@@ -499,7 +503,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 					await postEditorSidebarComponent.closeStatusSection();
 					let editorPage = await EditorPage.Expect( driver );
 					await editorPage.waitForPage();
-					postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+					postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 					await postEditorToolbarComponent.ensureSaved( { clickSave: true } );
 					return await postEditorToolbarComponent.clickPublishPost();
 				}
@@ -514,7 +518,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 					'The publish date shown is not the expected publish date'
 				);
 				await editorConfirmationSidebarComponent.confirmAndPublish();
-				let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+				const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 				await postEditorToolbarComponent.waitForPostSucessNotice();
 				let postEditorPage = await EditorPage.Expect( driver );
 				let isScheduled = await postEditorPage.postIsScheduled();
@@ -559,14 +563,14 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 			test.describe( 'Set to private which publishes it', function() {
 				test.it( 'Ensure the post is saved', async function() {
-					let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+					const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 					await postEditorToolbarComponent.ensureSaved();
 				} );
 
 				test.it( 'Can set visibility to private which immediately publishes it', async function() {
 					const postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
 					await postEditorSidebarComponent.setVisibilityToPrivate();
-					this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+					this.postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 					await this.postEditorToolbarComponent.waitForSuccessViewPostNotice();
 					await this.postEditorToolbarComponent.viewPublishedPostOrPage();
 				} );
@@ -678,7 +682,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				await this.postEditorSidebarComponent.setVisibilityToPasswordProtected( postPassword );
 				this.editorPage = await EditorPage.Expect( driver );
 				await this.editorPage.enterContent( blogPostQuote );
-				this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+				this.postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 				await this.postEditorToolbarComponent.ensureSaved();
 			} );
 
@@ -699,7 +703,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			test.describe( 'Publish and View', function() {
 				// Can publish and view content
 				test.before( async function() {
-					let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+					const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 					await postEditorToolbarComponent.publishAndViewContent( { useConfirmStep: true } );
 				} );
 
@@ -1138,7 +1142,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can publish the post', async function() {
-				this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+				this.postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 				await this.postEditorToolbarComponent.ensureSaved();
 				await this.postEditorToolbarComponent.publishThePost( { useConfirmStep: true } );
 				return await this.postEditorToolbarComponent.waitForSuccessViewPostNotice();
@@ -1186,7 +1190,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						await this.editorPage.enterTitle( updatedBlogPostTitle );
 						let errorShown = await this.editorPage.errorDisplayed();
 						assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
-						this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+						this.postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 						await this.postEditorToolbarComponent.publishThePost();
 						return await this.postEditorToolbarComponent.waitForSuccessAndViewPost();
 					}
@@ -1240,7 +1244,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can publish and view content', async function() {
-				let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+				const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 				await postEditorToolbarComponent.ensureSaved();
 				await postEditorToolbarComponent.publishAndViewContent( { useConfirmStep: true } );
 			} );
@@ -1301,7 +1305,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can publish and view content', async function() {
-			const postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+			const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 			await postEditorToolbarComponent.ensureSaved();
 			await postEditorToolbarComponent.publishAndViewContent( { useConfirmStep: true } );
 		} );
@@ -1374,7 +1378,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can publish the post', async function() {
-				this.postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+				this.postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 				await this.postEditorToolbarComponent.ensureSaved();
 				await this.postEditorToolbarComponent.publishThePost( { useConfirmStep: true } );
 
@@ -1388,7 +1392,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 		test.describe( 'Revert the post to draft', function() {
 			test.it( 'Can revert the post to draft', async function() {
 				let postEditorSidebarComponent = new PostEditorSidebarComponent( driver );
-				let postEditorToolbarComponent = new PostEditorToolbarComponent( driver );
+				const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 				await postEditorSidebarComponent.revertToDraft();
 				await postEditorToolbarComponent.waitForIsDraftStatus();
 				let isDraft = await postEditorToolbarComponent.statusIsDraft();

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -446,7 +446,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		test.it( 'Can see the post in the Activity log', async function() {
-			await new ReaderPage( driver, true ).displayed();
+			await ReaderPage.Visit( driver );
 			await new NavbarComponent( driver ).clickMySites();
 			let sidebarComponent = new SidebarComponent( driver );
 			await sidebarComponent.ensureSidebarMenuVisible();
@@ -1145,7 +1145,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 			test.describe( 'Edit the post via posts', function() {
 				test.it( 'Can view the posts list', async function() {
-					this.readerPage = new ReaderPage( driver, true );
+					this.readerPage = await ReaderPage.Visit( driver );
 					this.navbarComponent = new NavbarComponent( driver );
 					await this.navbarComponent.clickMySites();
 					const jetpackSiteName = dataHelper.getJetpackSiteName();

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -17,7 +17,7 @@ import ActivityPage from '../lib/pages/stats/activity-page';
 import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
 
 import SidebarComponent from '../lib/components/sidebar-component.js';
-import NavbarComponent from '../lib/components/navbar-component.js';
+import NavBarComponent from '../lib/components/nav-bar-component.js';
 import PostPreviewComponent from '../lib/components/post-preview-component.js';
 import PostEditorSidebarComponent from '../lib/components/post-editor-sidebar-component.js';
 import PostEditorToolbarComponent from '../lib/components/post-editor-toolbar-component';
@@ -447,7 +447,8 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 		test.it( 'Can see the post in the Activity log', async function() {
 			await ReaderPage.Visit( driver );
-			await new NavbarComponent( driver ).clickMySites();
+			const navBarComponent = await NavBarComponent.Expect( driver );
+			await navBarComponent.clickMySites();
 			let sidebarComponent = new SidebarComponent( driver );
 			await sidebarComponent.ensureSidebarMenuVisible();
 			await sidebarComponent.selectStats();
@@ -1146,7 +1147,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			test.describe( 'Edit the post via posts', function() {
 				test.it( 'Can view the posts list', async function() {
 					this.readerPage = await ReaderPage.Visit( driver );
-					this.navbarComponent = new NavbarComponent( driver );
+					this.navbarComponent = await NavBarComponent.Expect( driver );
 					await this.navbarComponent.clickMySites();
 					const jetpackSiteName = dataHelper.getJetpackSiteName();
 					this.sidebarComponent = new SidebarComponent( driver );

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -1099,8 +1099,8 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			test.it( 'Can then see the Posts page with a confirmation message', async function() {
-				const postsPage = new PostsPage( driver );
-				let displayed = await postsPage.successNoticeDisplayed();
+				const postsPage = await PostsPage.Expect( driver );
+				const displayed = await postsPage.successNoticeDisplayed();
 				return assert.equal(
 					displayed,
 					true,
@@ -1154,7 +1154,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						await this.sidebarComponent.selectSite( jetpackSiteName );
 					}
 					await this.sidebarComponent.selectPosts();
-					return ( this.postsPage = new PostsPage( driver ) );
+					return ( this.postsPage = await PostsPage.Expect( driver ) );
 				} );
 
 				test.it( 'Can see and edit our new post', async function() {

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -368,7 +368,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 		} );
 	} );
 
-	test.describe.only( 'Basic Public Post @canary @parallel @jetpack', function() {
+	test.describe( 'Basic Public Post @canary @parallel @jetpack', function() {
 		this.bailSuite( true );
 
 		test.it( 'Delete Cookies and Local Storage', async function() {

--- a/specs/wp-reader-spec.js
+++ b/specs/wp-reader-spec.js
@@ -49,13 +49,14 @@ test.describe( 'Reader: (' + screenSize + ') @parallel @visdiff', function() {
 
 		test.describe( 'Leave a comment on the latest post in the Reader', function() {
 			test.it( 'Can see the Reader stream', async function() {
-				this.readerPage = new ReaderPage( driver );
-				return await this.readerPage.waitForPage();
+				const readerPage = await ReaderPage.Expect( driver );
+				return await readerPage.waitForPage();
 			} );
 
 			test.it( 'The latest post is on the expected test site', async function() {
 				const testSiteForNotifications = dataHelper.configGet( 'testSiteForNotifications' );
-				let siteOfLatestPost = await this.readerPage.siteOfLatestPost();
+				const readerPage = await ReaderPage.Expect( driver );
+				let siteOfLatestPost = await readerPage.siteOfLatestPost();
 				return assert.equal(
 					siteOfLatestPost,
 					testSiteForNotifications,
@@ -65,7 +66,8 @@ test.describe( 'Reader: (' + screenSize + ') @parallel @visdiff', function() {
 
 			test.it( 'Can comment on the latest post', async function() {
 				this.comment = dataHelper.randomPhrase();
-				await this.readerPage.commentOnLatestPost( this.comment, eyes );
+				const readerPage = await ReaderPage.Expect( driver );
+				await readerPage.commentOnLatestPost( this.comment, eyes );
 			} );
 
 			test.describe( 'Delete the new comment', function() {

--- a/specs/wp-reader-spec.js
+++ b/specs/wp-reader-spec.js
@@ -9,7 +9,7 @@ import LoginFlow from '../lib/flows/login-flow.js';
 import ReaderPage from '../lib/pages/reader-page.js';
 import ReaderManagePage from '../lib/pages/reader-manage-page.js';
 
-import NavbarComponent from '../lib/components/navbar-component.js';
+import NavBarComponent from '../lib/components/nav-bar-component.js';
 import NotificationsComponent from '../lib/components/notifications-component.js';
 
 import * as driverManager from '../lib/driver-manager.js';
@@ -85,7 +85,7 @@ test.describe( 'Reader: (' + screenSize + ') @parallel @visdiff', function() {
 					'Can delete the new comment (and wait for UNDO grace period so it is actually deleted)',
 					async function() {
 						await eyesHelper.eyesScreenshot( driver, eyes, 'Followed Sites Feed' );
-						this.navBarComponent = await NavbarComponent.Expect( driver );
+						this.navBarComponent = await NavBarComponent.Expect( driver );
 						await this.navBarComponent.openNotifications();
 						this.notificationsComponent = new NotificationsComponent( driver );
 						await this.notificationsComponent.selectCommentByText( this.comment );

--- a/specs/wp-reader-spec.js
+++ b/specs/wp-reader-spec.js
@@ -85,7 +85,7 @@ test.describe( 'Reader: (' + screenSize + ') @parallel @visdiff', function() {
 					'Can delete the new comment (and wait for UNDO grace period so it is actually deleted)',
 					async function() {
 						await eyesHelper.eyesScreenshot( driver, eyes, 'Followed Sites Feed' );
-						this.navBarComponent = new NavbarComponent( driver );
+						this.navBarComponent = await NavbarComponent.Expect( driver );
 						await this.navBarComponent.openNotifications();
 						this.notificationsComponent = new NotificationsComponent( driver );
 						await this.notificationsComponent.selectCommentByText( this.comment );

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -185,7 +185,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				await driver.get( magicLoginLink );
 				const magicLoginPage = await MagicLoginPage.Expect( driver );
 				await magicLoginPage.finishLogin();
-				return await new ReaderPage( driver ).displayed();
+				return await ReaderPage.Expect( driver );
 			} );
 
 			test.it( 'Can delete our newly created account', async function() {
@@ -883,7 +883,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 
 			test.it( 'We can cancel the domain', async function() {
 				return ( async () => {
-					await new ReaderPage( driver, true ).displayed();
+					await ReaderPage.Visit( driver );
 					await new NavBarComponent( driver ).clickMySites();
 					await new SideBarComponent( driver ).selectSettings();
 					await new DomainOnlySettingsPage( driver ).manageDomain();

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -37,7 +37,7 @@ import CloseAccountPage from '../lib/pages/account/close-account-page';
 
 import FindADomainComponent from '../lib/components/find-a-domain-component.js';
 import SecurePaymentComponent from '../lib/components/secure-payment-component.js';
-import NavBarComponent from '../lib/components/navbar-component';
+import NavBarComponent from '../lib/components/nav-bar-component';
 import SideBarComponent from '../lib/components/sidebar-component';
 import LoggedOutMasterbarComponent from '../lib/components/logged-out-masterbar-component';
 

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -190,7 +190,8 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 
 			test.it( 'Can delete our newly created account', async function() {
 				return ( async () => {
-					await new NavBarComponent( driver ).clickProfileLink();
+					const navBarComponent = await NavBarComponent.Expect( driver );
+					await navBarComponent.clickProfileLink();
 					await new ProfilePage( driver ).chooseAccountSettings();
 					await new AccountSettingsPage( driver ).chooseCloseYourAccount();
 					const closeAccountPage = await CloseAccountPage.Expect( driver );
@@ -363,7 +364,8 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 
 			test.it( 'Can delete the plan', async function() {
 				return ( async () => {
-					await new NavBarComponent( driver ).clickProfileLink();
+					const navBarComponent = await NavBarComponent.Expect( driver );
+					await navBarComponent.clickProfileLink();
 					await new ProfilePage( driver ).chooseManagePurchases();
 					const purchasesPage = new PurchasesPage( driver );
 					await purchasesPage.dismissGuidedTour();
@@ -383,7 +385,8 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 
 			test.it( 'Can delete our newly created account', async function() {
 				return ( async () => {
-					await new NavBarComponent( driver ).clickProfileLink();
+					const navBarComponent = await NavBarComponent.Expect( driver );
+					await navBarComponent.clickProfileLink();
 					await new ProfilePage( driver ).chooseAccountSettings();
 					await new AccountSettingsPage( driver ).chooseCloseYourAccount();
 					const closeAccountPage = await CloseAccountPage.Expect( driver );
@@ -531,7 +534,8 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 
 			test.it( 'Can delete the plan', async function() {
 				return ( async () => {
-					await new NavBarComponent( driver ).clickProfileLink();
+					const navBarComponent = await NavBarComponent.Expect( driver );
+					await navBarComponent.clickProfileLink();
 					await new ProfilePage( driver ).chooseManagePurchases();
 					const purchasesPage = new PurchasesPage( driver );
 					await purchasesPage.dismissGuidedTour();
@@ -551,7 +555,8 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 
 			test.it( 'Can delete our newly created account', async function() {
 				return ( async () => {
-					await new NavBarComponent( driver ).clickProfileLink();
+					const navBarComponent = await NavBarComponent.Expect( driver );
+					await navBarComponent.clickProfileLink();
 					await new ProfilePage( driver ).chooseAccountSettings();
 					await new AccountSettingsPage( driver ).chooseCloseYourAccount();
 					const closeAccountPage = await CloseAccountPage.Expect( driver );
@@ -694,7 +699,8 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 
 			test.it( 'Can delete the plan', async function() {
 				return ( async () => {
-					await new NavBarComponent( driver ).clickProfileLink();
+					const navBarComponent = await NavBarComponent.Expect( driver );
+					await navBarComponent.clickProfileLink();
 					await new ProfilePage( driver ).chooseManagePurchases();
 					const purchasesPage = new PurchasesPage( driver );
 					await purchasesPage.dismissGuidedTour();
@@ -714,7 +720,8 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 
 			test.it( 'Can delete our newly created account', async function() {
 				return ( async () => {
-					await new NavBarComponent( driver ).clickProfileLink();
+					const navBarComponent = await NavBarComponent.Expect( driver );
+					await navBarComponent.clickProfileLink();
 					await new ProfilePage( driver ).chooseAccountSettings();
 					await new AccountSettingsPage( driver ).chooseCloseYourAccount();
 					const closeAccountPage = await CloseAccountPage.Expect( driver );
@@ -866,7 +873,8 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			);
 
 			test.it( 'Can open the sidebar', async function() {
-				return await new NavBarComponent( driver ).clickMySites();
+				const navBarComponent = await NavBarComponent.Expect( driver );
+				await navBarComponent.clickMySites();
 			} );
 
 			test.it( 'We should only one option - the settings option', async function() {
@@ -884,7 +892,8 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			test.it( 'We can cancel the domain', async function() {
 				return ( async () => {
 					await ReaderPage.Visit( driver );
-					await new NavBarComponent( driver ).clickMySites();
+					const navBarComponent = await NavBarComponent.Expect( driver );
+					await navBarComponent.clickMySites();
 					await new SideBarComponent( driver ).selectSettings();
 					await new DomainOnlySettingsPage( driver ).manageDomain();
 					await new DomainDetailsPage( driver ).viewPaymentSettings();
@@ -1066,7 +1075,8 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 
 			test.it( 'Can cancel the domain', async function() {
 				return ( async () => {
-					await new NavBarComponent( driver ).clickProfileLink();
+					const navBarComponent = await NavBarComponent.Expect( driver );
+					await navBarComponent.clickProfileLink();
 					await new ProfilePage( driver ).chooseManagePurchases();
 
 					let purchasesPage = new PurchasesPage( driver );
@@ -1307,7 +1317,8 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 
 			test.it( 'Can delete our newly created account', async function() {
 				return ( async () => {
-					await new NavBarComponent( driver ).clickProfileLink();
+					const navBarComponent = await NavBarComponent.Expect( driver );
+					await navBarComponent.clickProfileLink();
 					await new ProfilePage( driver ).chooseAccountSettings();
 					await new AccountSettingsPage( driver ).chooseCloseYourAccount();
 					const closeAccountPage = await CloseAccountPage.Expect( driver );


### PR DESCRIPTION
This updates the invite users spec to use async page objects:

- cleans up a lot of code
- removes the follower test as it doesn't work on our test site
- changes the description of the private site test to indicate this is WordPress.com only (there are no private Jetpack sites)

Also fixes #1185