### PR TITLE
A/B Tests: Add staleCartNotice test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -65,7 +65,8 @@
 		"multiyearSubscriptions",
 		"jetpackSignupGoogleTop",
 		"domainSuggestionKrakenV321",
-		"domainSearchTLDFilterPlacement"
+		"domainSearchTLDFilterPlacement",
+		"staleCartNotice"
 	],
 	"overrideABTests": [
 		[ "businessPlanDescriptionAT_20170605", "original" ],
@@ -76,6 +77,7 @@
 		[ "multiyearSubscriptions_20180601", "hide" ],
 		[ "jetpackSignupGoogleTop_20180427", "original" ],
 		[ "domainSuggestionKrakenV321_20180524", "domainsbot" ],
-		[ "domainSearchTLDFilterPlacement_20180531", "belowFeatured" ]
+		[ "domainSearchTLDFilterPlacement_20180531", "belowFeatured" ],
+		[ "staleCartNotice_20180618", "siteDeservesBoost" ]
 	]
 }


### PR DESCRIPTION
Required by https://github.com/Automattic/wp-calypso/pull/22995

Add `staleCartNotice` starting on `20180618` and with default variation/override `siteDeservesBoost`.