### PR TITLE
Remove plansBannerFromDomainNudge

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -66,7 +66,6 @@
 		"domainSuggestionKrakenV322",
 		"domainSearchTLDFilterPlacement",
 		"aboutSuggestionMatches",
-		"plansBannerFromDomainNudge",
 		"nudgeAPalooza"
 
 	],
@@ -80,7 +79,6 @@
 		[ "domainSuggestionKrakenV322_20180709", "domainsbot" ],
 		[ "domainSearchTLDFilterPlacement_20180531", "belowFeatured" ],
 		[ "aboutSuggestionMatches_20180704", "control" ],
-		[ "plansBannerFromDomainNudge_20180712", "noShow" ],
 		[ "nudgeAPalooza_20180711", "control" ]
 	]
 }


### PR DESCRIPTION
We ended up not needing this test and instead wrapped it into a different, existing one.
Related Calypso PR: https://github.com/Automattic/wp-calypso/pull/26127
