### PR TITLE
Domains: Added new abtest for Kracken and removed the old one

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -64,7 +64,7 @@
 		"springSale30PercentOff",
 		"multiyearSubscriptions",
 		"jetpackSignupGoogleTop",
-		"domainSuggestionKrakenV321",
+		"domainSuggestionKrakenV322",
 		"domainSearchTLDFilterPlacement",
 		"staleCartNotice"
 	],
@@ -76,7 +76,7 @@
 		[ "springSale30PercentOff_20180413", "control" ],
 		[ "multiyearSubscriptions_20180601", "hide" ],
 		[ "jetpackSignupGoogleTop_20180427", "original" ],
-		[ "domainSuggestionKrakenV321_20180524", "domainsbot" ],
+		[ "domainSuggestionKrakenV322_20180621", "domainsbot" ],
 		[ "domainSearchTLDFilterPlacement_20180531", "belowFeatured" ],
 		[ "staleCartNotice_20180618", "siteDeservesBoost" ]
 	]


### PR DESCRIPTION
This depends on https://github.com/Automattic/wp-calypso/pull/25665