### PR TITLE
Precommit: Prevent eslint printing help when no files to lint

### DIFF
--- a/scripts/pre-commit-hook.js
+++ b/scripts/pre-commit-hook.js
@@ -1,6 +1,4 @@
-/**
- * @format
- */
+/** @format */
 
 /**
  * External dependencies
@@ -51,18 +49,21 @@ files.forEach( file => {
 	execSync( `git add ${ file }` );
 } );
 
-// linting should happen after formatting
-const lintResult = spawnSync( 'eslint', [ ...files, '--max-warnings=0' ], {
-	shell: true,
-	stdio: 'inherit',
-} );
+// We may have no files to lint. Prevent eslint from printing help documentation.
+if ( files.length ) {
+	// linting should happen after formatting
+	const lintResult = spawnSync( 'eslint', [ ...files, '--max-warnings=0' ], {
+		shell: true,
+		stdio: 'inherit',
+	} );
 
-if ( lintResult.status ) {
-	console.log(
-		'COMMIT ABORTED:',
-		'The linter reported some problems. ' +
-			'If you are aware of them and it is OK, ' +
-			'repeat the commit command with --no-verify to avoid this check.'
-	);
-	process.exit( 1 ); // eslint-disable-line no-process-exit
+	if ( lintResult.status ) {
+		console.log(
+			'COMMIT ABORTED:',
+			'The linter reported some problems. ' +
+				'If you are aware of them and it is OK, ' +
+				'repeat the commit command with --no-verify to avoid this check.'
+		);
+		process.exit( 1 ); // eslint-disable-line no-process-exit
+	}
 }


### PR DESCRIPTION
Prevent eslint pre-commit from printing help output.

---

When there are no files that should be passed to eslint, eslint prints help output in the pre-commit hook:

```
$ git commit

husky > pre-commit (node v10.4.1)
eslint [options] file.js [file.js] [dir]

Basic configuration:
  -c, --config path::String   Use configuration from this file or shareable config
  --no-eslintrc               Disable use of configuration from .eslintrc
  --env [String]              Specify environments
  --ext [String]              Specify JavaScript file extensions - default: .js
  --global [String]           Define global variables
  --parser String             Specify the parser to be used - default: espree

Caching:
  --cache                     Only check changed files - default: false
  --cache-file path::String   Path to the cache file. Deprecated: use --cache-location - default: .eslintcache
  --cache-location path::String  Path to the cache file or directory

Specifying rules and plugins:
  --rulesdir [path::String]   Use additional rules from this directory
  --plugin [String]           Specify plugins
  --rule Object               Specify rules

Ignoring files:
  --ignore-path path::String  Specify path of ignore file
  --no-ignore                 Disable use of .eslintignore
  --ignore-pattern [String]   Pattern of files to ignore (in addition to those in .eslintignore)

Using stdin:
  --stdin                     Lint code provided on <STDIN> - default: false
  --stdin-filename String     Specify filename to process STDIN as

Handling warnings:
  --quiet                     Report errors only - default: false
  --max-warnings Int          Number of warnings to trigger nonzero exit code - default: -1

Output:
  -o, --output-file path::String  Specify file to write report to
  -f, --format String         Use a specific output format - default: stylish
  --no-color                  Disable color in piped output

Miscellaneous:
  --init                      Run config initialization wizard - default: false
  --fix                       Automatically fix problems
  --debug                     Output debugging information
  -h, --help                  Show help
  -v, --version               Outputs the version number
  --no-inline-config          Allow comments to change eslint config/rules
  --print-config              Print the configuration to be used

```

---

## Testing
1. Change a file that should not be eslint-ed, for example `package.json`.
1. `git commit`
1. The pre-commit hook runs, but eslint does not output help
1. Add an eslint violation to a file that should be linted
1. `git commit`
1. The pre-commit eslint should run and abort the commit.