### PR TITLE
Increase timeout for Jetpack disconnect

### DIFF
--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -57,14 +57,16 @@ test.describe( `Jetpack Connect: (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
 	test.describe( 'Disconnect expired sites: @parallel @jetpack @canary', function() {
+		const timeout = mochaTimeOut * 10;
 		this.bailSuite( true );
+		this.timeout( timeout );
 
 		test.before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
 		test.it( 'Can disconnect any expired sites', async function() {
-			return await new JetpackConnectFlow( driver, 'jetpackConnectUser' ).removeSites();
+			return await new JetpackConnectFlow( driver, 'jetpackConnectUser' ).removeSites( timeout );
 		} );
 	} );
 

--- a/specs-jetpack-calypso/wp-pressable-nux-spec.js
+++ b/specs-jetpack-calypso/wp-pressable-nux-spec.js
@@ -35,14 +35,16 @@ if ( host === 'PRESSABLE' ) {
 		this.timeout( mochaTimeOut * 2 );
 
 		test.describe( 'Disconnect expired sites: @parallel @jetpack', function() {
+			const timeout = mochaTimeOut * 10;
 			this.bailSuite( true );
+			this.timeout( timeout );
 
 			test.before( async function() {
 				return await driverManager.ensureNotLoggedIn( driver );
 			} );
 
 			test.it( 'Can disconnect any expired sites', async function() {
-				return await new JetpackConnectFlow( driver ).removeSites();
+				return await new JetpackConnectFlow( driver ).removeSites( timeout );
 			} );
 		} );
 


### PR DESCRIPTION
Adding long timeout for `Disconnect expired sites` spec, to make sure it deletes most of the sites 