### PR TITLE
Stability improvements for Jetpack Connect tests

### DIFF
--- a/lib/async-base-container.js
+++ b/lib/async-base-container.js
@@ -43,6 +43,9 @@ export default class AsyncBaseContainer {
 	}
 
 	async _expectInit() {
+		if ( global.__jetpackConnectUser === true ) {
+			await driverHelper.refreshIfJNError();
+		}
 		await this.waitForPage();
 		await this.checkForUnknownABTestKeys();
 		await this.checkForConsoleErrors();

--- a/lib/async-base-container.js
+++ b/lib/async-base-container.js
@@ -43,7 +43,7 @@ export default class AsyncBaseContainer {
 	}
 
 	async _expectInit() {
-		if ( global.__jetpackConnectUser === true ) {
+		if ( global.__JNSite === true ) {
 			await driverHelper.refreshIfJNError( this.driver );
 		}
 		await this.waitForPage();

--- a/lib/async-base-container.js
+++ b/lib/async-base-container.js
@@ -44,7 +44,7 @@ export default class AsyncBaseContainer {
 
 	async _expectInit() {
 		if ( global.__jetpackConnectUser === true ) {
-			await driverHelper.refreshIfJNError();
+			await driverHelper.refreshIfJNError( this.driver );
 		}
 		await this.waitForPage();
 		await this.checkForUnknownABTestKeys();

--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -387,13 +387,18 @@ export async function refreshIfJNError( driver, timeout = 2000 ) {
 	}
 
 	// Match only 503 Error codes
-	const JNSiteError = by.xpath(
+	const jnSiteError = by.xpath(
 		"//pre[@class='error' and .='/srv/users/SYSUSER/log/APPNAME/APPNAME_apache.error.log' and //title[.='503 Service Unavailable']]"
 	);
 
+	// Match WP DB error
+	const jnDBError = by.xpath( '//h1[.="Error establishing a database connection"]' );
+
 	const refreshIfNeeded = async () => {
-		const jnErrorDisplayed = await isEventuallyPresentAndDisplayed( driver, JNSiteError, timeout );
-		if ( jnErrorDisplayed ) {
+		const jnErrorDisplayed = await isEventuallyPresentAndDisplayed( driver, jnSiteError, timeout );
+		const jnDBErrorDisplayed = await isElementPresent( driver, jnDBError );
+		if ( jnErrorDisplayed || jnDBErrorDisplayed ) {
+			console.log( 'JN Error! Refreshing the page' );
 			await driver.navigate().refresh();
 			return refreshIfNeeded();
 		}

--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -400,7 +400,7 @@ export async function refreshIfJNError( driver, timeout = 2000 ) {
 		if ( jnErrorDisplayed || jnDBErrorDisplayed ) {
 			console.log( 'JN Error! Refreshing the page' );
 			await driver.navigate().refresh();
-			return refreshIfNeeded();
+			return await refreshIfNeeded();
 		}
 		return true;
 	};

--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -381,7 +381,7 @@ export function ensurePopupsClosed( driver ) {
 	return switchToWindowByIndex( driver, 0 );
 }
 
-export function refreshIfJNError( driver, timeout = 2000 ) {
+export async function refreshIfJNError( driver, timeout = 2000 ) {
 	if ( dataHelper.getTargetType() !== 'JETPACK' ) {
 		return false;
 	}
@@ -391,18 +391,16 @@ export function refreshIfJNError( driver, timeout = 2000 ) {
 		"//pre[@class='error' and .='/srv/users/SYSUSER/log/APPNAME/APPNAME_apache.error.log' and //title[.='503 Service Unavailable']]"
 	);
 
-	const refreshIfNeeded = () =>
-		isEventuallyPresentAndDisplayed( driver, JNSiteError, timeout ).then( jnErrorDisplayed => {
-			if ( jnErrorDisplayed ) {
-				return driver
-					.navigate()
-					.refresh()
-					.then( () => refreshIfNeeded() );
-			}
-			return true;
-		} );
+	const refreshIfNeeded = async () => {
+		const jnErrorDisplayed = await isEventuallyPresentAndDisplayed( driver, JNSiteError, timeout );
+		if ( jnErrorDisplayed ) {
+			await driver.navigate().refresh();
+			return refreshIfNeeded();
+		}
+		return true;
+	};
 
-	return refreshIfNeeded();
+	return await refreshIfNeeded();
 }
 
 export async function scrollIntoView( driver, selector ) {

--- a/lib/flows/jetpack-connect-flow.js
+++ b/lib/flows/jetpack-connect-flow.js
@@ -81,7 +81,8 @@ export default class JetpackConnectFlow {
 			// seems like it is not waiting for this
 			await driverHelper.waitTillPresentAndDisplayed(
 				this.driver,
-				By.css( '.notice.is-success.is-dismissable' )
+				By.css( '.notice.is-success.is-dismissable' ),
+				config.get( 'explicitWaitMS' ) * 2
 			);
 			await driverHelper.clickWhenClickable(
 				this.driver,

--- a/lib/flows/jetpack-connect-flow.js
+++ b/lib/flows/jetpack-connect-flow.js
@@ -24,6 +24,8 @@ export default class JetpackConnectFlow {
 	}
 
 	async createJNSite() {
+		global.__JNSite = true;
+
 		const wporgCreator = await WporgCreatorPage.Visit(
 			this.driver,
 			WporgCreatorPage._getCreatorURL( this.template )

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -34,9 +34,6 @@ export default class LoginFlow {
 				loginURL: legacyConfig[ 2 ],
 				legacyAccountName: accountOrFeatures,
 			};
-			if ( accountOrFeatures === 'jetpackConnectUser' ) {
-				global.__jetpackConnectUser = true;
-			}
 		} else {
 			this.account = dataHelper.pickRandomAccountWithFeatures( accountOrFeatures );
 			if ( ! this.account ) {

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -12,7 +12,6 @@ import NavBarComponent from '../components/nav-bar-component.js';
 
 import * as eyesHelper from '../eyes-helper';
 import * as dataHelper from '../data-helper';
-import * as driverHelper from '../driver-helper';
 const host = dataHelper.getJetpackHost();
 
 export default class LoginFlow {
@@ -35,6 +34,9 @@ export default class LoginFlow {
 				loginURL: legacyConfig[ 2 ],
 				legacyAccountName: accountOrFeatures,
 			};
+			if ( accountOrFeatures === 'jetpackConnectUser' ) {
+				global.__jetpackConnectUser = true;
+			}
 		} else {
 			this.account = dataHelper.pickRandomAccountWithFeatures( accountOrFeatures );
 			if ( ! this.account ) {
@@ -42,10 +44,6 @@ export default class LoginFlow {
 					`Could not find any account matching features '${ accountOrFeatures.toString() }'`
 				);
 			}
-		}
-
-		if ( this.account.legacyAccountName === 'jetpackConnectUser' ) {
-			driverHelper.refreshIfJNError( driver );
 		}
 	}
 

--- a/lib/pages/woocommerce/woo-wizard-jetpack-page.js
+++ b/lib/pages/woocommerce/woo-wizard-jetpack-page.js
@@ -16,7 +16,7 @@ export default class WooWizardJetpackPage extends AsyncBaseContainer {
 		return await driverHelper.waitTillNotPresent(
 			this.driver,
 			buttonSelector,
-			this.explicitWaitMS * 10
+			this.explicitWaitMS * 20
 		);
 	}
 }

--- a/lib/pages/woocommerce/woo-wizard-jetpack-page.js
+++ b/lib/pages/woocommerce/woo-wizard-jetpack-page.js
@@ -16,7 +16,7 @@ export default class WooWizardJetpackPage extends AsyncBaseContainer {
 		return await driverHelper.waitTillNotPresent(
 			this.driver,
 			buttonSelector,
-			this.explicitWaitMS * 8
+			this.explicitWaitMS * 10
 		);
 	}
 }

--- a/lib/pages/woocommerce/woo-wizard-jetpack-page.js
+++ b/lib/pages/woocommerce/woo-wizard-jetpack-page.js
@@ -12,6 +12,7 @@ export default class WooWizardJetpackPage extends AsyncBaseContainer {
 
 	async selectContinueWithJetpack() {
 		const buttonSelector = By.css( 'button.button-primary' );
+		await this.driver.sleep( 2000 );
 		await driverHelper.clickWhenClickable( this.driver, buttonSelector );
 		return await driverHelper.waitTillNotPresent(
 			this.driver,

--- a/lib/pages/woocommerce/woo-wizard-jetpack-page.js
+++ b/lib/pages/woocommerce/woo-wizard-jetpack-page.js
@@ -16,7 +16,7 @@ export default class WooWizardJetpackPage extends AsyncBaseContainer {
 		return await driverHelper.waitTillNotPresent(
 			this.driver,
 			buttonSelector,
-			this.explicitWaitMS * 3
+			this.explicitWaitMS * 4
 		);
 	}
 }

--- a/lib/pages/woocommerce/woo-wizard-jetpack-page.js
+++ b/lib/pages/woocommerce/woo-wizard-jetpack-page.js
@@ -16,7 +16,7 @@ export default class WooWizardJetpackPage extends AsyncBaseContainer {
 		return await driverHelper.waitTillNotPresent(
 			this.driver,
 			buttonSelector,
-			this.explicitWaitMS * 4
+			this.explicitWaitMS * 8
 		);
 	}
 }

--- a/lib/pages/woocommerce/woo-wizard-jetpack-page.js
+++ b/lib/pages/woocommerce/woo-wizard-jetpack-page.js
@@ -16,7 +16,7 @@ export default class WooWizardJetpackPage extends AsyncBaseContainer {
 		return await driverHelper.waitTillNotPresent(
 			this.driver,
 			buttonSelector,
-			this.explicitWaitMS * 2
+			this.explicitWaitMS * 3
 		);
 	}
 }

--- a/lib/pages/wp-admin/wp-admin-customizer-page.js
+++ b/lib/pages/wp-admin/wp-admin-customizer-page.js
@@ -10,7 +10,7 @@ export default class WPAdminCustomizerPage extends AsyncBaseContainer {
 		super( driver, by.css( '.wp-customizer' ) );
 	}
 
-	static async refreshIfError( driver ) {
+	static async refreshIfJNError( driver ) {
 		return await driverHelper.refreshIfJNError( driver );
 	}
 }

--- a/lib/pages/wp-admin/wp-admin-dashboard-page.js
+++ b/lib/pages/wp-admin/wp-admin-dashboard-page.js
@@ -44,4 +44,8 @@ export default class WPAdminDashboardPage extends AsyncBaseContainer {
 		url = url.replace( /^https?:\/\//, '' ).replace( /\/wp-admin/, '' );
 		return `https://${ url }/wp-admin`;
 	}
+
+	static async refreshIfJNError( driver ) {
+		return await driverHelper.refreshIfJNError( driver );
+	}
 }

--- a/lib/pages/wp-admin/wp-admin-new-user-page.js
+++ b/lib/pages/wp-admin/wp-admin-new-user-page.js
@@ -7,7 +7,7 @@ import AsyncBaseContainer from '../../async-base-container';
 
 export default class WPAdminNewUserPage extends AsyncBaseContainer {
 	constructor( driver ) {
-		driverHelper.refreshIfJNError( driver );
+		// driverHelper.refreshIfJNError( driver );
 		super( driver, By.css( 'h1#add-new-user' ) );
 	}
 

--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -23,10 +23,19 @@ const CONTINUE_LINK = By.linkText( 'The new WP is ready to go, visit it!' );
 
 export default class WporgCreatorPage extends AsyncBaseContainer {
 	constructor( driver, url ) {
+		super( driver, By.css( '#progress' ), url );
+	}
+
+	static async Visit( driver, url ) {
 		// Randomly wait 1-10 sec before actually creating JN site.
 		// It may prevent these "Service Unavailable" errors
-		driver.sleep( Math.floor( Math.random() * 10 + 1 ) * 1000 );
-		super( driver, By.css( '#progress' ), url );
+		await driver.sleep( Math.floor( Math.random() * 10 + 1 ) * 1000 );
+		const page = new this( driver, url );
+		if ( ! page.url ) {
+			throw new Error( `URL is required to visit the ${ page.name }` );
+		}
+		await page._visitInit();
+		return page;
 	}
 
 	async _postInit() {

--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -23,6 +23,9 @@ const CONTINUE_LINK = By.linkText( 'The new WP is ready to go, visit it!' );
 
 export default class WporgCreatorPage extends AsyncBaseContainer {
 	constructor( driver, url ) {
+		// Randomly wait 1-10 sec before actually creating JN site.
+		// It may prevent these "Service Unavailable" errors
+		driver.sleep( Math.floor( Math.random() * 10 + 1 ) * 1000 );
 		super( driver, By.css( '#progress' ), url );
 	}
 

--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -42,7 +42,7 @@ export default class WporgCreatorPage extends AsyncBaseContainer {
 		await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,
 			CONTINUE_LINK,
-			this.explicitWaitMS * 10
+			this.explicitWaitMS * 20
 		);
 		return await driverHelper.clickWhenClickable( this.driver, CONTINUE_LINK );
 	}

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -375,6 +375,8 @@ describe( `Jetpack Connect: (${ screenSize })`, function() {
 		} );
 
 		step( 'Can activate Jetpack', async function() {
+			this.timeout( mochaTimeOut * 2 );
+
 			const wooWizardJetpackPage = await WooWizardJetpackPage.Expect( driver );
 			return await wooWizardJetpackPage.selectContinueWithJetpack();
 		} );

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -213,6 +213,7 @@ describe( `Jetpack Connect: (${ screenSize })`, function() {
 
 		step( 'Log out from WP Admin', async function() {
 			await driverManager.ensureNotLoggedIn( driver );
+			await WPAdminDashboardPage.refreshIfJNError( driver );
 			const wPAdminDashboardPage = await WPAdminDashboardPage.Visit(
 				driver,
 				WPAdminDashboardPage.getUrl( siteName )
@@ -339,6 +340,7 @@ describe( `Jetpack Connect: (${ screenSize })`, function() {
 		} );
 
 		step( 'Can enter WooCommerce Wizard', async function() {
+			await WPAdminDashboardPage.refreshIfJNError( driver );
 			const wPAdminDashboardPage = await WPAdminDashboardPage.Expect( driver );
 			return await wPAdminDashboardPage.enterWooCommerceWizard();
 		} );

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -375,7 +375,7 @@ describe( `Jetpack Connect: (${ screenSize })`, function() {
 		} );
 
 		step( 'Can activate Jetpack', async function() {
-			this.timeout( mochaTimeOut * 2 );
+			this.timeout( mochaTimeOut * 5 );
 
 			const wooWizardJetpackPage = await WooWizardJetpackPage.Expect( driver );
 			return await wooWizardJetpackPage.selectContinueWithJetpack();

--- a/specs/wp-theme-switch-spec.js
+++ b/specs/wp-theme-switch-spec.js
@@ -138,7 +138,7 @@ describe( `[${ host }] Activating Themes: (${ screenSize }) @parallel @jetpack @
 				} );
 
 				step( 'Can customize the site from the theme thanks dialog', async function() {
-					await WPAdminCustomizerPage.refreshIfError( driver );
+					await WPAdminCustomizerPage.refreshIfJNError( driver );
 					return await WPAdminCustomizerPage.Expect( driver );
 				} );
 			}


### PR DESCRIPTION
This PR attempts to increase the stability of Jetpack Connect tests (which uses JN sites).

- Introduced `global.__JNSite` which should indicate that the current test uses JN site.
- Added some `sleep`s, and increases some wait timeouts

To test:
 - run: `TARGET=JETPACK JETPACKHOST=PRESSABLE ./run.sh -j`