### PR TITLE
Run comment test in CI

### DIFF
--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -1,6 +1,6 @@
 /** @format */
 
-import { By, until } from 'selenium-webdriver';
+import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper.js';
 import * as driverManager from '../driver-manager.js';
 
@@ -166,26 +166,6 @@ export default class PostEditorToolbarComponent extends AsyncBaseContainer {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( 'button.editor-ground-control__back' )
-		);
-	}
-
-	async visitSite() {
-		await driverHelper.waitTillPresentAndDisplayed(
-			this.driver,
-			By.css( 'span.web-preview__loading-message' )
-		);
-		await this.driver.wait(
-			until.ableToSwitchToFrame( By.css( 'iframe.web-preview__frame' ) ),
-			this.explicitWaitMS,
-			'Could not switch to comment form iFrame'
-		);
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '#main' ) );
-		await this.driver.switchTo().defaultContent();
-
-		await this.driver.sleep( 5000 );
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( 'a.web-preview__external' )
 		);
 	}
 }

--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -170,11 +170,12 @@ export default class PostEditorToolbarComponent extends AsyncBaseContainer {
 	}
 
 	async visitSite() {
+		await this.ensureSaved();
+		await this.waitForSuccessViewPostNotice();
 		await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,
 			By.css( 'span.web-preview__loading-message' )
 		);
-		await this.waitForSuccessViewPostNotice();
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( 'a.web-preview__external' )

--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -170,6 +170,10 @@ export default class PostEditorToolbarComponent extends AsyncBaseContainer {
 	}
 
 	async visitSite() {
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.web-preview__loading-message' )
+		);
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( 'a.web-preview__external' )

--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -1,6 +1,6 @@
 /** @format */
 
-import { By } from 'selenium-webdriver';
+import { By, until } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper.js';
 import * as driverManager from '../driver-manager.js';
 
@@ -170,12 +170,18 @@ export default class PostEditorToolbarComponent extends AsyncBaseContainer {
 	}
 
 	async visitSite() {
-		await this.ensureSaved();
-		await this.waitForSuccessViewPostNotice();
-		await driverHelper.waitTillPresentAndDisplayed(
-			this.driver,
-			By.css( 'span.web-preview__loading-message' )
+		// await driverHelper.waitTillPresentAndDisplayed(
+		// 	this.driver,
+		// 	By.css( 'span.web-preview__loading-message' )
+		// );
+		await this.driver.wait(
+			until.ableToSwitchToFrame( By.css( 'iframe.web-preview__frame' ) ),
+			this.explicitWaitMS,
+			'Could not switch to comment form iFrame'
 		);
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '#main' ) );
+		await this.driver.switchTo().defaultContent();
+
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( 'a.web-preview__external' )

--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -179,10 +179,10 @@ export default class PostEditorToolbarComponent extends AsyncBaseContainer {
 			this.explicitWaitMS,
 			'Could not switch to comment form iFrame'
 		);
-		await this.driver.sleep( 2000 );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '#main' ) );
 		await this.driver.switchTo().defaultContent();
 
+		await this.driver.sleep( 5000 );
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( 'a.web-preview__external' )

--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -172,8 +172,9 @@ export default class PostEditorToolbarComponent extends AsyncBaseContainer {
 	async visitSite() {
 		await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,
-			By.css( '.web-preview__loading-message' )
+			By.css( 'span.web-preview__loading-message' )
 		);
+		await this.waitForSuccessViewPostNotice();
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( 'a.web-preview__external' )

--- a/lib/components/post-editor-toolbar-component.js
+++ b/lib/components/post-editor-toolbar-component.js
@@ -170,15 +170,16 @@ export default class PostEditorToolbarComponent extends AsyncBaseContainer {
 	}
 
 	async visitSite() {
-		// await driverHelper.waitTillPresentAndDisplayed(
-		// 	this.driver,
-		// 	By.css( 'span.web-preview__loading-message' )
-		// );
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( 'span.web-preview__loading-message' )
+		);
 		await this.driver.wait(
 			until.ableToSwitchToFrame( By.css( 'iframe.web-preview__frame' ) ),
 			this.explicitWaitMS,
 			'Could not switch to comment form iFrame'
 		);
+		await this.driver.sleep( 2000 );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '#main' ) );
 		await this.driver.switchTo().defaultContent();
 

--- a/lib/pages/frontend/comments-area-component.js
+++ b/lib/pages/frontend/comments-area-component.js
@@ -15,7 +15,7 @@ export default class CommentsAreaComponent extends AsyncBaseContainer {
 		const commentForm = By.css( '#commentform' );
 		const commentFormWordPress = By.css( '#comment-form-wordpress' );
 		const commentField = By.css( '#comment' );
-		const submitButton = By.css( '.form-submit #comment-submit' );
+		const submitButton = By.css( ".form-submit[style='display: block;'] #comment-submit" );
 		const commentContent = By.xpath( `//div[@class='comment-content']/p[.='${ comment }']` );
 
 		await this.switchToFrameIfJetpack();
@@ -26,6 +26,7 @@ export default class CommentsAreaComponent extends AsyncBaseContainer {
 		await driverHelper.clickWhenClickable( this.driver, commentForm );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, commentFormWordPress );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, submitButton );
