### PR TITLE
Skip domains tests if domain registration is unavailable

### DIFF
--- a/lib/components/domain-registration-unavailable-component.js
+++ b/lib/components/domain-registration-unavailable-component.js
@@ -1,0 +1,11 @@
+/** @format */
+
+import { By } from 'selenium-webdriver';
+
+import AsyncBaseContainer from '../async-base-container';
+
+export default class RegistrationUnavailableComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.empty-content' ) );
+	}
+}

--- a/lib/components/new-user-domain-registration-unavailable-component.js
+++ b/lib/components/new-user-domain-registration-unavailable-component.js
@@ -1,0 +1,11 @@
+/** @format */
+
+import { By } from 'selenium-webdriver';
+
+import AsyncBaseContainer from '../async-base-container';
+
+export default class NewUserRegistrationUnavailableComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.notice__text' ) );
+	}
+}

--- a/lib/components/purchase-domain-only-component.js
+++ b/lib/components/purchase-domain-only-component.js
@@ -28,10 +28,13 @@ export default class PurchaseDomainOnlyComponent extends AsyncBaseContainer {
 		return await this.checkForUnknownABTestKeys();
 	}
 
-	async searchForDomainNameAndSelectRecommended( domainName ) {
+	async searchDomain( domainName ) {
 		const searchInputSelector = By.css( '.src-components-domain-search-input' );
 		await driverHelper.setWhenSettable( this.driver, searchInputSelector, domainName );
-		await this.waitForResults();
+		return await this.waitForResults();
+	}
+
+	async selectRecommendedDomain() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( '.src-components-domain-recommended-label' )

--- a/lib/components/purchase-domain-only-component.js
+++ b/lib/components/purchase-domain-only-component.js
@@ -1,0 +1,40 @@
+/** @format */
+
+import { By } from 'selenium-webdriver';
+
+import AsyncBaseContainer from '../async-base-container';
+
+import * as driverHelper from '../driver-helper.js';
+
+export default class PurchaseDomainOnlyComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.src-components-domain-search-content' ) );
+	}
+
+	async waitForResults() {
+		const driver = this.driver;
+		const resultsLoadingSelector = By.css( '.domain-suggestion.is-placeholder' );
+		await driver.wait(
+			function() {
+				return driverHelper
+					.isElementPresent( driver, resultsLoadingSelector )
+					.then( function( present ) {
+						return ! present;
+					} );
+			},
+			this.explicitWaitMS * 2,
+			'The domain results loading element was still present when it should have disappeared by now.'
+		);
+		return await this.checkForUnknownABTestKeys();
+	}
+
+	async searchForDomainNameAndSelectRecommended( domainName ) {
+		const searchInputSelector = By.css( '.src-components-domain-search-input' );
+		await driverHelper.setWhenSettable( this.driver, searchInputSelector, domainName );
+		await this.waitForResults();
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.src-components-domain-recommended-label' )
+		);
+	}
+}

--- a/lib/pages/signup/search-domains-page.js
+++ b/lib/pages/signup/search-domains-page.js
@@ -1,0 +1,10 @@
+/** @format */
+
+import { By } from 'selenium-webdriver';
+import AsyncBaseContainer from '../../async-base-container';
+
+export default class SearchDomainsPage extends AsyncBaseContainer {
+	constructor( driver, url ) {
+		super( driver, By.css( '.src-components-domain-search-content' ), url );
+	}
+}

--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -10,6 +10,7 @@ import ReaderPage from '../lib/pages/reader-page.js';
 import StatsPage from '../lib/pages/stats-page.js';
 
 import FindADomainComponent from '../lib/components/find-a-domain-component.js';
+import RegistrationUnavailableComponent from '../lib/components/domain-registration-unavailable-component';
 import SecurePaymentComponent from '../lib/components/secure-payment-component.js';
 import ShoppingCartWidgetComponent from '../lib/components/shopping-cart-widget-component.js';
 import SidebarComponent from '../lib/components/sidebar-component.js';
