### PR TITLE
Domains: Bump timeout for transfer precheck screen and enable test again

### DIFF
--- a/lib/pages/transfer-domain-precheck-page.js
+++ b/lib/pages/transfer-domain-precheck-page.js
@@ -11,7 +11,7 @@ export default class TransferDomainPrecheckPage extends AsyncBaseContainer {
 			driver,
 			By.css( '.transfer-domain-step__precheck' ),
 			null,
-			config.get( 'explicitWaitMS' ) * 2
+			config.get( 'explicitWaitMS' ) * 3
 		);
 	}
 }

--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -188,7 +188,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function(
 		} );
 	} );
 
-	xdescribe( 'Transfer a domain to an existing site (partial) @parallel', function() {
+	describe( 'Transfer a domain to an existing site (partial) @parallel', function() {
 		const domain = 'automattic.com';
 
 		before( async function() {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-e2e-tests/issues/1382