### PR TITLE
Update plan selector

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -73,7 +73,7 @@
 		[ "skipThemesSelectionModal_20170904", "show" ],
 		[ "checklistThankYouForFreeUser_20171204", "hide" ],
 		[ "checklistThankYouForPaidUser_20171204", "hide" ],
-		[ "mobilePlansTablesOnSignup_20180330", "original" ],
+		[ "mobilePlansTablesOnSignup_20180330", "vertical" ],
 		[ "springSale30PercentOff_20180413", "control" ],
 		[ "multiyearSubscriptions_20180601", "hide" ],
 		[ "jetpackSignupGoogleTop_20180427", "original" ],

--- a/lib/pages/signup/pick-a-plan-page.js
+++ b/lib/pages/signup/pick-a-plan-page.js
@@ -6,6 +6,7 @@ import { By } from 'selenium-webdriver';
 import AsyncBaseContainer from '../../async-base-container';
 
 import * as driverHelper from '../../driver-helper.js';
+import * as driverManager from '../../driver-manager';
 import { getJetpackHost } from '../../data-helper.js';
 
 export default class PickAPlanPage extends AsyncBaseContainer {
@@ -41,8 +42,11 @@ export default class PickAPlanPage extends AsyncBaseContainer {
 	}
 
 	async _selectPlan( level ) {
-		const prefix = '.plans-features-main';
-		const selector = By.css( `${ prefix } button.is-${ level }-plan:not([disabled])` );
+		const plansPrefix =
+			driverManager.currentScreenSize() === 'mobile'
+				? '.plan-features__mobile'
+				: '.plan-features__table';
+		const selector = By.css( `${ plansPrefix } button.is-${ level }-plan:not([disabled])` );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 }


### PR DESCRIPTION
This is so our tests for ready for when https://github.com/Automattic/wp-calypso/pull/25499

This can be merged before that PR as this now forces the 'vertical' variant which is what will be the standard view going forward