@@ -72,7 +73,17 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function(
 		} );
 
 		step( 'Can see the domain search component', async function() {
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			let findADomainComponent;
+			try {
+				findADomainComponent = await FindADomainComponent.Expect( driver );
+			} catch ( err ) {
+				if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
+					await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
+						suppressDuplicateMessages: true,
+					} );
+					return this.skip();
+				}
+			}
 			return await findADomainComponent.waitForResults();
 		} );
 
@@ -139,7 +150,17 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function(
 		} );
 
 		step( 'Can see the domain search component', async function() {
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			let findADomainComponent;
+			try {
+				findADomainComponent = await FindADomainComponent.Expect( driver );
+			} catch ( err ) {
+				if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
+					await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
+						suppressDuplicateMessages: true,
+					} );
+					return this.skip();
+				}
+			}
 			return await findADomainComponent.waitForResults();
 		} );
 
@@ -216,7 +237,17 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function(
 		} );
 
 		step( 'Can see the domain search component', async function() {
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			let findADomainComponent;
+			try {
+				findADomainComponent = await FindADomainComponent.Expect( driver );
+			} catch ( err ) {
+				if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
+					await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
+						suppressDuplicateMessages: true,
+					} );
+					return this.skip();
+				}
+			}
 			return await findADomainComponent.waitForResults();
 		} );
 

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -45,7 +45,6 @@ import NoSitesComponent from '../lib/components/no-sites-component';
 import * as SlackNotifier from '../lib/slack-notifier';
 
 import EmailClient from '../lib/email-client.js';
-import RegistrationUnavailableComponent from '../lib/components/domain-registration-unavailable-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -94,17 +93,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
 			async function() {
-				let findADomainComponent;
-				try {
-					findADomainComponent = await FindADomainComponent.Expect( driver );
-				} catch ( err ) {
-					if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
-						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
-							suppressDuplicateMessages: true,
-						} );
-						return this.skip();
-					}
-				}
+				const findADomainComponent = await FindADomainComponent.Expect( driver );
 				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
 				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
 					expectedBlogAddresses,
@@ -253,17 +242,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can then see the domains page ', async function() {
-			let findADomainComponent;
-			try {
-				findADomainComponent = await FindADomainComponent.Expect( driver );
-			} catch ( err ) {
-				if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
-					await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
-						suppressDuplicateMessages: true,
-					} );
-					return this.skip();
-				}
-			}
+			const findADomainComponent = await FindADomainComponent.Expect( driver );
 			let displayed = await findADomainComponent.displayed();
 			await eyesHelper.eyesScreenshot( driver, eyes, 'Domains Page' );
 			return assert.strictEqual( displayed, true, 'The choose a domain page is not displayed' );
@@ -459,17 +438,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the domains page and can search for a blog name, can see and select a free WordPress.com blog address in results',
 			async function() {
-				let findADomainComponent;
-				try {
-					findADomainComponent = await FindADomainComponent.Expect( driver );
-				} catch ( err ) {
-					if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
-						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
-							suppressDuplicateMessages: true,
-						} );
-						return this.skip();
-					}
-				}
+				const findADomainComponent = await FindADomainComponent.Expect( driver );
 				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
 				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
 					expectedBlogAddresses,
@@ -634,17 +603,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the domains page and can search for a blog name, can see and select a free WordPress.com blog address in results',
 			async function() {
-				let findADomainComponent;
-				try {
-					findADomainComponent = await FindADomainComponent.Expect( driver );
-				} catch ( err ) {
-					if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
-						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
-							suppressDuplicateMessages: true,
-						} );
-						return this.skip();
-					}
-				}
+				const findADomainComponent = await FindADomainComponent.Expect( driver );
 				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
 				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
 					expectedBlogAddresses,
@@ -1016,17 +975,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the domains page, and can search for a blog name, can see and select a paid .live address in results ',
 			async function() {
-				let findADomainComponent;
-				try {
-					findADomainComponent = await FindADomainComponent.Expect( driver );
-				} catch ( err ) {
-					if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
-						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
-							suppressDuplicateMessages: true,
-						} );
-						return this.skip();
-					}
-				}
+				const findADomainComponent = await FindADomainComponent.Expect( driver );
 				await findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
 				return await findADomainComponent.selectDomainAddress( expectedDomainName );
 			}
