### PR TITLE
put this.driver instead of self.driver #2

### DIFF
--- a/lib/pages/plugins-browser-page.js
+++ b/lib/pages/plugins-browser-page.js
@@ -38,6 +38,6 @@ export default class PluginsBrowserPage extends AsyncBaseContainer {
 		);
 		await driverHelper.clickWhenClickable( this.driver, by.css( '.search__close-icon' ) );
 		await this.searchForPlugin( searchTerm );
-		return await driverHelper.isEventuallyPresentAndDisplayed( self.driver, selector );
+		return await driverHelper.isEventuallyPresentAndDisplayed( this.driver, selector );
 	}
 }


### PR DESCRIPTION
I've missed one `self.driver` in the previous PR #1293. Now it's fixed.