### PR TITLE
Add plansBannerFromDomainNudge AB test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -67,7 +67,7 @@
 		"domainSearchTLDFilterPlacement",
 		"staleCartNotice",
 		"aboutSuggestionMatches",
-		"plansBannerFromDomainNudge",
+		"plansBannerFromDomainNudge"
 	],
 	"overrideABTests": [
 		[ "businessPlanDescriptionAT_20170605", "original" ],
@@ -80,6 +80,6 @@
 		[ "domainSearchTLDFilterPlacement_20180531", "belowFeatured" ],
 		[ "staleCartNotice_20180618", "siteDeservesBoost" ],
 		[ "aboutSuggestionMatches_20180704", "control" ],
-		[ "plansBannerFromDomainNudge_20180712", "noShow" ],
+		[ "plansBannerFromDomainNudge_20180712", "noShow" ]
 	]
 }

--- a/config/default.json
+++ b/config/default.json
@@ -66,7 +66,8 @@
 		"domainSuggestionKrakenV322",
 		"domainSearchTLDFilterPlacement",
 		"staleCartNotice",
-		"aboutSuggestionMatches"
+		"aboutSuggestionMatches",
+		"plansBannerFromDomainNudge",
 	],
 	"overrideABTests": [
 		[ "businessPlanDescriptionAT_20170605", "original" ],
@@ -78,6 +79,7 @@
 		[ "domainSuggestionKrakenV322_20180709", "domainsbot" ],
 		[ "domainSearchTLDFilterPlacement_20180531", "belowFeatured" ],
 		[ "staleCartNotice_20180618", "siteDeservesBoost" ],
-		[ "aboutSuggestionMatches_20180704", "control" ]
+		[ "aboutSuggestionMatches_20180704", "control" ],
+		[ "plansBannerFromDomainNudge", "noShow" ],
 	]
 }

--- a/config/default.json
+++ b/config/default.json
@@ -80,6 +80,6 @@
 		[ "domainSearchTLDFilterPlacement_20180531", "belowFeatured" ],
 		[ "staleCartNotice_20180618", "siteDeservesBoost" ],
 		[ "aboutSuggestionMatches_20180704", "control" ],
-		[ "plansBannerFromDomainNudge", "noShow" ],
+		[ "plansBannerFromDomainNudge_20180712", "noShow" ],
 	]
 }


### PR DESCRIPTION
This adds the Calypso plansBannerFromDomainNudge AB test.
Calypso PR: Automattic/wp-calypso#26034