@@ -1178,17 +1127,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
 			async function() {
 				const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
-				let findADomainComponent;
-				try {
-					findADomainComponent = await FindADomainComponent.Expect( driver );
-				} catch ( err ) {
-					if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
-						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
-							suppressDuplicateMessages: true,
-						} );
-						return this.skip();
-					}
-				}
+				const findADomainComponent = await FindADomainComponent.Expect( driver );
 				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
 				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
 					expectedBlogAddresses,
@@ -1299,17 +1238,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the domains page and can search for a blog name, can see and select a free WordPress.com blog address in results',
 			async function() {
-				let findADomainComponent;
-				try {
-					findADomainComponent = await FindADomainComponent.Expect( driver );
-				} catch ( err ) {
-					if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
-						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
-							suppressDuplicateMessages: true,
-						} );
-						return this.skip();
-					}
-				}
+				const findADomainComponent = await FindADomainComponent.Expect( driver );
 				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
 				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
 					expectedBlogAddresses,
@@ -1438,17 +1367,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the domains page, and Can search for a blog name, can see and select a free .art.blog address in the results',
 			async function() {
-				let findADomainComponent;
-				try {
-					findADomainComponent = await FindADomainComponent.Expect( driver );
-				} catch ( err ) {
-					if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
-						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
-							suppressDuplicateMessages: true,
-						} );
-						return this.skip();
-					}
-				}
+				const findADomainComponent = await FindADomainComponent.Expect( driver );
 				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
 				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
 					expectedDomainName,

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -978,11 +978,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			async function() {
 				const findADomainComponent = await FindADomainComponent.Expect( driver );
 				await findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
-				if ( await NewUserRegistrationUnavailableComponent.Expect( driver ) ) {
-					await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ' );
-					return this.skip();
+				try {
+					return await findADomainComponent.selectDomainAddress( expectedDomainName );
+				} catch ( err ) {
+					if ( await NewUserRegistrationUnavailableComponent.Expect( driver ) ) {
+						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ' );
+						return this.skip();
+					}
 				}
-				return await findADomainComponent.selectDomainAddress( expectedDomainName );
 			}
 		);
 

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -45,6 +45,7 @@ import NoSitesComponent from '../lib/components/no-sites-component';
 import * as SlackNotifier from '../lib/slack-notifier';
 
 import EmailClient from '../lib/email-client.js';
+import RegistrationUnavailableComponent from '../lib/components/domain-registration-unavailable-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -93,7 +94,17 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
 			async function() {
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
+				let findADomainComponent;
+				try {
+					findADomainComponent = await FindADomainComponent.Expect( driver );
+				} catch ( err ) {
+					if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
+						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
+							suppressDuplicateMessages: true,
+						} );
+						return this.skip();
+					}
+				}
 				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
 				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
 					expectedBlogAddresses,
@@ -242,7 +253,17 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can then see the domains page ', async function() {
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
+			let findADomainComponent;
+			try {
+				findADomainComponent = await FindADomainComponent.Expect( driver );
+			} catch ( err ) {
+				if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
+					await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
+						suppressDuplicateMessages: true,
+					} );
+					return this.skip();
+				}
+			}
 			let displayed = await findADomainComponent.displayed();
 			await eyesHelper.eyesScreenshot( driver, eyes, 'Domains Page' );
 			return assert.strictEqual( displayed, true, 'The choose a domain page is not displayed' );
@@ -438,7 +459,17 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the domains page and can search for a blog name, can see and select a free WordPress.com blog address in results',
 			async function() {
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
+				let findADomainComponent;
+				try {
+					findADomainComponent = await FindADomainComponent.Expect( driver );
+				} catch ( err ) {
+					if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
+						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
+							suppressDuplicateMessages: true,
+						} );
+						return this.skip();
+					}
+				}
 				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
 				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
 					expectedBlogAddresses,
