### PR TITLE
Update assert.equal

### DIFF
--- a/lib/async-base-container.js
+++ b/lib/async-base-container.js
@@ -119,7 +119,7 @@ export default class AsyncBaseContainer {
 		await this.driver.get( startUrl );
 
 		let flowValue = await this.driver.executeScript( 'return window.localStorage.signupFlowName;' );
-		assert.equal(
+		assert.strictEqual(
 			flowValue,
 			`"${ flow }"`,
 			"The local storage value for flow wasn't set correctly"

--- a/lib/pages/landing-page.js
+++ b/lib/pages/landing-page.js
@@ -11,7 +11,7 @@ export default class LandingPage extends AsyncBaseContainer {
 
 	checkURL() {
 		this.driver.getCurrentUrl().then( currentUrl => {
-			assert.equal(
+			assert.strictEqual(
 				true,
 				currentUrl.includes( 'wordpress.com' ),
 				`The current url: '${ currentUrl }' does not include 'wordpress.com'`

--- a/lib/pages/wp-home-page.js
+++ b/lib/pages/wp-home-page.js
@@ -30,7 +30,7 @@ export default class WPHomePage extends AsyncBaseContainer {
 	async checkURL( culture ) {
 		const target = culture ? localizationData[ culture ].wpcom_base_url : 'wordpress.com';
 		let currentUrl = await this.driver.getCurrentUrl();
-		return assert.equal(
+		return assert.strictEqual(
 			true,
 			currentUrl.includes( target ),
 			`The current url: '${ currentUrl }' does not include ${ target }`

--- a/specs-jetpack-calypso/wp-jetpack-onboarding-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-onboarding-spec.js
@@ -69,7 +69,7 @@ test.describe( `Jetpack Onboarding: (${ screenSize })`, function() {
 			await wizardNavigationComponent.skipStep();
 			const summaryPage = await SummaryPage.Expect( driver );
 			let toDoCount = await summaryPage.countToDoSteps();
-			assert.equal( toDoCount, 4, 'Expected and actual steps are not equal.' );
+			assert.strictEqual( toDoCount, 4, 'Expected and actual steps are not equal.' );
 		} );
 
 		test.it( 'Can go back to first step in flow from summary page', async function() {
@@ -122,14 +122,18 @@ test.describe( `Jetpack Onboarding: (${ screenSize })`, function() {
 		test.it( 'Can see onboarding summary page', async function() {
 			const summaryPage = await SummaryPage.Expect( driver );
 			let toDoCount = await summaryPage.countToDoSteps();
-			assert.equal( toDoCount, 0, 'Expected and actual steps are not equal.' );
+			assert.strictEqual( toDoCount, 0, 'Expected and actual steps are not equal.' );
 			return await summaryPage.selectVisitSite();
 		} );
 
 		test.it( 'Can see site home page', async function() {
 			const viewPagePage = await ViewPagePage.Expect( driver );
 			let title = await viewPagePage.pageTitle();
-			return assert.equal( title.toUpperCase(), 'HOME PAGE', 'Homepage not set to a static page' );
+			return assert.strictEqual(
+				title.toUpperCase(),
+				'HOME PAGE',
+				'Homepage not set to a static page'
+			);
 		} );
 	} );
 
@@ -222,7 +226,7 @@ test.describe( `Jetpack Onboarding: (${ screenSize })`, function() {
 		test.it( 'Can see onboarding summary page', async function() {
 			const summaryPage = await SummaryPage.Expect( driver );
 			let toDoCount = await summaryPage.countToDoSteps();
-			assert.equal( toDoCount, 1, 'Expected and actual steps are not equal.' );
+			assert.strictEqual( toDoCount, 1, 'Expected and actual steps are not equal.' );
 			return await summaryPage.selectVisitSite();
 		} );
 
@@ -232,20 +236,24 @@ test.describe( `Jetpack Onboarding: (${ screenSize })`, function() {
 			const businessAddress = [ address, city, stateCode, postalCode, countryCode ];
 
 			let title = await viewSitePage.siteTitle();
-			assert.equal( title.toUpperCase(), blogTitle.toUpperCase(), 'Site title not is not correct' );
+			assert.strictEqual(
+				title.toUpperCase(),
+				blogTitle.toUpperCase(),
+				'Site title not is not correct'
+			);
 
 			let tagline = await viewSitePage.siteTagline();
-			assert.equal( tagline, blogTagline, 'Site tagline not is not correct' );
+			assert.strictEqual( tagline, blogTagline, 'Site tagline not is not correct' );
 
 			let siteBusinessName = await widgetContactInfoComponent.getName();
-			assert.equal(
+			assert.strictEqual(
 				siteBusinessName.toUpperCase(),
 				businessName.toUpperCase(),
 				'Business name not found on page'
 			);
 
 			let siteBusinessAddress = await widgetContactInfoComponent.getAddress();
-			return assert.equal(
+			return assert.strictEqual(
 				siteBusinessAddress,
 				businessAddress.join( ' ' ),
 				'Business address not found on page'
@@ -330,20 +338,20 @@ test.describe( `Jetpack Onboarding: (${ screenSize })`, function() {
 			test.it( 'Can see onboarding summary page', async function() {
 				const summaryPage = await SummaryPage.Expect( driver );
 				let toDoCount = await summaryPage.countToDoSteps();
-				assert.equal( toDoCount, 2, 'Expected and actual steps are not equal.' );
+				assert.strictEqual( toDoCount, 2, 'Expected and actual steps are not equal.' );
 				return await summaryPage.selectVisitSite();
 			} );
 
 			test.it( 'Can see site home page', async function() {
 				const viewSitePage = await ViewSitePage.Expect( driver );
 				let title = await viewSitePage.siteTitle();
-				assert.equal(
+				assert.strictEqual(
 					title.toUpperCase(),
 					blogTitle.toUpperCase(),
 					'Site title not is not correct'
 				);
 				let tagline = await viewSitePage.siteTagline();
-				return assert.equal( tagline, blogTagline, 'Site tagline not is not correct' );
+				return assert.strictEqual( tagline, blogTagline, 'Site tagline not is not correct' );
 			} );
 		}
 	);
@@ -431,20 +439,20 @@ test.describe( `Jetpack Onboarding: (${ screenSize })`, function() {
 			test.it( 'Can see onboarding summary page', async function() {
 				const summaryPage = await SummaryPage.Expect( driver );
 				let toDoCount = await summaryPage.countToDoSteps();
-				assert.equal( toDoCount, 0, 'Expected and actual steps are not equal.' );
+				assert.strictEqual( toDoCount, 0, 'Expected and actual steps are not equal.' );
 				return await summaryPage.selectVisitSite();
 			} );
 
 			test.it( 'Can see site home page', async function() {
 				const viewSitePage = await ViewSitePage.Expect( driver );
 				let title = await viewSitePage.siteTitle();
-				assert.equal(
+				assert.strictEqual(
 					title.toUpperCase(),
 					blogTitle.toUpperCase(),
 					'Site title not is not correct'
 				);
 				let tagline = await viewSitePage.siteTagline();
-				return assert.equal( tagline, blogTagline, 'Site tagline not is not correct' );
+				return assert.strictEqual( tagline, blogTagline, 'Site tagline not is not correct' );
 			} );
 		}
 	);

--- a/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plugins-spec.js
@@ -63,7 +63,7 @@ test.describe(
 				const pluginDetailsPage = await PluginDetailsPage.Expect( driver );
 				await pluginDetailsPage.waitForSuccessNotice();
 				let successMessageText = await pluginDetailsPage.getSuccessNoticeText();
-				return assert.equal(
+				return assert.strictEqual(
 					successMessageText.indexOf( expectedPartialText ) > -1,
 					true,
 					`The success message '${ successMessageText }' does not include '${ expectedPartialText }'`

--- a/specs-visdiff/wp-calypso-visdiff.js
+++ b/specs-visdiff/wp-calypso-visdiff.js
@@ -66,7 +66,7 @@ test.describe( `Calypso Visual Diff (${ screenSize })`, function() {
 			this.editorPage = await EditorPage.Expect( driver );
 			await this.editorPage.waitForTitle();
 			let titleShown = await this.editorPage.titleShown();
-			assert.equal( titleShown, defaultPageTitle, 'The page title shown was unexpected' );
+			assert.strictEqual( titleShown, defaultPageTitle, 'The page title shown was unexpected' );
 		} );
 
 		test.it( 'Close sidebar for editor screenshot', async function() {
@@ -127,7 +127,7 @@ test.describe( `Calypso Visual Diff (${ screenSize })`, function() {
 			this.editorPage = await EditorPage.Expect( driver );
 			await this.editorPage.waitForTitle();
 			let titleShown = await this.editorPage.titleShown();
-			assert.equal( titleShown, defaultPostTitle, 'The post title shown was unexpected' );
+			assert.strictEqual( titleShown, defaultPostTitle, 'The post title shown was unexpected' );
 		} );
 
 		test.it( 'Can open the editor media modal', async function() {

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -97,7 +97,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 
 			let actualEmailAddress = await acceptInvitePage.getEmailPreFilled();
 			let headerInviteText = await acceptInvitePage.getHeaderInviteText();
-			assert.equal( actualEmailAddress, newInviteEmailAddress );
+			assert.strictEqual( actualEmailAddress, newInviteEmailAddress );
 			assert( headerInviteText.includes( 'editor' ) );
 
 			await acceptInvitePage.enterUsernameAndPasswordAndSignUp( newUserName, password );
@@ -123,7 +123,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			await peoplePage.selectTeam();
 			await peoplePage.searchForUser( newUserName );
 			const numberPeopleShown = await peoplePage.numberSearchResults();
-			assert.equal(
+			assert.strictEqual(
 				numberPeopleShown,
 				1,
 				`The number of people search results for '${ newUserName }' was incorrect`
@@ -133,7 +133,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			const editTeamMemberPage = await EditTeamMemberPage.Expect( driver );
 			await editTeamMemberPage.removeUserAndDeleteContent();
 			const displayed = await peoplePage.successNoticeDisplayed();
-			return assert.equal(
+			return assert.strictEqual(
 				displayed,
 				true,
 				'The deletion successful notice was not shown on the people page.'
@@ -276,7 +276,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 
 				let actualEmailAddress = await acceptInvitePage.getEmailPreFilled();
 				let headerInviteText = await acceptInvitePage.getHeaderInviteText();
-				assert.equal( actualEmailAddress, newInviteEmailAddress );
+				assert.strictEqual( actualEmailAddress, newInviteEmailAddress );
 				assert( headerInviteText.includes( 'view' ) );
 
 				await acceptInvitePage.enterUsernameAndPasswordAndSignUp( newUserName, password );
@@ -286,7 +286,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			test.it( 'Can see user has been added as a Viewer', async function() {
 				const noticesComponent = await NoticesComponent.Expect( driver );
 				let followMessageDisplayed = await noticesComponent.followMessageTitle();
-				assert.equal(
+				assert.strictEqual(
 					true,
 					followMessageDisplayed.includes( 'viewer' ),
 					`The follow message '${ followMessageDisplayed }' does not include 'viewer'`
@@ -311,7 +311,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				await peoplePage.removeUserByName( newUserName );
 				await peoplePage.waitForSearchResults();
 				displayed = await peoplePage.viewerDisplayed( newUserName );
-				return assert.equal(
+				return assert.strictEqual(
 					displayed,
 					false,
 					`The username of '${ newUserName }' was still displayed as a site viewer`
@@ -400,7 +400,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 
 				let actualEmailAddress = await acceptInvitePage.getEmailPreFilled();
 				let headerInviteText = await acceptInvitePage.getHeaderInviteText();
-				assert.equal( actualEmailAddress, newInviteEmailAddress );
+				assert.strictEqual( actualEmailAddress, newInviteEmailAddress );
 				assert( headerInviteText.includes( 'contributor' ) );
 
 				await acceptInvitePage.enterUsernameAndPasswordAndSignUp( newUserName, password );
@@ -445,7 +445,7 @@ test.describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 				await peoplePage.selectTeam();
 				await peoplePage.searchForUser( newUserName );
 				let numberPeopleShown = await peoplePage.numberSearchResults();
-				return assert.equal(
+				return assert.strictEqual(
 					numberPeopleShown,
 					1,
 					`The number of people search results for '${ newUserName }' was incorrect`

--- a/specs/wp-log-in-out-spec.js
+++ b/specs/wp-log-in-out-spec.js
@@ -162,7 +162,7 @@ test.describe(
 		// 				approvePushToken( pushToken, loginFlow.account.bearerToken ).then( () => {
 		// 					const readerPage = new ReaderPage( driver );
 		// 					readerPage.displayed().then( displayed => {
-		// 						assert.equal( displayed, true, 'The reader page is not displayed after log in' );
+		// 						assert.strictEqual( displayed, true, 'The reader page is not displayed after log in' );
 		// 						done();
 		// 					} );
 		// 				} );
@@ -233,7 +233,7 @@ test.describe(
 		// 					magicLoginPage.finishLogin();
 		// 					let readerPage = new ReaderPage( driver );
 		// 					return readerPage.displayed().then( function( displayed ) {
-		// 						return assert.equal( displayed, true, 'The reader page is not displayed after log in' );
+		// 						return assert.strictEqual( displayed, true, 'The reader page is not displayed after log in' );
 		// 					} );
 		// 				} );
 		//

--- a/specs/wp-notifications-spec.js
+++ b/specs/wp-notifications-spec.js
@@ -100,7 +100,7 @@ test.describe( `[${ host }] Notifications: (${ screenSize }) @parallel @visdiff`
 		await notificationsComponent.selectComments();
 		let content = await notificationsComponent.allCommentsContent();
 		await eyesHelper.eyesScreenshot( driver, eyes, 'Notifications List' );
-		return assert.equal(
+		return assert.strictEqual(
 			content.includes( expectedContent ),
 			true,
 			`The actual notifications content '${ content }' does not contain expected content '${ expectedContent }'`

--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -64,7 +64,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 			await editorPage.enterPostImage( fileDetails );
 			await editorPage.waitUntilImageInserted( fileDetails );
 			let errorShown = await editorPage.errorDisplayed();
-			assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
+			assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
 		} );
 
 		test.it( 'Can disable sharing buttons', async function() {
@@ -87,7 +87,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
 			await pagePreviewComponent.displayed();
 			let actualPageTitle = await pagePreviewComponent.pageTitle();
-			assert.equal(
+			assert.strictEqual(
 				actualPageTitle.toUpperCase(),
 				pageTitle.toUpperCase(),
 				'The page preview title is not correct'
@@ -97,7 +97,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		test.it( 'Can see correct page content in preview', async function() {
 			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
 			let content = await pagePreviewComponent.pageContent();
-			assert.equal(
+			assert.strictEqual(
 				content.indexOf( pageQuote ) > -1,
 				true,
 				'The page preview content (' +
@@ -111,7 +111,11 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		test.it( 'Can see the image uploaded in the preview', async function() {
 			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
 			const imageDisplayed = await pagePreviewComponent.imageDisplayed( fileDetails );
-			return assert.equal( imageDisplayed, true, 'Could not see the image in the web preview' );
+			return assert.strictEqual(
+				imageDisplayed,
+				true,
+				'Could not see the image in the web preview'
+			);
 		} );
 
 		test.it( 'Can close page preview', async function() {
@@ -128,7 +132,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
 			await pagePreviewComponent.displayed();
 			let actualPageTitle = await pagePreviewComponent.pageTitle();
-			assert.equal(
+			assert.strictEqual(
 				actualPageTitle.toUpperCase(),
 				pageTitle.toUpperCase(),
 				'The page preview title is not correct'
@@ -138,7 +142,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		test.it( 'Can see correct page content in preview', async function() {
 			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
 			const content = await pagePreviewComponent.pageContent();
-			assert.equal(
+			assert.strictEqual(
 				content.indexOf( pageQuote ) > -1,
 				true,
 				'The page preview content (' +
@@ -152,7 +156,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		test.it( 'Can see the image uploaded in the preview', async function() {
 			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
 			const imageDisplayed = await pagePreviewComponent.imageDisplayed( fileDetails );
-			assert.equal( imageDisplayed, true, 'Could not see the image in the web preview' );
+			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the web preview' );
 		} );
 
 		test.it( 'Can close page preview', async function() {
@@ -169,7 +173,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		test.it( 'Can see correct page title', async function() {
 			const viewPagePage = await ViewPagePage.Expect( driver );
 			let actualPageTitle = await viewPagePage.pageTitle();
-			assert.equal(
+			assert.strictEqual(
 				actualPageTitle.toUpperCase(),
 				pageTitle.toUpperCase(),
 				'The published blog page title is not correct'
@@ -179,7 +183,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		test.it( 'Can see correct page content', async function() {
 			const viewPagePage = await ViewPagePage.Expect( driver );
 			let content = await viewPagePage.pageContent();
-			assert.equal(
+			assert.strictEqual(
 				content.indexOf( pageQuote ) > -1,
 				true,
 				'The page content (' +
@@ -193,7 +197,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		test.it( "Can't see sharing buttons", async function() {
 			const viewPagePage = await ViewPagePage.Expect( driver );
 			let visible = await viewPagePage.sharingButtonsVisible();
-			assert.equal(
+			assert.strictEqual(
 				visible,
 				false,
 				'Sharing buttons are shown even though they were disabled when creating the page.'
@@ -203,7 +207,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		test.it( 'Can see the image uploaded displayed', async function() {
 			const viewPagePage = await ViewPagePage.Expect( driver );
 			let imageDisplayed = await viewPagePage.imageDisplayed( fileDetails );
-			assert.equal( imageDisplayed, true, 'Could not see the image in the published page' );
+			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the published page' );
 		} );
 
 		test.after( async function() {
@@ -252,7 +256,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 			test.it( 'Can view page title as logged in user', async function() {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const actualPageTitle = await viewPagePage.pageTitle();
-				assert.equal(
+				assert.strictEqual(
 					actualPageTitle.toUpperCase(),
 					( 'Private: ' + pageTitle ).toUpperCase(),
 					'The published blog page title is not correct'
@@ -262,7 +266,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 			test.it( 'Can view page content as logged in user', async function() {
 				const viewPagePage = await ViewPagePage.Expect( driver );
 				const content = await viewPagePage.pageContent();
-				assert.equal(
+				assert.strictEqual(
 					content.indexOf( pageQuote ) > -1,
 					true,
 					'The page content (' +
@@ -279,7 +283,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 
 				const notFoundPage = await NotFoundPage.Expect( driver );
 				const displayed = await notFoundPage.displayed();
-				assert.equal(
+				assert.strictEqual(
 					displayed,
 					true,
 					'Could not see the not found (404) page. Check that it is displayed'
@@ -295,7 +299,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 			test.it( "Can't view page title or content as non-logged in user", async function() {
 				const notFoundPage = await NotFoundPage.Expect( driver );
 				const displayed = await notFoundPage.displayed();
-				assert.equal(
+				assert.strictEqual(
 					displayed,
 					true,
 					'Could not see the not found (404) page. Check that it is displayed'
@@ -344,7 +348,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( 'Can view page title', async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const actualPageTitle = await viewPagePage.pageTitle();
-					assert.equal(
+					assert.strictEqual(
 						actualPageTitle.toUpperCase(),
 						( 'Protected: ' + pageTitle ).toUpperCase()
 					);
@@ -353,7 +357,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( 'Can see password field', async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const isPasswordProtected = await viewPagePage.isPasswordProtected();
-					assert.equal(
+					assert.strictEqual(
 						isPasswordProtected,
 						true,
 						'The page does not appear to be password protected'
@@ -363,7 +367,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( "Can't see content when no password is entered", async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const content = await viewPagePage.pageContent();
-					assert.equal(
+					assert.strictEqual(
 						content.indexOf( pageQuote ) === -1,
 						true,
 						'The page content (' +
@@ -384,7 +388,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( 'Can view page title', async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const actualPageTitle = await viewPagePage.pageTitle();
-					assert.equal(
+					assert.strictEqual(
 						actualPageTitle.toUpperCase(),
 						( 'Protected: ' + pageTitle ).toUpperCase()
 					);
@@ -393,7 +397,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( 'Can see password field', async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const isPasswordProtected = await viewPagePage.isPasswordProtected();
-					assert.equal(
+					assert.strictEqual(
 						isPasswordProtected,
 						true,
 						'The page does not appear to be password protected'
@@ -403,7 +407,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( "Can't see content when incorrect password is entered", async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const content = await viewPagePage.pageContent();
-					assert.equal(
+					assert.strictEqual(
 						content.indexOf( pageQuote ) === -1,
 						true,
 						'The page content (' +
@@ -424,7 +428,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( 'Can view page title', async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const actualPageTitle = await viewPagePage.pageTitle();
-					assert.equal(
+					assert.strictEqual(
 						actualPageTitle.toUpperCase(),
 						( 'Protected: ' + pageTitle ).toUpperCase()
 					);
@@ -433,7 +437,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( "Can't see password field", async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const isPasswordProtected = await viewPagePage.isPasswordProtected();
-					assert.equal(
+					assert.strictEqual(
 						isPasswordProtected,
 						false,
 						'The page still seems to be password protected'
@@ -443,7 +447,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( 'Can see page content', async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const content = await viewPagePage.pageContent();
-					assert.equal(
+					assert.strictEqual(
 						content.indexOf( pageQuote ) > -1,
 						true,
 						'The page content (' +
@@ -466,7 +470,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( 'Can view page title', async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const actualPageTitle = await viewPagePage.pageTitle();
-					assert.equal(
+					assert.strictEqual(
 						actualPageTitle.toUpperCase(),
 						( 'Protected: ' + pageTitle ).toUpperCase()
 					);
@@ -475,7 +479,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( 'Can see password field', async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const isPasswordProtected = await viewPagePage.isPasswordProtected();
-					assert.equal(
+					assert.strictEqual(
 						isPasswordProtected,
 						true,
 						'The page does not appear to be password protected'
@@ -485,7 +489,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( "Can't see content when no password is entered", async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const content = await viewPagePage.pageContent();
-					assert.equal(
+					assert.strictEqual(
 						content.indexOf( pageQuote ) === -1,
 						true,
 						'The page content (' +
@@ -506,7 +510,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( 'Can view page title', async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const actualPageTitle = await viewPagePage.pageTitle();
-					assert.equal(
+					assert.strictEqual(
 						actualPageTitle.toUpperCase(),
 						( 'Protected: ' + pageTitle ).toUpperCase()
 					);
@@ -515,7 +519,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( 'Can see password field', async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const isPasswordProtected = await viewPagePage.isPasswordProtected();
-					assert.equal(
+					assert.strictEqual(
 						isPasswordProtected,
 						true,
 						'The page does not appear to be password protected'
@@ -525,7 +529,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( "Can't see content when incorrect password is entered", async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const content = await viewPagePage.pageContent();
-					assert.equal(
+					assert.strictEqual(
 						content.indexOf( pageQuote ) === -1,
 						true,
 						'The page content (' +
@@ -546,7 +550,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( 'Can view page title', async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const actualPageTitle = await viewPagePage.pageTitle();
-					assert.equal(
+					assert.strictEqual(
 						actualPageTitle.toUpperCase(),
 						( 'Protected: ' + pageTitle ).toUpperCase()
 					);
@@ -555,7 +559,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( "Can't see password field", async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const isPasswordProtected = await viewPagePage.isPasswordProtected();
-					assert.equal(
+					assert.strictEqual(
 						isPasswordProtected,
 						false,
 						'The page still seems to be password protected'
@@ -565,7 +569,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				test.it( 'Can see page content', async function() {
 					const viewPagePage = await ViewPagePage.Expect( driver );
 					const content = await viewPagePage.pageContent();
-					assert.equal(
+					assert.strictEqual(
 						content.indexOf( pageQuote ) > -1,
 						true,
 						'The page content (' +
@@ -612,7 +616,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 			await editorPage.insertPaymentButton( null, paymentButtonDetails );
 
 			let errorShown = await editorPage.errorDisplayed();
-			return assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
+			return assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
 		} );
 
 		test.it( 'Can see the payment button inserted into the visual editor', async function() {
@@ -629,14 +633,18 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		test.it( 'Can see the payment button in our published page', async function() {
 			const viewPagePage = await ViewPagePage.Expect( driver );
 			let displayed = await viewPagePage.paymentButtonDisplayed();
-			assert.equal( displayed, true, 'The published page does not contain the payment button' );
+			assert.strictEqual(
+				displayed,
+				true,
+				'The published page does not contain the payment button'
+			);
 		} );
 
 		test.it(
 			'The payment button in our published page opens a new Paypal window for payment',
 			async function() {
 				let numberOfOpenBrowserWindows = await driverHelper.numberOfOpenWindows( driver );
-				assert.equal(
+				assert.strictEqual(
 					numberOfOpenBrowserWindows,
 					1,
 					'There is more than one open browser window before clicking payment button'
@@ -647,7 +655,7 @@ test.describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 				await driverHelper.switchToWindowByIndex( driver, 1 );
 				const paypalCheckoutPage = await PaypalCheckoutPage.Expect( driver );
 				const amountDisplayed = await paypalCheckoutPage.priceDisplayed();
-				assert.equal(
+				assert.strictEqual(
 					amountDisplayed,
 					`${ paymentButtonDetails.symbol }${ paymentButtonDetails.price } ${
 						paymentButtonDetails.currency

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -81,7 +81,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 					await editorPage.enterPostImage( fileDetails );
 					await editorPage.waitUntilImageInserted( fileDetails );
 					let errorShown = await editorPage.errorDisplayed();
-					assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
+					assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
 				} );
 
 				test.describe( 'Categories and Tags', function() {
@@ -132,7 +132,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 									: '';
 								let postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
 								let accountDisplayed = await postEditorSidebarComponent.publicizeToTwitterAccountDisplayed();
-								assert.equal(
+								assert.strictEqual(
 									accountDisplayed,
 									publicizeTwitterAccount,
 									'Could not see see the publicize to twitter account ' +
@@ -144,7 +144,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 							test.it( 'Can see the default publicise message', async function() {
 								let postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
 								let messageDisplayed = await postEditorSidebarComponent.publicizeMessageDisplayed();
-								assert.equal(
+								assert.strictEqual(
 									messageDisplayed,
 									blogPostTitle,
 									"The publicize message is not defaulting to the post's title"
@@ -176,7 +176,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 							test.it( 'Can see correct post title in preview', async function() {
 								let postTitle = await this.postPreviewComponent.postTitle();
-								assert.equal(
+								assert.strictEqual(
 									postTitle.toLowerCase(),
 									blogPostTitle.toLowerCase(),
 									'The blog post preview title is not correct'
@@ -185,7 +185,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 							test.it( 'Can see correct post content in preview', async function() {
 								let content = await this.postPreviewComponent.postContent();
-								assert.equal(
+								assert.strictEqual(
 									content.indexOf( blogPostQuote ) > -1,
 									true,
 									'The post preview content (' +
@@ -198,7 +198,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 							test.it( 'Can see the post category in preview', async function() {
 								let categoryDisplayed = await this.postPreviewComponent.categoryDisplayed();
-								assert.equal(
+								assert.strictEqual(
 									categoryDisplayed.toUpperCase(),
 									newCategoryName.toUpperCase(),
 									'The category: ' + newCategoryName + ' is not being displayed on the post'
@@ -207,7 +207,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 							test.it( 'Can see the post tag in preview', async function() {
 								let tagDisplayed = await this.postPreviewComponent.tagDisplayed();
-								assert.equal(
+								assert.strictEqual(
 									tagDisplayed.toUpperCase(),
 									newTagName.toUpperCase(),
 									'The tag: ' + newTagName + ' is not being displayed on the post'
@@ -216,7 +216,11 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 							test.it( 'Can see the image in preview', async function() {
 								let imageDisplayed = await this.postPreviewComponent.imageDisplayed( fileDetails );
-								assert.equal( imageDisplayed, true, 'Could not see the image in the web preview' );
+								assert.strictEqual(
+									imageDisplayed,
+									true,
+									'Could not see the image in the web preview'
+								);
 							} );
 
 							test.it( 'Can close post preview', async function() {
@@ -234,7 +238,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 								test.it( 'Can see correct post title in preview', async function() {
 									this.postPreviewComponent = await PostPreviewComponent.Expect( driver );
 									let postTitle = await this.postPreviewComponent.postTitle();
-									assert.equal(
+									assert.strictEqual(
 										postTitle.toLowerCase(),
 										blogPostTitle.toLowerCase(),
 										'The blog post preview title is not correct'
@@ -243,7 +247,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 								test.it( 'Can see correct post content in preview', async function() {
 									let content = await this.postPreviewComponent.postContent();
-									assert.equal(
+									assert.strictEqual(
 										content.indexOf( blogPostQuote ) > -1,
 										true,
 										'The post preview content (' +
@@ -256,7 +260,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 								test.it( 'Can see the post category in preview', async function() {
 									let categoryDisplayed = await this.postPreviewComponent.categoryDisplayed();
-									assert.equal(
+									assert.strictEqual(
 										categoryDisplayed.toUpperCase(),
 										newCategoryName.toUpperCase(),
 										'The category: ' + newCategoryName + ' is not being displayed on the post'
@@ -265,7 +269,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 								test.it( 'Can see the post tag in preview', async function() {
 									let tagDisplayed = await this.postPreviewComponent.tagDisplayed();
-									assert.equal(
+									assert.strictEqual(
 										tagDisplayed.toUpperCase(),
 										newTagName.toUpperCase(),
 										'The tag: ' + newTagName + ' is not being displayed on the post'
@@ -276,7 +280,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 									let imageDisplayed = await this.postPreviewComponent.imageDisplayed(
 										fileDetails
 									);
-									assert.equal(
+									assert.strictEqual(
 										imageDisplayed,
 										true,
 										'Could not see the image in the web preview'
@@ -299,7 +303,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 								test.it( 'Can see correct post title', async function() {
 									this.viewPostPage = await ViewPostPage.Expect( driver );
 									let postTitle = await this.viewPostPage.postTitle();
-									assert.equal(
+									assert.strictEqual(
 										postTitle.toLowerCase(),
 										blogPostTitle.toLowerCase(),
 										'The published blog post title is not correct'
@@ -308,7 +312,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 								test.it( 'Can see correct post content', async function() {
 									let content = await this.viewPostPage.postContent();
-									assert.equal(
+									assert.strictEqual(
 										content.indexOf( blogPostQuote ) > -1,
 										true,
 										'The post content (' +
@@ -321,7 +325,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 								test.it( 'Can see correct post category', async function() {
 									let categoryDisplayed = await this.viewPostPage.categoryDisplayed();
-									assert.equal(
+									assert.strictEqual(
 										categoryDisplayed.toUpperCase(),
 										newCategoryName.toUpperCase(),
 										'The category: ' + newCategoryName + ' is not being displayed on the post'
@@ -330,7 +334,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 								test.it( 'Can see correct post tag', async function() {
 									let tagDisplayed = await this.viewPostPage.tagDisplayed();
-									assert.equal(
+									assert.strictEqual(
 										tagDisplayed.toUpperCase(),
 										newTagName.toUpperCase(),
 										'The tag: ' + newTagName + ' is not being displayed on the post'
@@ -339,7 +343,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 								test.it( 'Can see the image published', async function() {
 									let imageDisplayed = await this.viewPostPage.imageDisplayed( fileDetails );
-									assert.equal(
+									assert.strictEqual(
 										imageDisplayed,
 										true,
 										'Could not see the image in the published post'
@@ -391,7 +395,11 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				await this.editorPage.enterContent( blogPostQuote + '\n' );
 
 				let errorShown = await this.editorPage.errorDisplayed();
-				return assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
+				return assert.strictEqual(
+					errorShown,
+					false,
+					'There is an error shown on the editor page!'
+				);
 			} );
 
 			test.it( 'Can publish and view content', async function() {
@@ -403,7 +411,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			test.it( 'Can see correct post title', async function() {
 				this.viewPostPage = await ViewPostPage.Expect( driver );
 				let postTitle = await this.viewPostPage.postTitle();
-				assert.equal(
+				assert.strictEqual(
 					postTitle.toLowerCase(),
 					blogPostTitle.toLowerCase(),
 					'The published blog post title is not correct'
@@ -435,7 +443,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			await editorPage.enterContent( blogPostQuote + '\n' );
 
 			let errorShown = await editorPage.errorDisplayed();
-			return assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
+			return assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
 		} );
 
 		test.it( 'Can publish and view content', async function() {
@@ -486,7 +494,11 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				await this.editorPage.enterContent( blogPostQuote + '\n' );
 
 				let errorShown = await this.editorPage.errorDisplayed();
-				return assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
+				return assert.strictEqual(
+					errorShown,
+					false,
+					'There is an error shown on the editor page!'
+				);
 			} );
 
 			test.it(
@@ -512,7 +524,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 					driver
 				);
 				const publishDateShown = await editorConfirmationSidebarComponent.publishDateShown();
-				assert.equal(
+				assert.strictEqual(
 					publishDateShown,
 					publishDate,
 					'The publish date shown is not the expected publish date'
@@ -582,7 +594,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can see correct post title', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let postTitle = await viewPostPage.postTitle();
-							assert.equal(
+							assert.strictEqual(
 								postTitle.toLowerCase(),
 								'private: ' + blogPostTitle.toLowerCase(),
 								'The published blog post title is not correct'
@@ -592,7 +604,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can see correct post content', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let content = await viewPostPage.postContent();
-							assert.equal(
+							assert.strictEqual(
 								content.indexOf( blogPostQuote ) > -1,
 								true,
 								'The post content (' +
@@ -606,7 +618,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can see comments enabled', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let visible = await viewPostPage.commentsVisible();
-							assert.equal(
+							assert.strictEqual(
 								visible,
 								true,
 								'Comments are not shown even though they were enabled when creating the post.'
@@ -616,7 +628,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( "Can't see sharing buttons", async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let visible = await viewPostPage.sharingButtonsVisible();
-							assert.equal(
+							assert.strictEqual(
 								visible,
 								false,
 								'Sharing buttons are shown even though they were disabled when creating the post.'
@@ -632,7 +644,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 							test.it( "Can't see post at all", async function() {
 								let notFoundPage = await NotFoundPage.Expect( driver );
 								let displayed = await notFoundPage.displayed();
-								assert.equal(
+								assert.strictEqual(
 									displayed,
 									true,
 									'Could not see the not found (404) page. Check that it is displayed'
@@ -646,7 +658,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( "Can't see post at all", async function() {
 							let notFoundPage = await NotFoundPage.Expect( driver );
 							let displayed = await notFoundPage.displayed();
-							assert.equal(
+							assert.strictEqual(
 								displayed,
 								true,
 								'Could not see the not found (404) page. Check that it is displayed'
@@ -714,7 +726,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can view post title', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let postTitle = await viewPostPage.postTitle();
-							assert.equal(
+							assert.strictEqual(
 								postTitle.toLowerCase(),
 								( 'Protected: ' + blogPostTitle ).toLowerCase()
 							);
@@ -723,7 +735,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can see password field', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let isPasswordProtected = await viewPostPage.isPasswordProtected();
-							assert.equal(
+							assert.strictEqual(
 								isPasswordProtected,
 								true,
 								'The blog post does not appear to be password protected'
@@ -733,7 +745,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( "Can't see content when no password is entered", async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let content = await viewPostPage.postContent();
-							assert.equal(
+							assert.strictEqual(
 								content.indexOf( blogPostQuote ) === -1,
 								true,
 								'The post content (' +
@@ -747,7 +759,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( "Can't see comments", async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let visible = await viewPostPage.commentsVisible();
-							assert.equal(
+							assert.strictEqual(
 								visible,
 								false,
 								'Comments are shown even though they were disabled when creating the post.'
@@ -757,7 +769,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can see sharing buttons', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let visible = await viewPostPage.sharingButtonsVisible();
-							return assert.equal(
+							return assert.strictEqual(
 								visible,
 								true,
 								'Sharing buttons are not shown even though they were enabled when creating the post.'
@@ -776,7 +788,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can view post title', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let postTitle = await viewPostPage.postTitle();
-							assert.equal(
+							assert.strictEqual(
 								postTitle.toLowerCase(),
 								( 'Protected: ' + blogPostTitle ).toLowerCase()
 							);
@@ -785,7 +797,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can see password field', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let isPasswordProtected = await viewPostPage.isPasswordProtected();
-							assert.equal(
+							assert.strictEqual(
 								isPasswordProtected,
 								true,
 								'The blog post does not appear to be password protected'
@@ -795,7 +807,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( "Can't see content when incorrect password is entered", async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let content = await viewPostPage.postContent();
-							assert.equal(
+							assert.strictEqual(
 								content.indexOf( blogPostQuote ) === -1,
 								true,
 								'The post content (' +
@@ -809,7 +821,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( "Can't see comments", async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let visible = await viewPostPage.commentsVisible();
-							assert.equal(
+							assert.strictEqual(
 								visible,
 								false,
 								'Comments are shown even though they were disabled when creating the post.'
@@ -819,7 +831,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can see sharing buttons', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let visible = await viewPostPage.sharingButtonsVisible();
-							assert.equal(
+							assert.strictEqual(
 								visible,
 								true,
 								'Sharing buttons are not shown even though they were enabled when creating the post.'
@@ -838,7 +850,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can view post title', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let postTitle = await viewPostPage.postTitle();
-							assert.equal(
+							assert.strictEqual(
 								postTitle.toLowerCase(),
 								( 'Protected: ' + blogPostTitle ).toLowerCase()
 							);
@@ -847,7 +859,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( "Can't see password field", async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let isPasswordProtected = await viewPostPage.isPasswordProtected();
-							assert.equal(
+							assert.strictEqual(
 								isPasswordProtected,
 								false,
 								'The blog post still appears to be password protected'
@@ -857,7 +869,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can see page content', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let content = await viewPostPage.postContent();
-							assert.equal(
+							assert.strictEqual(
 								content.indexOf( blogPostQuote ) > -1,
 								true,
 								'The post content (' +
@@ -871,7 +883,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( "Can't see comments", async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let visible = await viewPostPage.commentsVisible();
-							assert.equal(
+							assert.strictEqual(
 								visible,
 								false,
 								'Comments are shown even though they were disabled when creating the post.'
@@ -881,7 +893,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can see sharing buttons', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let visible = await viewPostPage.sharingButtonsVisible();
-							assert.equal(
+							assert.strictEqual(
 								visible,
 								true,
 								'Sharing buttons are not shown even though they were enabled when creating the post.'
@@ -898,7 +910,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can view post title', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let postTitle = await viewPostPage.postTitle();
-							assert.equal(
+							assert.strictEqual(
 								postTitle.toLowerCase(),
 								( 'Protected: ' + blogPostTitle ).toLowerCase()
 							);
@@ -907,7 +919,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can see password field', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let isPasswordProtected = await viewPostPage.isPasswordProtected();
-							assert.equal(
+							assert.strictEqual(
 								isPasswordProtected,
 								true,
 								'The blog post does not appear to be password protected'
@@ -917,7 +929,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( "Can't see content when no password is entered", async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let content = await viewPostPage.postContent();
-							assert.equal(
+							assert.strictEqual(
 								content.indexOf( blogPostQuote ) === -1,
 								true,
 								'The post content (' +
@@ -931,7 +943,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( "Can't see comments", async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let visible = await viewPostPage.commentsVisible();
-							assert.equal(
+							assert.strictEqual(
 								visible,
 								false,
 								'Comments are shown even though they were disabled when creating the post.'
@@ -941,7 +953,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can see sharing buttons', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let visible = await viewPostPage.sharingButtonsVisible();
-							return assert.equal(
+							return assert.strictEqual(
 								visible,
 								true,
 								'Sharing buttons are not shown even though they were enabled when creating the post.'
@@ -960,7 +972,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can view post title', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let postTitle = await viewPostPage.postTitle();
-							assert.equal(
+							assert.strictEqual(
 								postTitle.toLowerCase(),
 								( 'Protected: ' + blogPostTitle ).toLowerCase()
 							);
@@ -969,7 +981,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can see password field', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let isPasswordProtected = await viewPostPage.isPasswordProtected();
-							assert.equal(
+							assert.strictEqual(
 								isPasswordProtected,
 								true,
 								'The blog post does not appear to be password protected'
@@ -979,7 +991,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( "Can't see content when incorrect password is entered", async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let content = await viewPostPage.postContent();
-							assert.equal(
+							assert.strictEqual(
 								content.indexOf( blogPostQuote ) === -1,
 								true,
 								'The post content (' +
@@ -993,7 +1005,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( "Can't see comments", async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let visible = await viewPostPage.commentsVisible();
-							assert.equal(
+							assert.strictEqual(
 								visible,
 								false,
 								'Comments are shown even though they were disabled when creating the post.'
@@ -1003,7 +1015,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can see sharing buttons', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let visible = await viewPostPage.sharingButtonsVisible();
-							assert.equal(
+							assert.strictEqual(
 								visible,
 								true,
 								'Sharing buttons are not shown even though they were enabled when creating the post.'
@@ -1022,7 +1034,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can view post title', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let postTitle = await viewPostPage.postTitle();
-							assert.equal(
+							assert.strictEqual(
 								postTitle.toLowerCase(),
 								( 'Protected: ' + blogPostTitle ).toLowerCase()
 							);
@@ -1031,7 +1043,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( "Can't see password field", async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let isPasswordProtected = await viewPostPage.isPasswordProtected();
-							assert.equal(
+							assert.strictEqual(
 								isPasswordProtected,
 								false,
 								'The blog post still appears to be password protected'
@@ -1041,7 +1053,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can see page content', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let content = await viewPostPage.postContent();
-							assert.equal(
+							assert.strictEqual(
 								content.indexOf( blogPostQuote ) > -1,
 								true,
 								'The post content (' +
@@ -1055,7 +1067,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( "Can't see comments", async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let visible = await viewPostPage.commentsVisible();
-							assert.equal(
+							assert.strictEqual(
 								visible,
 								false,
 								'Comments are shown even though they were disabled when creating the post.'
@@ -1065,7 +1077,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 						test.it( 'Can see sharing buttons', async function() {
 							let viewPostPage = await ViewPostPage.Expect( driver );
 							let visible = await viewPostPage.sharingButtonsVisible();
-							assert.equal(
+							assert.strictEqual(
 								visible,
 								true,
 								'Sharing buttons are not shown even though they were enabled when creating the post.'
@@ -1108,7 +1120,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			test.it( 'Can then see the Posts page with a confirmation message', async function() {
 				const postsPage = await PostsPage.Expect( driver );
 				const displayed = await postsPage.successNoticeDisplayed();
-				return assert.equal(
+				return assert.strictEqual(
 					displayed,
 					true,
 					'The Posts page success notice for deleting the post is not displayed'
@@ -1140,7 +1152,11 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				await this.editorPage.enterTitle( originalBlogPostTitle );
 				await this.editorPage.enterContent( blogPostQuote );
 				let errorShown = await this.editorPage.errorDisplayed();
-				return assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
+				return assert.strictEqual(
+					errorShown,
+					false,
+					'There is an error shown on the editor page!'
+				);
 			} );
 
 			test.it( 'Can publish the post', async function() {
@@ -1167,7 +1183,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				test.it( 'Can see and edit our new post', async function() {
 					await this.postsPage.waitForPostTitled( originalBlogPostTitle );
 					let displayed = await this.postsPage.isPostDisplayed( originalBlogPostTitle );
-					assert.equal(
+					assert.strictEqual(
 						displayed,
 						true,
 						`The blog post titled '${ originalBlogPostTitle }' is not displayed in the list of posts`
@@ -1179,7 +1195,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				test.it( 'Can see the post title', async function() {
 					await this.editorPage.waitForTitle();
 					let titleShown = await this.editorPage.titleShown();
-					assert.equal(
+					assert.strictEqual(
 						titleShown,
 						originalBlogPostTitle,
 						'The blog post title shown was unexpected'
@@ -1191,7 +1207,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 					async function() {
 						await this.editorPage.enterTitle( updatedBlogPostTitle );
 						let errorShown = await this.editorPage.errorDisplayed();
-						assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
+						assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
 						this.postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 						await this.postEditorToolbarComponent.publishThePost();
 						return await this.postEditorToolbarComponent.waitForSuccessAndViewPost();
@@ -1205,7 +1221,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 					test.it( 'Can see correct post title', async function() {
 						let postTitle = await this.viewPostPage.postTitle();
-						return assert.equal(
+						return assert.strictEqual(
 							postTitle.toLowerCase(),
 							updatedBlogPostTitle.toLowerCase(),
 							'The published blog post title is not correct'
@@ -1237,7 +1253,11 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				await this.editorPage.insertContactForm();
 
 				let errorShown = await this.editorPage.errorDisplayed();
-				return assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
+				return assert.strictEqual(
+					errorShown,
+					false,
+					'There is an error shown on the editor page!'
+				);
 			} );
 
 			test.it( 'Can see the contact form inserted into the visual editor', async function() {
@@ -1254,7 +1274,11 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			test.it( 'Can see the contact form in our published post', async function() {
 				this.viewPostPage = await ViewPostPage.Expect( driver );
 				let displayed = await this.viewPostPage.contactFormDisplayed();
-				assert.equal( displayed, true, 'The published post does not contain the contact form' );
+				assert.strictEqual(
+					displayed,
+					true,
+					'The published post does not contain the contact form'
+				);
 			} );
 		} );
 	} );
@@ -1298,7 +1322,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			await editorPage.insertPaymentButton( eyes, paymentButtonDetails );
 
 			let errorShown = await editorPage.errorDisplayed();
-			return assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
+			return assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
 		} );
 
 		test.it( 'Can see the payment button inserted into the visual editor', async function() {
@@ -1315,14 +1339,18 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 		test.it( 'Can see the payment button in our published post', async function() {
 			const viewPostPage = await ViewPostPage.Expect( driver );
 			let displayed = await viewPostPage.paymentButtonDisplayed();
-			assert.equal( displayed, true, 'The published post does not contain the payment button' );
+			assert.strictEqual(
+				displayed,
+				true,
+				'The published post does not contain the payment button'
+			);
 		} );
 
 		test.it(
 			'The payment button in our published post opens a new Paypal window for payment',
 			async function() {
 				let numberOfOpenBrowserWindows = await driverHelper.numberOfOpenWindows( driver );
-				assert.equal(
+				assert.strictEqual(
 					numberOfOpenBrowserWindows,
 					1,
 					'There is more than one open browser window before clicking payment button'
@@ -1333,7 +1361,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				await driverHelper.switchToWindowByIndex( driver, 1 );
 				const paypalCheckoutPage = await PaypalCheckoutPage.Expect( driver );
 				const amountDisplayed = await paypalCheckoutPage.priceDisplayed();
-				assert.equal(
+				assert.strictEqual(
 					amountDisplayed,
 					`${ paymentButtonDetails.symbol }${ paymentButtonDetails.price } ${
 						paymentButtonDetails.currency
@@ -1376,7 +1404,11 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				await this.editorPage.enterContent( blogPostQuote );
 
 				let errorShown = await this.editorPage.errorDisplayed();
-				return assert.equal( errorShown, false, 'There is an error shown on the editor page!' );
+				return assert.strictEqual(
+					errorShown,
+					false,
+					'There is an error shown on the editor page!'
+				);
 			} );
 
 			test.it( 'Can publish the post', async function() {
@@ -1398,7 +1430,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				await postEditorSidebarComponent.revertToDraft();
 				await postEditorToolbarComponent.waitForIsDraftStatus();
 				let isDraft = await postEditorToolbarComponent.statusIsDraft();
-				assert.equal( isDraft, true, 'The post is not set as draft' );
+				assert.strictEqual( isDraft, true, 'The post is not set as draft' );
 			} );
 		} );
 	} );

--- a/specs/wp-reader-spec.js
+++ b/specs/wp-reader-spec.js
@@ -57,7 +57,7 @@ test.describe( 'Reader: (' + screenSize + ') @parallel @visdiff', function() {
 				const testSiteForNotifications = dataHelper.configGet( 'testSiteForNotifications' );
 				const readerPage = await ReaderPage.Expect( driver );
 				let siteOfLatestPost = await readerPage.siteOfLatestPost();
-				return assert.equal(
+				return assert.strictEqual(
 					siteOfLatestPost,
 					testSiteForNotifications,
 					'The latest post is not on the expected test site'

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -142,15 +142,15 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				const viewBlogPage = await ViewBlogPage.Expect( driver );
 				await viewBlogPage.waitForTrampolineWelcomeMessage();
 				let displayed = await viewBlogPage.isTrampolineWelcomeDisplayed();
-				assert.equal( displayed, true, 'The trampoline welcome message is not displayed' );
+				assert.strictEqual( displayed, true, 'The trampoline welcome message is not displayed' );
 				let url = await viewBlogPage.urlDisplayed();
-				assert.equal(
+				assert.strictEqual(
 					url,
 					'https://' + newBlogAddress + '/',
 					'The displayed URL on the view blog page is not as expected'
 				);
 				let title = await viewBlogPage.title();
-				return assert.equal(
+				return assert.strictEqual(
 					title,
 					blogName,
 					'The expected blog title is not displaying correctly'
@@ -169,7 +169,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 					emails.find( email => email.subject.includes( 'WordPress.com' ) );
 				let emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
 				//Disabled due to a/b test on activation email. See https://github.com/Automattic/wp-e2e-tests/issues/819
-				//assert.equal( emails.length, 2, 'The number of newly registered emails is not equal to 2 (activation and magic link)' );
+				//assert.strictEqual( emails.length, 2, 'The number of newly registered emails is not equal to 2 (activation and magic link)' );
 				for ( let email of emails ) {
 					if ( email.subject.includes( 'WordPress.com' ) ) {
 						return ( magicLoginLink = email.html.links[ 0 ].href );
@@ -261,7 +261,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				const findADomainComponent = await FindADomainComponent.Expect( driver );
 				let displayed = await findADomainComponent.displayed();
 				await eyesHelper.eyesScreenshot( driver, eyes, 'Domains Page' );
-				return assert.equal( displayed, true, 'The choose a domain page is not displayed' );
+				return assert.strictEqual( displayed, true, 'The choose a domain page is not displayed' );
 			} );
 
 			test.it(
@@ -288,7 +288,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				const pickAPlanPage = await PickAPlanPage.Expect( driver );
 				let displayed = await pickAPlanPage.displayed();
 				await eyesHelper.eyesScreenshot( driver, eyes, 'Plans Page' );
-				assert.equal( displayed, true, 'The pick a plan page is not displayed' );
+				assert.strictEqual( displayed, true, 'The pick a plan page is not displayed' );
 				return await pickAPlanPage.selectPremiumPlan();
 			} );
 
@@ -319,9 +319,13 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 					const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 					await eyesHelper.eyesScreenshot( driver, eyes, 'Secure Payment Page' );
 					const premiumPlanInCart = await securePaymentComponent.containsPremiumPlan();
-					assert.equal( premiumPlanInCart, true, "The cart doesn't contain the premium plan" );
+					assert.strictEqual(
+						premiumPlanInCart,
+						true,
+						"The cart doesn't contain the premium plan"
+					);
 					const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
-					return assert.equal(
+					return assert.strictEqual(
 						numberOfProductsInCart,
 						1,
 						"The cart doesn't contain the expected number of products"
@@ -335,7 +339,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 					const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 					if ( driverManager.currentScreenSize() === 'desktop' ) {
 						const totalShown = await securePaymentComponent.cartTotalDisplayed();
-						assert.equal(
+						assert.strictEqual(
 							totalShown.indexOf( expectedCurrencySymbol ),
 							0,
 							`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
@@ -361,7 +365,11 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				const checkOutThankyouPage = await CheckOutThankyouPage.Expect( driver );
 				let displayed = await checkOutThankyouPage.displayed();
 				await eyesHelper.eyesScreenshot( driver, eyes, 'Checkout Thank You Page' );
-				return assert.equal( displayed, true, 'The checkout thank you page is not displayed' );
+				return assert.strictEqual(
+					displayed,
+					true,
+					'The checkout thank you page is not displayed'
+				);
 			} );
 
 			test.it( 'Can delete the plan', async function() {
@@ -498,7 +506,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 					const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 					if ( driverManager.currentScreenSize() === 'desktop' ) {
 						const totalShown = await securePaymentComponent.cartTotalDisplayed();
-						assert.equal(
+						assert.strictEqual(
 							totalShown.indexOf( expectedCurrencySymbol ),
 							0,
 							`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
@@ -517,9 +525,13 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				async function() {
 					const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 					const premiumPlanInCart = await securePaymentComponent.containsPremiumPlan();
-					assert.equal( premiumPlanInCart, true, "The cart doesn't contain the premium plan" );
+					assert.strictEqual(
+						premiumPlanInCart,
+						true,
+						"The cart doesn't contain the premium plan"
+					);
 					const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
-					return assert.equal(
+					return assert.strictEqual(
 						numberOfProductsInCart,
 						1,
 						"The cart doesn't contain the expected number of products"
@@ -668,7 +680,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 					const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 					if ( driverManager.currentScreenSize() === 'desktop' ) {
 						const totalShown = await securePaymentComponent.cartTotalDisplayed();
-						assert.equal(
+						assert.strictEqual(
 							totalShown.indexOf( expectedCurrencySymbol ),
 							0,
 							`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
@@ -687,9 +699,13 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				async function() {
 					const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 					const personalPlanInCart = await securePaymentComponent.containsPersonalPlan();
-					assert.equal( personalPlanInCart, true, "The cart doesn't contain the personal plan" );
+					assert.strictEqual(
+						personalPlanInCart,
+						true,
+						"The cart doesn't contain the personal plan"
+					);
 					const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
-					return assert.equal(
+					return assert.strictEqual(
 						numberOfProductsInCart,
 						1,
 						"The cart doesn't contain the expected number of products"
@@ -839,15 +855,19 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				async function() {
 					const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 					const domainInCart = await securePaymentComponent.containsDotLiveDomain();
-					assert.equal( domainInCart, true, "The cart doesn't contain the .live domain product" );
+					assert.strictEqual(
+						domainInCart,
+						true,
+						"The cart doesn't contain the .live domain product"
+					);
 					const privateWhoISInCart = await securePaymentComponent.containsPrivateWhois();
-					assert.equal(
+					assert.strictEqual(
 						privateWhoISInCart,
 						true,
 						"The cart doesn't contain the private domain product"
 					);
 					const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
-					return assert.equal(
+					return assert.strictEqual(
 						numberOfProductsInCart,
 						2,
 						"The cart doesn't contain the expected number of products"
@@ -861,7 +881,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 					const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 					if ( driverManager.currentScreenSize() === 'desktop' ) {
 						const totalShown = await securePaymentComponent.cartTotalDisplayed();
-						assert.equal(
+						assert.strictEqual(
 							totalShown.indexOf( expectedCurrencySymbol ),
 							0,
 							`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
@@ -903,7 +923,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			test.it( 'We should only one option - the settings option', async function() {
 				const sideBarComponent = await SideBarComponent.Expect( driver );
 				let numberMenuItems = await sideBarComponent.numberOfMenuItems();
-				assert.equal(
+				assert.strictEqual(
 					numberMenuItems,
 					1,
 					'There is not a single menu item for a domain only site'
@@ -926,7 +946,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 
 					const managePurchasePage = await ManagePurchasePage.Expect( driver );
 					let domainDisplayed = await managePurchasePage.domainDisplayed();
-					assert.equal(
+					assert.strictEqual(
 						domainDisplayed,
 						expectedDomainName,
 						'The domain displayed on the manage purchase page is unexpected'
@@ -1046,21 +1066,25 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				async function() {
 					const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 					const domainInCart = await securePaymentComponent.containsDotLiveDomain();
-					assert.equal( domainInCart, true, "The cart doesn't contain the .live domain product" );
+					assert.strictEqual(
+						domainInCart,
+						true,
+						"The cart doesn't contain the .live domain product"
+					);
 					const privateWhoISInCart = await securePaymentComponent.containsPrivateWhois();
-					assert.equal(
+					assert.strictEqual(
 						privateWhoISInCart,
 						true,
 						"The cart doesn't contain the private domain product"
 					);
 					const businessPlanInCart = await securePaymentComponent.containsBusinessPlan();
-					assert.equal(
+					assert.strictEqual(
 						businessPlanInCart,
 						true,
 						"The cart doesn't contain the business plan product"
 					);
 					const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
-					return assert.equal(
+					return assert.strictEqual(
 						numberOfProductsInCart,
 						3,
 						"The cart doesn't contain the expected number of products"
@@ -1074,7 +1098,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 					const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 					if ( driverManager.currentScreenSize() === 'desktop' ) {
 						const totalShown = await securePaymentComponent.cartTotalDisplayed();
-						assert.equal(
+						assert.strictEqual(
 							totalShown.indexOf( expectedCurrencySymbol ),
 							0,
 							`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
@@ -1207,14 +1231,18 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 				const viewBlogPage = await ViewBlogPage.Expect( driver );
 				viewBlogPage.waitForTrampolineWelcomeMessage();
 				let displayed = await viewBlogPage.isTrampolineWelcomeDisplayed();
-				return assert.equal( displayed, true, 'The trampoline welcome message is not displayed' );
+				return assert.strictEqual(
+					displayed,
+					true,
+					'The trampoline welcome message is not displayed'
+				);
 			}
 		);
 
 		test.it( 'Can see the correct blog URL displayed', async function() {
 			const viewBlogPage = await ViewBlogPage.Expect( driver );
 			const url = await viewBlogPage.urlDisplayed();
-			return assert.equal(
+			return assert.strictEqual(
 				url,
 				'https://' + newBlogAddress + '/',
 				'The displayed URL on the view blog page is not as expected'
@@ -1225,7 +1253,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 			test.it( 'Can see the correct blog title displayed', async function() {
 				const viewBlogPage = await ViewBlogPage.Expect( driver );
 				const title = await viewBlogPage.title();
-				return assert.equal(
+				return assert.strictEqual(
 					title,
 					'Site Title',
 					'The expected blog title is not displaying correctly'
@@ -1322,7 +1350,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 						`First product in cart is not ${ chosenThemeName }`
 					);
 					const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
-					return assert.equal(
+					return assert.strictEqual(
 						numberOfProductsInCart,
 						1,
 						"The cart doesn't contain the expected number of products"
@@ -1336,7 +1364,7 @@ test.describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function()
 					const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 					if ( driverManager.currentScreenSize() === 'desktop' ) {
 						const totalShown = await securePaymentComponent.cartTotalDisplayed();
-						assert.equal(
+						assert.strictEqual(
 							totalShown.indexOf( expectedCurrencySymbol ),
 							0,
 							`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`

--- a/specs/wp-theme-multisite-spec.js
+++ b/specs/wp-theme-multisite-spec.js
@@ -75,7 +75,7 @@ test.describe( `[${ host }] Themes: All sites (${ screenSize })`, function() {
 
 				test.it( 'should show the site selector', async function() {
 					let siteSelectorShown = await this.siteSelector.displayed();
-					return assert.equal( siteSelectorShown, true, 'The site selector was not shown' );
+					return assert.strictEqual( siteSelectorShown, true, 'The site selector was not shown' );
 				} );
 
 				test.describe( 'when a site is selected, and Customize is clicked', function() {
@@ -147,7 +147,7 @@ test.describe( `[${ host }] Themes: All sites (${ screenSize })`, function() {
 
 				test.it( 'shows the site selector', async function() {
 					let siteSelectorShown = await this.siteSelector.displayed();
-					return assert.equal( siteSelectorShown, true, 'The site selector was not shown' );
+					return assert.strictEqual( siteSelectorShown, true, 'The site selector was not shown' );
 				} );
 
 				test.it( 'can select the first site sites', async function() {
@@ -166,14 +166,14 @@ test.describe( `[${ host }] Themes: All sites (${ screenSize })`, function() {
 						await this.themeDetailPage.goBackToAllThemes();
 						this.currentThemeComponent = await CurrentThemeComponent.Expect( driver );
 						let name = await this.currentThemeComponent.getThemeName();
-						return assert.equal( name, this.currentThemeName );
+						return assert.strictEqual( name, this.currentThemeName );
 					} );
 
 					test.it( 'should highlight the current theme as active', async function() {
 						await this.themesPage.showOnlyFreeThemes();
 						await this.themesPage.searchFor( this.themeSearchName );
 						let name = await this.themesPage.getActiveThemeName();
-						return assert.equal( name, this.currentThemeName );
+						return assert.strictEqual( name, this.currentThemeName );
 					} );
 				} );
 			} );

--- a/specs/wp-theme-switch-spec.js
+++ b/specs/wp-theme-switch-spec.js
@@ -79,7 +79,7 @@ test.describe( `[${ host }] Switching Themes: (${ screenSize })`, function() {
 					this.themeDetailPage = await ThemeDetailPage.Expect( driver );
 					let displayed = await this.themeDetailPage.displayed();
 					await eyesHelper.eyesScreenshot( driver, eyes, 'Theme Details Page' );
-					assert.equal(
+					assert.strictEqual(
 						displayed,
 						true,
 						'Could not see the theme detail page after activating a new theme'

--- a/specs/wp-view-site-spec.js
+++ b/specs/wp-view-site-spec.js
@@ -54,12 +54,12 @@ test.describe(
 			test.it( 'Can see the web preview button', async function() {
 				this.siteViewComponent = await SiteViewComponent.Expect( driver );
 				let present = await this.siteViewComponent.isWebPreviewPresent();
-				return assert.equal( present, true, 'The web preview button was not displayed' );
+				return assert.strictEqual( present, true, 'The web preview button was not displayed' );
 			} );
 
 			test.it( 'Can see the web preview "open in new window" button', async function() {
 				let present = await this.siteViewComponent.isOpenInNewWindowButtonPresent();
-				return assert.equal(
+				return assert.strictEqual(
 					present,
 					true,
 					'The web preview "open in new window" button was not displayed'
@@ -68,7 +68,7 @@ test.describe(
 
 			test.it( 'Can see the site preview', async function() {
 				let present = await this.siteViewComponent.isSitePresent();
-				return assert.equal( present, true, 'The web site preview was not displayed' );
+				return assert.strictEqual( present, true, 'The web site preview was not displayed' );
 			} );
 
 			if ( screenSize !== 'mobile' ) {


### PR DESCRIPTION
`assert.equa`l is deprecated
use `strictEqual` instead

See: https://nodejs.org/docs/latest/api/assert.html#assert_assert_strictequal_actual_expected_message