### PR TITLE
Update Login Flow to not Visit the Reader Page

### DIFF
--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -90,7 +90,7 @@ export default class LoginFlow {
 
 		await this.login();
 
-		const readerPage = await ReaderPage.Visit( this.driver );
+		const readerPage = await ReaderPage.Expect( this.driver );
 		await readerPage.waitForPage();
 
 		const navbarComponent = await NavBarComponent.Expect( this.driver );
@@ -138,7 +138,7 @@ export default class LoginFlow {
 	async loginAndSelectMySite( site = null ) {
 		await this.login();
 
-		const readerPage = await ReaderPage.Visit( this.driver );
+		const readerPage = await ReaderPage.Expect( this.driver );
 		await readerPage.waitForPage();
 
 		const navbarComponent = await NavBarComponent.Expect( this.driver );


### PR DESCRIPTION
This page comes in the flow so we don't need to actually visit it directly - will avoid extra time and a redirect from /read