### PR TITLE
Disable test

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1068,7 +1068,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Sign up for a domain only purchase coming in from wordpress.com/domains in EUR currency @parallel', function() {
+	xdescribe( 'Sign up for a domain only purchase coming in from wordpress.com/domains in EUR currency @parallel', function() {
 		const siteName = dataHelper.getNewBlogName();
 		const expectedDomainName = `${ siteName }.live`;
 		const emailAddress = dataHelper.getEmailAddress( siteName, signupInboxId );


### PR DESCRIPTION
Test is failing on wp-e2e-tests-for-branches because /domains isn't in calypso

@Stojdza 