### PR TITLE
Revert "Include comment tests in CI"

### DIFF
--- a/lib/pages/frontend/comments-area-component.js
+++ b/lib/pages/frontend/comments-area-component.js
@@ -35,6 +35,7 @@ export default class CommentsAreaComponent extends AsyncBaseContainer {
 		// 	await driverHelper.setWhenSettable( this.driver, By.css( '#site' ), site );
 		// }
 
+		// await this.driver.sleep( 1000 );
 		await driverHelper.scrollIntoView( this.driver, submitButton );
 		await driverHelper.clickWhenClickable( this.driver, submitButton );
 		await this.switchToFrameIfJetpack();
@@ -48,8 +49,11 @@ export default class CommentsAreaComponent extends AsyncBaseContainer {
 				commentObj.comment
 			}']`
 		);
-
+		// await this.driver.sleep( 1000 );
+		// await driverHelper.waitTillPresentAndDisplayed( this.driver, replyButton );
 		await driverHelper.clickWhenClickable( this.driver, replyButton );
+		// await this.driver.sleep( 1000 );
+
 		await this._postComment( commentObj );
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, replyContent );
 	}

--- a/specs/wp-comments-spec.js
+++ b/specs/wp-comments-spec.js
@@ -35,7 +35,7 @@ describe( `[${ host }] Comments: (${ screenSize })`, function() {
 		return fileDetails;
 	} );
 
-	describe( 'Commenting and replying to newly created post: @parallel @jetpack', function() {
+	describe( 'Commenting and replying to newly created post', function() {
 		before( async function() {
 			await driverManager.ensureNotLoggedIn( driver );
 		} );


### PR DESCRIPTION
This reverts commit 5146e46ef217dcb5d3220b3bafb1ba391cc6acea.

It's quite a small change, and the functionality was already tested in https://github.com/Automattic/wp-e2e-tests/pull/1406, so hopefully merging this not needed