### PR TITLE
Add basic import scenario

### DIFF
--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -11,6 +11,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 		super( driver, By.css( '.sidebar' ) );
 		this.storeSelector = By.css( '.sites-navigation li a[href*=store]' );
 		this.settingsSelector = By.css( '.sites-navigation [data-tip-target="settings"] a' );
+		this.importSelector = By.css( '.sites-navigation [data-tip-target="side-menu-import"] a' );
 	}
 
 	async selectDomains() {
@@ -144,6 +145,14 @@ export default class SidebarComponent extends AsyncBaseContainer {
 
 	async settingsOptionExists() {
 		return await driverHelper.isElementPresent( this.driver, this.settingsSelector );
+	}
+
+	async importOptionExists() {
+		return await driverHelper.isElementPresent( this.driver, this.importSelector );
+	}
+
+	async selectImport() {
+		return await driverHelper.clickWhenClickable( this.driver, this.importSelector );
 	}
 
 	async selectPages() {

--- a/lib/pages/settings/importer-page.js
+++ b/lib/pages/settings/importer-page.js
@@ -1,0 +1,18 @@
+/** @format */
+
+import { By } from 'selenium-webdriver';
+import AsyncBaseContainer from '../../async-base-container';
+import * as DriverHelper from '../../driver-helper.js';
+
+export default class ImporterPage extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.importer__section-title' ) );
+	}
+
+	async importerIsDisplayed( importerClass ) {
+		return DriverHelper.isElementPresent(
+			this.driver,
+			By.css( `.importer__shell .${ importerClass }` )
+		);
+	}
+}

--- a/specs/wp-import-site-spec.js
+++ b/specs/wp-import-site-spec.js
@@ -1,0 +1,71 @@
+/** @format */
+
+import config from 'config';
+import assert from 'assert';
+
+import LoginFlow from '../lib/flows/login-flow.js';
+
+import NavBarComponent from '../lib/components/nav-bar-component.js';
+import SideBarComponent from '../lib/components/sidebar-component';
+
+import ImporterPage from '../lib/pages/settings/importer-page';
+
+import * as driverManager from '../lib/driver-manager.js';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+
+let driver;
+
+before( async function() {
+	this.timeout( startBrowserTimeoutMS );
+	driver = await driverManager.startBrowser();
+} );
+
+describe( 'Verify Import Option: (' + screenSize + ') @parallel', function() {
+	this.timeout( mochaTimeOut );
+
+	step( 'Ensure not logged in', async function() {
+		await driverManager.ensureNotLoggedIn( driver );
+	} );
+
+	step( 'Can log in as default user', async function() {
+		const loginFlow = new LoginFlow( driver );
+		return await loginFlow.login();
+	} );
+
+	step( 'Can open the sidebar', async function() {
+		const navBarComponent = await NavBarComponent.Expect( driver );
+		await navBarComponent.clickMySites();
+	} );
+
+	step( "Can see an 'Import' option", async function() {
+		const sideBarComponent = await SideBarComponent.Expect( driver );
+		return assert(
+			await sideBarComponent.settingsOptionExists(),
+			'The settings menu option does not exist'
+		);
+	} );
+
+	step( "Following 'Import' menu option opens the Import page", async function() {
+		const sideBarComponent = await SideBarComponent.Expect( driver );
+		await sideBarComponent.selectImport();
+		await ImporterPage.Expect( driver );
+	} );
+
+	step( 'Can see the WordPress importer', async function() {
+		const importerPage = await ImporterPage.Expect( driver );
+		assert( await importerPage.importerIsDisplayed( 'wordpress' ) );
+	} );
+
+	step( 'Can see the Medium importer', async function() {
+		const importerPage = await ImporterPage.Expect( driver );
+		assert( await importerPage.importerIsDisplayed( 'medium' ) );
+	} );
+
+	step( 'Can see the Blogger importer', async function() {
+		const importerPage = await ImporterPage.Expect( driver );
+		assert( await importerPage.importerIsDisplayed( 'blogger-alt' ) );
+	} );
+} );


### PR DESCRIPTION
There's a high level "Import" menu item now in Calypso https://github.com/Automattic/wp-calypso/pull/26447

So I thought it was time we at least make sure that Import loads for customers

**This PR:**

1. Visits Calypso makes sure Import is present
2. Follows import - checks import page is present
3. Makes sure WordPress, Medium and Blogger importers are displayed

**This PR doesn't**

1. Do an import
2. Check the beta importer is there
3. Work on Jetpack - Jetpack imports aren't supported in Calypso - these are done in wp-admin

**To Test:**

1. Run `specs/wp-import-site-spec.js` making sure it works desktop and mobile
2. It's pretty straightforward this one