### PR TITLE
Remove scheduled post when test is finished

### DIFF
--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -531,6 +531,11 @@ describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 					'The newly scheduled post is not showing in the editor as scheduled'
 				);
 			} );
+
+			after( async function() {
+				let postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
+				await postEditorSidebarComponent.trashPost();
+			} );
 		} );
 	} );
 

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -472,7 +472,7 @@ describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		describe( 'Schedule a New Post', function() {
+		describe( 'Schedule (and remove) a New Post', function() {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote = '“Worries shared are worries halved.”\n- Unknown';
 
@@ -526,15 +526,15 @@ describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 				const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 				await postEditorToolbarComponent.waitForPostSucessNotice();
 				const postEditorPage = await EditorPage.Expect( driver );
-				assert(
+				return assert(
 					await postEditorPage.postIsScheduled(),
 					'The newly scheduled post is not showing in the editor as scheduled'
 				);
 			} );
 
-			after( async function() {
+			step( 'Remove scheduled post', async function() {
 				let postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
-				await postEditorSidebarComponent.trashPost();
+				return await postEditorSidebarComponent.trashPost();
 			} );
 		} );
 	} );


### PR DESCRIPTION
After successful test `Schedule Basic Public Post @parallel @jetpack`, scheduled post is trashed. 

Fixes #1229 