### PR TITLE
Update date on nudgeAPalooza test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -80,6 +80,6 @@
 		[ "domainSearchTLDFilterPlacement_20180531", "belowFeatured" ],
 		[ "aboutSuggestionMatches_20180704", "control" ],
 		[ "includeDotBlogSubdomain_20180723", "no" ],
-		[ "nudgeAPalooza_20180711", "control" ]
+		[ "nudgeAPalooza_20180726", "control" ]
 	]
 }


### PR DESCRIPTION
We want to enable nudgeAPalooza test for everyone. We had a happy accident where some users got already assigned to this test with a skewed distribution. In a related PR (https://github.com/Automattic/wp-calypso/pull/26330) the datestamp is updated to start fresh allocation, and this PR reflects that.