### PR TITLE
Update nudge a palooza test date

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -77,7 +77,7 @@
 		[ "domainSearchTLDFilterPlacement_20180531", "belowFeatured" ],
 		[ "aboutSuggestionMatches_20180704", "control" ],
 		[ "includeDotBlogSubdomain_20180723", "no" ],
-		[ "nudgeAPalooza_20180726", "control" ],
-		[ "gSuiteDiscount_20180803", "control" ]
+		[ "gSuiteDiscount_20180803", "control" ],
+                [ "nudgeAPalooza_20180806", "control" ]
 	]
 }


### PR DESCRIPTION
Because of a bug we found (p2EDhh-tc-p2), we had to disable the feature flag related to features of this test. [The fix will soon be merged](https://github.com/Automattic/wp-calypso/pull/26483) and we'll need to restart the test to get fresh results. Related calypso PR is here:

https://github.com/Automattic/wp-calypso/pull/26485/files