### PR TITLE
Add support for Safari Canaries

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -35,7 +35,7 @@
 			"platform": "OS X 10.11",
 			"screenResolution": "2048x1536",
 			"nativeEvents": true,
-			"version": "9.0"
+			"version": "10"
 		},
 		"win-firefox": {
 			"browserName": "firefox",

--- a/magellan-safari-canary.json
+++ b/magellan-safari-canary.json
@@ -1,0 +1,17 @@
+{
+  "mocha_tests": [
+    "specs/"
+  ],
+  "mocha_opts": "test/mocha.opts",
+  "mocha_args": "-R spec-xunit-reporter",
+  "max_test_attempts": 3,
+  "max_workers": 1,
+  "suiteTag": "safaricanary",
+  "sauce": false,
+  "browser": "safari",
+  "framework": "testarmada-magellan-mocha-plugin",
+  "reporters": [
+	  "./lib/reporter/magellan-reporter.js"
+  ],
+  "bail_time": 300000
+}

--- a/run.sh
+++ b/run.sh
@@ -28,6 +28,7 @@ function joinStr { local IFS="$1"; shift; echo "$*"; }
 
 I18N_CONFIG="\"browser\":\"chrome\",\"proxy\":\"system\",\"saveAllScreenshots\":true"
 IE11_CONFIG="\"sauce\":\"true\",\"sauceConfig\":\"win-ie11\""
+SAFARI_CONFIG="\"sauce\":\"true\",\"sauceConfig\":\"osx-safari\""
 
 declare -a MAGELLAN_CONFIGS
 
@@ -48,6 +49,7 @@ usage () {
 -H [host]	  - Specify an alternate host for Jetpack tests
 -w		  - Only execute signup tests on Windows/IE11, not compatible with -g flag
 -z		  - Only execute canary tests on Windows/IE11, not compatible with -g flag
+-y		  - Only execute canary tests on Safari 10 on Mac, not compatible with -g flag
 -l [config]	  - Execute the critical visdiff tests via Sauce Labs with the given configuration
 -c		  - Exit with status code 0 regardless of test results
 -m [browsers]	  - Execute the multi-browser visual-diff tests with the given list of browsers via grunt.  Specify browsers in comma-separated list or 'all'
@@ -66,7 +68,7 @@ if [ $# -eq 0 ]; then
   usage
 fi
 
-while getopts ":a:RpS:b:B:s:gjWCJH:wzl:cm:fiIUvxu:h" opt; do
+while getopts ":a:RpS:b:B:s:gjWCJH:wzyl:cm:fiIUvxu:h" opt; do
   case $opt in
     a)
       WORKERS=$OPTARG
@@ -128,6 +130,11 @@ while getopts ":a:RpS:b:B:s:gjWCJH:wzl:cm:fiIUvxu:h" opt; do
       NODE_CONFIG_ARGS+=$IE11_CONFIG
       SCREENSIZES="desktop"
       MAGELLAN_CONFIG="magellan-ie11-canary.json"
+      ;;
+    y)
+      NODE_CONFIG_ARGS+=$SAFARI_CONFIG
+      SCREENSIZES="desktop"
+      MAGELLAN_CONFIG="magellan-safari-canary.json"
       ;;
     l)
       NODE_CONFIG_ARGS+=("\"sauce\":\"true\",\"sauceConfig\":\"$OPTARG\"")

--- a/specs/wp-log-in-out-spec.js
+++ b/specs/wp-log-in-out-spec.js
@@ -21,7 +21,8 @@ import WPHomePage from '../lib/pages/wp-home-page';
 import NavBarComponent from '../lib/components/nav-bar-component.js';
 import LoggedOutMasterbarComponent from '../lib/components/logged-out-masterbar-component';
 
-import LoginFlow from '../lib/flows/login-flow.js';
+import LoginFlow from '../lib/flows/login-flow';
+import LoginPage from '../lib/pages/login-page';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -35,6 +36,20 @@ let eyes = eyesHelper.eyesSetup( true );
 before( async function() {
 	this.timeout( startBrowserTimeoutMS );
 	driver = await driverManager.startBrowser();
+} );
+
+describe( `[${ host }] Auth Screen Canary: (${ screenSize }) @parallel @safaricanary`, function() {
+	this.timeout( mochaTimeOut );
+
+	describe( 'Loading the log-in screen', function() {
+		before( async function() {
+			return await driverManager.ensureNotLoggedIn( driver );
+		} );
+
+		step( 'Can see the log in screen', async function() {
+			await LoginPage.Visit( driver, LoginPage.getLoginURL() );
+		} );
+	} );
 } );
 
 describe( `[${ host }] Authentication: (${ screenSize }) @parallel @jetpack @visdiff`, function() {


### PR DESCRIPTION
This adds a Safari 10 canary test that simply makes sure it can access to /log-in page which is rendered by Calypso