@@ -603,7 +634,17 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the domains page and can search for a blog name, can see and select a free WordPress.com blog address in results',
 			async function() {
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
+				let findADomainComponent;
+				try {
+					findADomainComponent = await FindADomainComponent.Expect( driver );
+				} catch ( err ) {
+					if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
+						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
+							suppressDuplicateMessages: true,
+						} );
+						return this.skip();
+					}
+				}
 				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
 				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
 					expectedBlogAddresses,
@@ -975,7 +1016,17 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the domains page, and can search for a blog name, can see and select a paid .live address in results ',
 			async function() {
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
+				let findADomainComponent;
+				try {
+					findADomainComponent = await FindADomainComponent.Expect( driver );
+				} catch ( err ) {
+					if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
+						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
+							suppressDuplicateMessages: true,
+						} );
+						return this.skip();
+					}
+				}
 				await findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
 				return await findADomainComponent.selectDomainAddress( expectedDomainName );
 			}
@@ -1127,7 +1178,17 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
 			async function() {
 				const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
+				let findADomainComponent;
+				try {
+					findADomainComponent = await FindADomainComponent.Expect( driver );
+				} catch ( err ) {
+					if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
+						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
+							suppressDuplicateMessages: true,
+						} );
+						return this.skip();
+					}
+				}
 				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
 				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
 					expectedBlogAddresses,
@@ -1238,7 +1299,17 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the domains page and can search for a blog name, can see and select a free WordPress.com blog address in results',
 			async function() {
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
+				let findADomainComponent;
+				try {
+					findADomainComponent = await FindADomainComponent.Expect( driver );
+				} catch ( err ) {
+					if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
+						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
+							suppressDuplicateMessages: true,
+						} );
+						return this.skip();
+					}
+				}
 				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
 				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
 					expectedBlogAddresses,