+		await driverHelper.scrollIntoView( this.driver, submitButton );
 		await driverHelper.setWhenSettable( this.driver, commentField, comment );
 
 		// Not needed when logged in:
@@ -35,7 +36,6 @@ export default class CommentsAreaComponent extends AsyncBaseContainer {
 		// 	await driverHelper.setWhenSettable( this.driver, By.css( '#site' ), site );
 		// }
 
-		await driverHelper.scrollIntoView( this.driver, submitButton );
 		await driverHelper.clickWhenClickable( this.driver, submitButton );
 		await this.switchToFrameIfJetpack();
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, commentContent );

--- a/lib/pages/frontend/comments-area-component.js
+++ b/lib/pages/frontend/comments-area-component.js
@@ -35,7 +35,6 @@ export default class CommentsAreaComponent extends AsyncBaseContainer {
 		// 	await driverHelper.setWhenSettable( this.driver, By.css( '#site' ), site );
 		// }
 
-		// await this.driver.sleep( 1000 );
 		await driverHelper.scrollIntoView( this.driver, submitButton );
 		await driverHelper.clickWhenClickable( this.driver, submitButton );
 		await this.switchToFrameIfJetpack();
@@ -49,11 +48,7 @@ export default class CommentsAreaComponent extends AsyncBaseContainer {
 				commentObj.comment
 			}']`
 		);
-		// await this.driver.sleep( 1000 );
-		// await driverHelper.waitTillPresentAndDisplayed( this.driver, replyButton );
 		await driverHelper.clickWhenClickable( this.driver, replyButton );
-		// await this.driver.sleep( 1000 );
-
 		await this._postComment( commentObj );
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, replyContent );
 	}

--- a/specs/wp-comments-spec.js
+++ b/specs/wp-comments-spec.js
@@ -53,8 +53,6 @@ describe( `[${ host }] Comments: (${ screenSize })`, function() {
 			const postEditorToolbar = await PostEditorToolbarComponent.Expect( driver );
 			await postEditorToolbar.ensureSaved();
 			await postEditorToolbar.publishAndViewContent( { useConfirmStep: true } );
-			// await postEditorToolbar.publishThePost( { useConfirmStep: true } );
-			// await postEditorToolbar.visitSite();
 		} );
 
 		step( 'Can post a comment', async function() {

--- a/specs/wp-comments-spec.js
+++ b/specs/wp-comments-spec.js
@@ -35,7 +35,7 @@ describe( `[${ host }] Comments: (${ screenSize })`, function() {
 		return fileDetails;
 	} );
 
-	describe( 'Commenting and replying to newly created post', function() {
+	describe( 'Commenting and replying to newly created post: @parallel @jetpack', function() {
 		before( async function() {
 			await driverManager.ensureNotLoggedIn( driver );
 		} );

--- a/specs/wp-comments-spec.js
+++ b/specs/wp-comments-spec.js
@@ -51,8 +51,10 @@ describe( `[${ host }] Comments: (${ screenSize })`, function() {
 
 		step( 'Can publish and visit site', async function() {
 			const postEditorToolbar = await PostEditorToolbarComponent.Expect( driver );
-			await postEditorToolbar.publishThePost( { useConfirmStep: true } );
-			await postEditorToolbar.visitSite();
+			await postEditorToolbar.ensureSaved();
+			await postEditorToolbar.publishAndViewContent( { useConfirmStep: true } );
+			// await postEditorToolbar.publishThePost( { useConfirmStep: true } );
+			// await postEditorToolbar.visitSite();
 		} );
 
 		step( 'Can post a comment', async function() {

--- a/specs/wp-comments-spec.js
+++ b/specs/wp-comments-spec.js
@@ -63,7 +63,7 @@ describe( `[${ host }] Comments: (${ screenSize })`, function() {
 		} );
 
 		step( 'Can post a reply', async function() {
-			await driver.sleep( 15000 ); // Wait to not to post too quickly
+			await driver.sleep( 10000 ); // Wait to not to post too quickly
 			const commentArea = await CommentsAreaComponent.Expect( driver );
 			await commentArea.reply(
 				{

--- a/specs/wp-comments-spec.js
+++ b/specs/wp-comments-spec.js
@@ -45,8 +45,6 @@ describe( `[${ host }] Comments: (${ screenSize })`, function() {
 			const editorPage = await EditorPage.Expect( driver );
 			await editorPage.enterTitle( blogPostTitle );
 			await editorPage.enterContent( blogPostQuote + '\n' );
-			await editorPage.enterPostImage( fileDetails );
-			await editorPage.waitUntilImageInserted( fileDetails );
 		} );
 
 		step( 'Can publish and visit site', async function() {
@@ -65,7 +63,7 @@ describe( `[${ host }] Comments: (${ screenSize })`, function() {
 		} );
 
 		step( 'Can post a reply', async function() {
-			await driver.sleep( 10000 ); // Wait to not to post too quickly
+			await driver.sleep( 15000 ); // Wait to not to post too quickly
 			const commentArea = await CommentsAreaComponent.Expect( driver );
 			await commentArea.reply(
 				{


### PR DESCRIPTION
Include comment test in CI runs

This test was added (and tested) in https://github.com/Automattic/wp-e2e-tests/pull/1406.

To test:

- run locally for WPCOM & JETPACK hosts: mocha specs/wp-comments-spec.js


CI test failures are not related to these changes.