### PR TITLE
Try using mocha steps

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -73,5 +73,8 @@
 		// Common top-of-file requires, expressions between external, interal
 		"vars-on-top": 1,
 		"yoda": 0
-	}
+	},
+  	"globals": {
+	  "step": false
+  	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7956,6 +7956,11 @@
         }
       }
     },
+    "mocha-steps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mocha-steps/-/mocha-steps-1.1.0.tgz",
+      "integrity": "sha1-QLq4kVfvRbsCVIHKbzFtBpg/LfA="
+    },
     "module-deps": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lodash": "^4.13.1",
     "mailosaur": "4.0.0",
     "mocha": "github:Automattic/mocha#90a9db1",
+    "mocha-steps": "^1.1.0",
     "node-slack-upload": "1.2.1",
     "png-itxt": "1.3.0",
     "prettier": "github:automattic/calypso-prettier#503d7779",

--- a/specs/wp-reader-spec.js
+++ b/specs/wp-reader-spec.js
@@ -1,6 +1,5 @@
 /** @format */
 
-import test from 'selenium-webdriver/testing';
 import config from 'config';
 import assert from 'assert';
 
@@ -24,16 +23,15 @@ let driver;
 
 let eyes = eyesHelper.eyesSetup( true );
 
-test.before( async function() {
+before( async function() {
 	this.timeout( startBrowserTimeoutMS );
 	driver = await driverManager.startBrowser();
 } );
 
-test.describe( 'Reader: (' + screenSize + ') @parallel @visdiff', function() {
-	this.bailSuite( true );
+describe( 'Reader: (' + screenSize + ') @parallel @visdiff', function() {
 	this.timeout( mochaTimeOut );
 
-	test.before( async function() {
+	before( async function() {
 		await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 
 		let testEnvironment = 'WordPress.com';
@@ -41,19 +39,18 @@ test.describe( 'Reader: (' + screenSize + ') @parallel @visdiff', function() {
 		eyesHelper.eyesOpen( driver, eyes, testEnvironment, testName );
 	} );
 
-	test.describe( 'Log in as commenting user', function() {
-		test.it( 'Can log in as commenting user', async function() {
+	describe( 'Log in as commenting user', function() {
+		step( 'Can log in as commenting user', async function() {
 			this.loginFlow = new LoginFlow( driver, 'commentingUser' );
 			return await this.loginFlow.login();
 		} );
 
-		test.describe( 'Leave a comment on the latest post in the Reader', function() {
-			test.it( 'Can see the Reader stream', async function() {
-				const readerPage = await ReaderPage.Expect( driver );
-				return await readerPage.waitForPage();
+		describe( 'Leave a comment on the latest post in the Reader', function() {
+			step( 'Can see the Reader stream', async function() {
+				await ReaderPage.Expect( driver );
 			} );
 
-			test.it( 'The latest post is on the expected test site', async function() {
+			step( 'The latest post is on the expected test site', async function() {
 				const testSiteForNotifications = dataHelper.configGet( 'testSiteForNotifications' );
 				const readerPage = await ReaderPage.Expect( driver );
 				let siteOfLatestPost = await readerPage.siteOfLatestPost();
@@ -64,25 +61,25 @@ test.describe( 'Reader: (' + screenSize + ') @parallel @visdiff', function() {
 				);
 			} );
 
-			test.it( 'Can comment on the latest post', async function() {
+			step( 'Can comment on the latest post', async function() {
 				this.comment = dataHelper.randomPhrase();
 				const readerPage = await ReaderPage.Expect( driver );
 				await readerPage.commentOnLatestPost( this.comment, eyes );
 			} );
 
-			test.describe( 'Delete the new comment', function() {
-				test.before( async function() {
+			describe( 'Delete the new comment', function() {
+				before( async function() {
 					await driverManager.clearCookiesAndDeleteLocalStorage( driver );
 					driver.get( dataHelper.configGet( 'calypsoBaseURL' ) );
 				} );
 
-				test.it( 'Can log in as test site owner', async function() {
+				step( 'Can log in as test site owner', async function() {
 					this.loginFlow = new LoginFlow( driver, 'notificationsUser' );
 					return await this.loginFlow.login();
 				} );
 
-				test.it(
-					'Can delete the new comment (and wait for UNDO grace period so it is actually deleted)',
+				step(
+					'Can delete the new comment (and wait for UNDO grace period so step is actually deleted)',
 					async function() {
 						await eyesHelper.eyesScreenshot( driver, eyes, 'Followed Sites Feed' );
 						this.navBarComponent = await NavBarComponent.Expect( driver );
@@ -95,8 +92,8 @@ test.describe( 'Reader: (' + screenSize + ') @parallel @visdiff', function() {
 					}
 				);
 
-				test.describe( 'Manage Followed Sites', function() {
-					test.it( 'Can see the Manage page', async function() {
+				describe( 'Manage Followed Sites', function() {
+					step( 'Can see the Manage page', async function() {
 						this.readerManagePage = await ReaderManagePage.Visit( driver );
 						await this.readerManagePage.waitForSites();
 						await eyesHelper.eyesScreenshot(
@@ -117,7 +114,7 @@ test.describe( 'Reader: (' + screenSize + ') @parallel @visdiff', function() {
 		} );
 	} );
 
-	test.after( async function() {
+	after( async function() {
 		await eyesHelper.eyesClose( eyes );
 	} );
 } );

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,5 @@
 --require @babel/register
 --require test/mocha.env.js
+--require mocha-steps
 lib/before.js
 lib/after.js


### PR DESCRIPTION
This converts just one spec to use mocha-steps

The good thing about mocha-steps is it allows us to convert specs one at a time as it's backwards compatible and shouldn't cause any dramas

The idea is to get rid of bail.suite from our codebase that way we can remove our fork of mocha and keep things up to date

Blog post explaining this here: https://watirmelon.blog/2018/07/04/bailing-with-mocha-e2e-tests/