### PR TITLE
Fix magic login when running locally

### DIFF
--- a/lib/pages/login-page.js
+++ b/lib/pages/login-page.js
@@ -82,7 +82,8 @@ export default class LoginPage extends AsyncBaseContainer {
 		await driverHelper.setWhenSettable(
 			this.driver,
 			By.css( '.magic-login__email-fields input[name="usernameOrEmail"]' ),
-			emailAddress
+			emailAddress,
+			{ pauseBetweenKeysMS: 5 }
 		);
 		await driverHelper.clickWhenClickable(
 			this.driver,


### PR DESCRIPTION
Fixes #1362 

**Testing Instructions**

1. Before this PR, run `describe( 'Sign up for a free site and log in via a magic link @parallel @email', function() {` locally (I am using calypso.localhost but shouldn't matter)
2. See that the magic login step fails as the button is disabled
3. Apply this PR and re-test