### PR TITLE
Add simple frontend comment test

### DIFF
--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -168,4 +168,11 @@ export default class PostEditorToolbarComponent extends AsyncBaseContainer {
 			By.css( 'button.editor-ground-control__back' )
 		);
 	}
+
+	async visitSite() {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( 'a.web-preview__external' )
+		);
+	}
 }

--- a/lib/pages/frontend/comments-area-component.js
+++ b/lib/pages/frontend/comments-area-component.js
@@ -1,0 +1,76 @@
+/** @format */
+
+import { By, until } from 'selenium-webdriver';
+import * as driverHelper from '../../driver-helper';
+import * as dataHelper from '../../data-helper';
+
+import AsyncBaseContainer from '../../async-base-container';
+
+export default class CommentsAreaComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '#comments.comments-area' ) );
+	}
+
+	async _postComment( { comment } ) {
+		const commentForm = By.css( '#commentform' );
+		const commentFormWordPress = By.css( '#comment-form-wordpress' );
+		const commentField = By.css( '#comment' );
+		const submitButton = By.css( '.form-submit #comment-submit' );
+		const commentContent = By.xpath( `//div[@class='comment-content']/p[.='${ comment }']` );
+
+		await this.switchToFrameIfJetpack();
+
+		// await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '#hc_post_as' ) );
+		// const isLoggedIn = await this.driver.findElement( By.css( '#hc_post_as' ) ).getAttribute( 'value' ) !== 'guest';
+
+		await driverHelper.clickWhenClickable( this.driver, commentForm );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, commentFormWordPress );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, submitButton );
+		await driverHelper.setWhenSettable( this.driver, commentField, comment );
+
+		// Not needed when logged in:
+		// await driverHelper.setWhenSettable( this.driver, By.css( '#author' ), name );
+		// await driverHelper.setWhenSettable( this.driver, By.css( '#email' ), email );
+		// if ( site ) {
+		// 	await driverHelper.setWhenSettable( this.driver, By.css( '#site' ), site );
+		// }
+
+		// await this.driver.sleep( 1000 );
+		await driverHelper.scrollIntoView( this.driver, submitButton );
+		await driverHelper.clickWhenClickable( this.driver, submitButton );
+		await this.switchToFrameIfJetpack();
+		return await driverHelper.waitTillPresentAndDisplayed( this.driver, commentContent );
+	}
+
+	async reply( commentObj, depth = 2 ) {
+		const replyButton = By.css( '.comment-reply-link' );
+		const replyContent = By.xpath(
+			`//li[contains(@class,'depth-${ depth }')]//div[@class='comment-content']/p[.='${
+				commentObj.comment
+			}']`
+		);
+		// await this.driver.sleep( 1000 );
+		// await driverHelper.waitTillPresentAndDisplayed( this.driver, replyButton );
+		await driverHelper.clickWhenClickable( this.driver, replyButton );
+		// await this.driver.sleep( 1000 );
+
+		await this._postComment( commentObj );
+		return await driverHelper.waitTillPresentAndDisplayed( this.driver, replyContent );
+	}
+
+	async switchToFrameIfJetpack() {
+		if ( dataHelper.getJetpackHost() === 'WPCOM' ) {
+			return false;
+		}
+		const iFrameSelector = By.css( 'iframe.jetpack_remote_comment' );
+		await this.driver.sleep( 1000 ); // To make sure that iFrame already there
+
+		await this.driver.switchTo().defaultContent();
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, iFrameSelector );
+		await this.driver.wait(
+			until.ableToSwitchToFrame( iFrameSelector ),
+			this.explicitWaitMS,
+			'Could not switch to comment form iFrame'
+		);
+	}
+}

--- a/specs/wp-comments-spec.js
+++ b/specs/wp-comments-spec.js
@@ -1,0 +1,80 @@
+/** @format */
+
+import config from 'config';
+
+import * as driverManager from '../lib/driver-manager';
+import * as dataHelper from '../lib/data-helper';
+import * as mediaHelper from '../lib/media-helper';
+import LoginFlow from '../lib/flows/login-flow';
+import EditorPage from '../lib/pages/editor-page';
+import PostEditorToolbarComponent from '../lib/components/post-editor-toolbar-component';
+import CommentsAreaComponent from '../lib/pages/frontend/comments-area-component';
+
+const host = dataHelper.getJetpackHost();
+const screenSize = driverManager.currentScreenSize();
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const mochaTimeoutMS = config.get( 'mochaTimeoutMS' );
+const blogPostTitle = dataHelper.randomPhrase();
+const blogPostQuote =
+	'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
+
+let driver;
+
+before( async function() {
+	this.timeout( startBrowserTimeoutMS );
+	driver = await driverManager.startBrowser();
+} );
+
+describe( `[${ host }] Comments: (${ screenSize })`, function() {
+	let fileDetails;
+	this.timeout( mochaTimeoutMS );
+
+	// Create image file for upload
+	before( async function() {
+		fileDetails = await mediaHelper.createFile();
+		return fileDetails;
+	} );
+
+	describe( 'Commenting and replying to newly created post', function() {
+		before( async function() {
+			await driverManager.ensureNotLoggedIn( driver );
+		} );
+
+		step( 'Can login and create a new post', async function() {
+			await new LoginFlow( driver ).loginAndStartNewPost();
+			const editorPage = await EditorPage.Expect( driver );
+			await editorPage.enterTitle( blogPostTitle );
+			await editorPage.enterContent( blogPostQuote + '\n' );
+			await editorPage.enterPostImage( fileDetails );
+			await editorPage.waitUntilImageInserted( fileDetails );
+		} );
+
+		step( 'Can publish and visit site', async function() {
+			const postEditorToolbar = await PostEditorToolbarComponent.Expect( driver );
+			await postEditorToolbar.publishThePost( { useConfirmStep: true } );
+			await postEditorToolbar.visitSite();
+		} );
+
+		step( 'Can post a comment', async function() {
+			const commentArea = await CommentsAreaComponent.Expect( driver );
+			return await commentArea._postComment( {
+				comment: dataHelper.randomPhrase(),
+				name: 'e2eTestName',
+				email: 'e2eTestName@test.com',
+			} );
+		} );
+
+		step( 'Can post a reply', async function() {
+			await driver.sleep( 10000 ); // Wait to not to post too quickly
+			const commentArea = await CommentsAreaComponent.Expect( driver );
+			await commentArea.reply(
+				{
+					comment: dataHelper.randomPhrase(),
+					name: 'e2eTestName',
+					email: 'e2eTestName@test.com',
+				},
+				2
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
This test was inspired by 6.4.1 Jetpack release, which happened because of the misconfigured iFrame options (https://github.com/Automattic/jetpack/issues/10000)

The new test creates a new post and adds a comment and reply to that comment. A function which adds a reply waits until its contents shows up correctly nested

To test:
- run locally for WPCOM & JETPACK hosts: `mocha specs/wp-comments-spec.js `