### PR TITLE
Fix race condition mobile editor

### DIFF
--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -577,6 +577,7 @@ test.describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 
 			test.describe( 'Set to private which publishes it', function() {
 				test.it( 'Ensure the post is saved', async function() {
+					await EditorPage.Expect( driver );
 					const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 					await postEditorToolbarComponent.ensureSaved();
 				} );


### PR DESCRIPTION
The mobile editor needs to be visible to ensure saved - this previously let the editor sidebar open and would sometimes fail when retry is disabled.

This ensures the editor page is displayed which closes the sidebar if it is open.