### PR TITLE
Skip test if domain registration is unavailable

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1112,7 +1112,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can see checkout page, choose domain privacy option and enter registrar details',
 			async function() {
-				const checkOutPage = await CheckOutPage.Expect( driver );
+				let checkOutPage;
+				try {
+					checkOutPage = await CheckOutPage.Expect( driver );
+				} catch ( err ) {
+					const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+					let numberOfItems = await securePaymentComponent.numberOfProductsInCart();
+					if ( numberOfItems === 0 ) {
+						await SlackNotifier.warn(
+							'OOPS! Something went wrong! Check if domains registrations is available.'
+						);
+						return this.skip();
+					}
+				}
 				await checkOutPage.selectAddPrivacyProtectionCheckbox();
 				await checkOutPage.enterRegistarDetails( testDomainRegistarDetails );
 				return await checkOutPage.submitForm();

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1073,7 +1073,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can visit the domains start page', async function() {
-			//TODO: Cover case when domain registration is not available
 			await StartPage.Visit(
 				driver,
 				StartPage.getStartURL( {
@@ -1116,6 +1115,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 				try {
 					checkOutPage = await CheckOutPage.Expect( driver );
 				} catch ( err ) {
+					//TODO: Check this code once more when domain registration is not available
 					const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 					let numberOfItems = await securePaymentComponent.numberOfProductsInCart();
 					if ( numberOfItems === 0 ) {


### PR DESCRIPTION
Last test which needed to be covered when domain registration is unavailable. 

Since `/domains` page is not part of the Calypso, our test is starting from the page `/start/domain-first/site-or-domain`. It's hard to test it locally because of this. I succeeded to catch this case while was on production, saw where it fails and cover with try/catch. 

I'm not 100% sure that test will be skipped successfully (registration unavailability was over before I made changes 😬), but in the worst case, the test will fail at the same step as before. 