### PR TITLE
JP Plans Spec: Test if 'Renew Now' works

### DIFF
--- a/lib/pages/manage-purchase-page.js
+++ b/lib/pages/manage-purchase-page.js
@@ -24,4 +24,11 @@ export default class ManagePurchasePage extends AsyncBaseContainer {
 			by.css( '.manage-purchase a[href$="cancel"]' )
 		);
 	}
+
+	async chooseRenewNow() {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			by.css( '.manage-purchase__purchase-expiring-notice a.notice__action' )
+		);
+	}
 }

--- a/lib/pages/purchases-page.js
+++ b/lib/pages/purchases-page.js
@@ -28,6 +28,10 @@ export default class PurchasesPage extends AsyncBaseContainer {
 		return await this._selectPlan( 'personal' );
 	}
 
+	async selectPremiumPlanOnConnectedSite() {
+		return await this._selectPlanOnConnectedSite( 'premium' );
+	}
+
 	async dismissGuidedTour() {
 		return await driverHelper.clickIfPresent(
 			this.driver,
@@ -49,6 +53,14 @@ export default class PurchasesPage extends AsyncBaseContainer {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			by.css( `a.purchase-item img.is-${ planName }-plan` )
+		);
+	}
+
+	async _selectPlanOnConnectedSite( planName ) {
+		await this._waitForPurchases();
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			by.css( `a.purchase-item:not(.is-disconnected-site) img.is-${ planName }-plan` )
 		);
 	}
 }

--- a/lib/pages/purchases-page.js
+++ b/lib/pages/purchases-page.js
@@ -60,7 +60,7 @@ export default class PurchasesPage extends AsyncBaseContainer {
 		await this._waitForPurchases();
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			by.css( `a.purchase-item:not(.is-disconnected-site) img.is-${ planName }-plan` )
+			by.css( `a.purchase-item[data-e2e-connected-site=true] img.is-${ planName }-plan` )
 		);
 	}
 }

--- a/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -112,7 +112,7 @@ describe( `[${ host }] Jetpack Plans: (${ screenSize }) @jetpack`, function() {
 			await profilePage.chooseManagePurchases();
 			const purchasesPage = await PurchasesPage.Expect( driver );
 			await purchasesPage.dismissGuidedTour();
-			await purchasesPage.selectPremiumPlan();
+			await purchasesPage.selectPremiumPlanOnConnectedSite();
 			const managePurchasePage = await ManagePurchasePage.Expect( driver );
 			await managePurchasePage.chooseRenewNow();
 			return await SecurePaymentComponent.Expect( driver );

--- a/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -21,6 +21,10 @@ import NavBarComponent from '../lib/components/nav-bar-component.js';
 
 import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar';
 
+import ProfilePage from '../lib/pages/profile-page.js';
+import PurchasesPage from '../lib/pages/purchases-page.js';
+import ManagePurchasePage from '../lib/pages/manage-purchase-page.js';
+
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
@@ -88,6 +92,30 @@ describe( `[${ host }] Jetpack Plans: (${ screenSize }) @jetpack`, function() {
 			await PlansPage.Expect( driver );
 			const shoppingCartWidgetComponent = await ShoppingCartWidgetComponent.Expect( driver );
 			await shoppingCartWidgetComponent.empty();
+		} );
+	} );
+
+	describe( 'Renew Premium Plan:', function() {
+		before( async function() {
+			return await driverManager.clearCookiesAndDeleteLocalStorage( driver );
+		} );
+
+		step( 'Can log into WordPress.com', async function() {
+			this.loginFlow = new LoginFlow( driver, 'jetpackUserPREMIUM' );
+			return await this.loginFlow.login();
+		} );
+
+		step( 'Can renew Premium plan', async function() {
+			const navBarComponent = await NavBarComponent.Expect( driver );
+			await navBarComponent.clickProfileLink();
+			const profilePage = await ProfilePage.Expect( driver );
+			await profilePage.chooseManagePurchases();
+			const purchasesPage = await PurchasesPage.Expect( driver );
+			await purchasesPage.dismissGuidedTour();
+			await purchasesPage.selectPremiumPlan();
+			const managePurchasePage = await ManagePurchasePage.Expect( driver );
+			await managePurchasePage.chooseRenewNow();
+			return await SecurePaymentComponent.Expect( driver );
 		} );
 	} );
 } );

--- a/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -105,7 +105,7 @@ describe( `[${ host }] Jetpack Plans: (${ screenSize }) @jetpack`, function() {
 			return await this.loginFlow.login();
 		} );
 
-		step( 'Can renew Premium plan', async function() {
+		step( '"Renew Now" link takes user to Payment Details form', async function() {
 			const navBarComponent = await NavBarComponent.Expect( driver );
 			await navBarComponent.clickProfileLink();
 			const profilePage = await ProfilePage.Expect( driver );


### PR DESCRIPTION
To guard against the sort of breakage caused by https://github.com/Automattic/wp-calypso/pull/25743. See p4TIVU-91R-p2

Huge props @bsessions85 for guidance! :pray: 

### To test that this passes with current Calypso production:
`NODE_ENV=decrypted JETPACKHOST='PRESSABLE' ./node_modules/.bin/mocha specs-jetpack-calypso/wp-jetpack-plans-spec.js`

cc @sirreal 

### To verify that https://github.com/Automattic/wp-calypso/pull/25743 breaks this e2e test:

* Run a local Calypso instance
  * with the corresponding branch (`revert-25742-revert-25473-update/no-required-site-manage-purchase`)
  * and with the commit from https://github.com/Automattic/wp-calypso/pull/26055 cherry-picked (https://github.com/Automattic/wp-calypso/commit/3b0440bfdfbe73aa07c5f3c237a63cae3fa986c2)
* Add `calypsoBaseURL": "http://calypso.localhost:3000",` to the top level of your `wp-e2e-tests/config/local-decrypted.json` file
* Run the same command as above, i.e. `NODE_ENV=decrypted JETPACKHOST='PRESSABLE' ./node_modules/.bin/mocha specs-jetpack-calypso/wp-jetpack-plans-spec.js`
* Verify that the `"Renew Now" link takes user to Payment Details form:` test doesn't pass.