### PR TITLE
put this.driver instead of self.driver

### DIFF
--- a/lib/pages/plugins-browser-page.js
+++ b/lib/pages/plugins-browser-page.js
@@ -36,7 +36,7 @@ export default class PluginsBrowserPage extends AsyncBaseContainer {
 		SlackNotifier.warn(
 			'The Jetpack Plugins Browser results were not showing the expected result, so trying again'
 		);
-		await driverHelper.clickWhenClickable( self.driver, by.css( '.search__close-icon' ) );
+		await driverHelper.clickWhenClickable( this.driver, by.css( '.search__close-icon' ) );
 		await this.searchForPlugin( searchTerm );
 		return await driverHelper.isEventuallyPresentAndDisplayed( self.driver, selector );
 	}


### PR DESCRIPTION
While running Jetpack-Calypso [tests](https://circleci.com/gh/Automattic/wp-e2e-tests/20804) I got an error `self is not defined`. It shouldn't happen anymore.