### PR TITLE
Updates an existing scenario to start from the /jetpack/new route

### DIFF
--- a/lib/pages/signup/jetpack-add-new-site-page.js
+++ b/lib/pages/signup/jetpack-add-new-site-page.js
@@ -1,0 +1,24 @@
+/** @format */
+
+import { By } from 'selenium-webdriver';
+
+import * as dataHelper from '../../data-helper';
+import * as driverHelper from '../../driver-helper';
+import AsyncBaseContainer from '../../async-base-container';
+import * as driverManager from '../../driver-manager';
+
+const screenSize = driverManager.currentScreenSize();
+
+export default class JetpackAddNewSitePage extends AsyncBaseContainer {
+	constructor( driver, url = dataHelper.getCalypsoURL( 'jetpack/new', 'ref=calypso-selector' ) ) {
+		super( driver, By.css( '.jetpack-new-site__main' ), url );
+	}
+
+	async createNewWordPressDotComSite() {
+		const wpComButtonSelector =
+			screenSize === 'mobile'
+				? By.css( '.jetpack-new-site__mobile-wpcom-site a.button' )
+				: By.css( '.jetpack-new-site__wpcom-site a.button' );
+		return driverHelper.clickWhenClickable( this.driver, wpComButtonSelector );
+	}
+}

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -10,6 +10,8 @@ import * as eyesHelper from '../lib/eyes-helper.js';
 import WPHomePage from '../lib/pages/wp-home-page.js';
 import ChooseAThemePage from '../lib/pages/signup/choose-a-theme-page.js';
 import StartPage from '../lib/pages/signup/start-page.js';
+import JetpackAddNewSitePage from '../lib/pages/signup/jetpack-add-new-site-page';
+
 import AboutPage from '../lib/pages/signup/about-page.js';
 import DomainFirstPage from '../lib/pages/signup/domain-first-page';
 import PickAPlanPage from '../lib/pages/signup/pick-a-plan-page.js';
@@ -69,7 +71,7 @@ before( async function() {
 describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 	this.timeout( mochaTimeOut );
 
-	describe( 'Sign up for a free non-blog site and log in via a magic link @parallel @email', function() {
+	describe( 'Sign up for a free WordPress.com site (not blog) from the Jetpack new site page, and log in via a magic link @parallel @email', function() {
 		const blogName = dataHelper.getNewBlogName();
 		let newBlogAddress = '';
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
@@ -80,9 +82,13 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can visit the start page', async function() {
-			await StartPage.Visit( driver, StartPage.getStartURL( { culture: locale } ) );
-		} );
+		step(
+			'Can visit the Jetpack Add New Site page and choose "Create a shiny new WordPress.com site"',
+			async function() {
+				const jetpackAddNewSitePage = await JetpackAddNewSitePage.Visit( driver );
+				await jetpackAddNewSitePage.createNewWordPressDotComSite();
+			}
+		);
 
 		step( 'Can see the "About" page, and enter some site information', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
@@ -204,11 +210,10 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Sign up for a free blog and log in via a magic link @parallel @email', function() {
+	describe( 'Sign up for a free blog and see the onboarding checklist @parallel', function() {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-		let magicLoginLink;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -275,36 +280,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			assert( header, 'The checklist header does not exist.' );
 
 			return assert( subheader, 'The checklist subheader does not exist.' );
-		} );
-
-		step( 'Can log out and request a magic link', async function() {
-			await driverManager.ensureNotLoggedIn( driver );
-			const loginPage = await LoginPage.Visit( driver );
-			return await loginPage.requestMagicLink( emailAddress );
-		} );
-
-		step( 'Can see email containing magic link', async function() {
-			const emailClient = new EmailClient( signupInboxId );
-			const validator = emails => emails.find( email => email.subject.includes( 'WordPress.com' ) );
-			let emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
-			//Disabled due to a/b test on activation email. See https://github.com/Automattic/wp-e2e-tests/issues/819
-			//assert.strictEqual( emails.length, 2, 'The number of newly registered emails is not equal to 2 (activation and magic link)' );
-			for ( let email of emails ) {
-				if ( email.subject.includes( 'WordPress.com' ) ) {
-					return ( magicLoginLink = email.html.links[ 0 ].href );
-				}
-			}
-			return assert(
-				magicLoginLink !== undefined,
-				'Could not locate the magic login link email link'
-			);
-		} );
-
-		step( 'Can visit the magic link and we should be logged in', async function() {
-			await driver.get( magicLoginLink );
-			const magicLoginPage = await MagicLoginPage.Expect( driver );
-			await magicLoginPage.finishLogin();
-			return await ReaderPage.Expect( driver );
 		} );
 
 		step( 'Can delete our newly created account', async function() {


### PR DESCRIPTION
There's a route in Calypso: `/jetpack/new` which we never touch

<img width="843" alt="screen shot 2018-08-06 at 3 14 26 pm" src="https://user-images.githubusercontent.com/128826/43698559-d90e9d28-998d-11e8-9f67-1aeb9c4d630e.png">

This updates an existing WordPress.com sign up scenario to start from here - I didn't add a new scenario as it would be overkill - this is simply an entry point into the regular sign up flows

I also removed the magic link login from the second sign up scenario since again it's overkill testing this twice

**Testing**

1. Make sure it runs against calypso.localhost
2. Make sure `Sign up for a free WordPress.com site (not blog) from the Jetpack new site page, and log in via a magic link` and `Sign up for a free blog and see the onboarding checklist` run desktop and mobile
3. Code looks ok
