### PR TITLE
Revert "Fix Free Plan selection during Signup (#1159)"

### DIFF
--- a/lib/pages/signup/pick-a-plan-page.js
+++ b/lib/pages/signup/pick-a-plan-page.js
@@ -21,11 +21,12 @@ export default class PickAPlanPage extends AsyncBaseContainer {
 	}
 
 	async selectFreePlan() {
-		// During signup, we no longer display the Free plan, so we have to click the "Skip" button
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.plans-skip-button button' )
-		);
+		// Jetpack connect no longer displays the Free plan, so we have to click the "Skip" button
+		if ( this.host !== 'WPCOM' ) {
+			return await driverHelper.clickWhenClickable( this.driver, By.css( '.plans-skip-button button' ) );
+		}
+
+		return await this._selectPlan( 'free' );
 	}
 
 	// Explicitly select the free button on jetpack without needing `host` above.


### PR DESCRIPTION
This reverts commit 1cc3e4b5b0dfed932cf5bd616c23840a41aa7bda.
The free plan button is going to come back to the page with the PR https://github.com/Automattic/wp-calypso/pull/25727