@@ -1367,7 +1438,17 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the domains page, and Can search for a blog name, can see and select a free .art.blog address in the results',
 			async function() {
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
+				let findADomainComponent;
+				try {
+					findADomainComponent = await FindADomainComponent.Expect( driver );
+				} catch ( err ) {
+					if ( await RegistrationUnavailableComponent.Expect( driver ) ) {
+						await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ', {
+							suppressDuplicateMessages: true,
+						} );
+						return this.skip();
+					}
+				}
 				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
 				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
 					expectedDomainName,

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1068,7 +1068,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe.only( 'Sign up for a domain only purchase coming in from wordpress.com/domains in EUR currency @parallel', function() {
+	describe( 'Sign up for a domain only purchase coming in from wordpress.com/domains in EUR currency @parallel', function() {
 		const siteName = dataHelper.getNewBlogName();
 		const expectedDomainName = `${ siteName }.live`;
 		const emailAddress = dataHelper.getEmailAddress( siteName, signupInboxId );

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1068,7 +1068,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Sign up for a domain only purchase coming in from wordpress.com/domains in EUR currency @parallel', function() {
+	describe.only( 'Sign up for a domain only purchase coming in from wordpress.com/domains in EUR currency @parallel', function() {
 		const siteName = dataHelper.getNewBlogName();
 		const expectedDomainName = `${ siteName }.live`;
 		const emailAddress = dataHelper.getEmailAddress( siteName, signupInboxId );
@@ -1103,9 +1103,9 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can search and select .live domain', async function() {
 			let purchaseDomainOnlyComponent = await PurchaseDomainOnlyComponent.Expect( driver );
-			return await purchaseDomainOnlyComponent.searchForDomainNameAndSelectRecommended(
-				expectedDomainName
-			);
+			await purchaseDomainOnlyComponent.searchDomain( expectedDomainName );
+			//TODO: Cover case when domain registration is not available
+			return await purchaseDomainOnlyComponent.selectRecommendedDomain();
 		} );
 
 		step( 'Can select domain only from the domain first choice page', async function() {

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -34,6 +34,7 @@ import ThemeDetailPage from '../lib/pages/theme-detail-page';
 import AccountSettingsPage from '../lib/pages/account/account-settings-page';
 import CloseAccountPage from '../lib/pages/account/close-account-page';
 import DesignTypePage from '../lib/pages/signup/design-type-page';
+import SearchDomainsPage from '../lib/pages/signup/search-domains-page';
 
 import FindADomainComponent from '../lib/components/find-a-domain-component.js';
 import SecurePaymentComponent from '../lib/components/secure-payment-component.js';
@@ -41,6 +42,7 @@ import NavBarComponent from '../lib/components/nav-bar-component';
 import SideBarComponent from '../lib/components/sidebar-component';
 import LoggedOutMasterbarComponent from '../lib/components/logged-out-masterbar-component';
 import NoSitesComponent from '../lib/components/no-sites-component';
+import PurchaseDomainOnlyComponent from '../lib/components/purchase-domain-only-component';
 
 import * as SlackNotifier from '../lib/slack-notifier';
 
@@ -762,14 +764,12 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can visit the domains start page', async function() {
-			await StartPage.Visit(
-				driver,
-				StartPage.getStartURL( {
-					culture: locale,
-					flow: 'domain-first/site-or-domain',
-					query: `new=${ expectedDomainName }`,
-				} )
-			);
+			return await SearchDomainsPage.Visit( driver, dataHelper.getCalypsoURL( 'domains' ) );
+		} );
+
+		step( 'Can search and select .live domain', async function() {
+			let purchaseDomainOnlyComponent = await PurchaseDomainOnlyComponent.Expect( driver );
+			return await purchaseDomainOnlyComponent.searchForDomainNameAndSelectRecommended( expectedDomainName );
 		} );
 
 		step( 'Can select domain only from the domain first choice page', async function() {

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -45,6 +45,7 @@ import NoSitesComponent from '../lib/components/no-sites-component';
 import * as SlackNotifier from '../lib/slack-notifier';
 
 import EmailClient from '../lib/email-client.js';
+import NewUserRegistrationUnavailableComponent from '../lib/components/new-user-domain-registration-unavailable-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -977,6 +978,10 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			async function() {
 				const findADomainComponent = await FindADomainComponent.Expect( driver );
 				await findADomainComponent.searchForBlogNameAndWaitForResults( expectedDomainName );
+				if ( await NewUserRegistrationUnavailableComponent.Expect( driver ) ) {
+					await SlackNotifier.warn( 'SKIPPING: Domain registration is currently unavailable. ' );
+					return this.skip();
+				}
 				return await findADomainComponent.selectDomainAddress( expectedDomainName );
 			}
 		);


### PR DESCRIPTION
Check if domain registration is available, and skip tests if it's not. 

**To test `wp-manage-domains-spec`:**
- change [this line](https://github.com/Automattic/wp-calypso/blob/7b91038e6b42d9fc63722cdc051d76e95e5ba698/client/my-sites/domains/domain-search/domain-search.jsx#L126) in Calypso to `if ( this.state.domainRegistrationAvailable ) {` 
- run tests against that Calypso
- domain registration should be unavailable

**To test `wp-signup-spec`:**
_**NOTE:** This includes only `Sign up for a site on a business paid plan w/ domain name coming in via /create as business flow in CAD currency @parallel` test._
- Change blocks of [this](https://github.com/Automattic/wp-calypso/blob/3048bc27bd9d5844659cb6ee5291580ced75c74d/client/components/domains/register-domain-step/index.jsx#L683) and [this](https://github.com/Automattic/wp-calypso/blob/3048bc27bd9d5844659cb6ee5291580ced75c74d/client/components/domains/register-domain-step/index.jsx#L617) functions to:
```
this.showValidationErrorMessage( domain, 'domain_registration_unavailable', {
     	maintenanceEndTime: null,
} );
```
- run tests against that Calypso
- domain registration should be unavailable

**Result:** Tests should be skipped and not failed. 


**Additional changes:** `Sign up for a domain only purchase coming in from wordpress.com/domains in EUR currency @parallel` - Now it opens _/domains_ page and searches for a domain instead opening direct link for a wanted _.live_ domain. This was needed to be done because we will add check for domain registration unavailability in the future. 

Fixes #1308 