### PR TITLE
Change the signup spec as we're going to rollout the checklist to other goal types

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -18,7 +18,6 @@ import CreateYourAccountPage from '../lib/pages/signup/create-your-account-page.
 import SignupProcessingPage from '../lib/pages/signup/signup-processing-page.js';
 import CheckOutPage from '../lib/pages/signup/checkout-page';
 import CheckOutThankyouPage from '../lib/pages/signup/checkout-thankyou-page.js';
-import ViewBlogPage from '../lib/pages/signup/view-blog-page.js';
 import LoginPage from '../lib/pages/login-page';
 import MagicLoginPage from '../lib/pages/magic-login-page';
 import ReaderPage from '../lib/pages/reader-page';
@@ -70,9 +69,8 @@ before( async function() {
 describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 	this.timeout( mochaTimeOut );
 
-	describe( 'Sign up for a free WordPress.com site (not blog) from the Jetpack new site page, and log in via a magic link @parallel @email', function() {
+	describe( 'Sign up for a free WordPress.com site from the Jetpack new site page, and log in via a magic link @parallel @email', function() {
 		const blogName = dataHelper.getNewBlogName();
-		let newBlogAddress = '';
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 		let magicLoginLink;
@@ -91,9 +89,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can see the "About" page, and enter some site information', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
-			await aboutPage.enterSiteDetails( blogName, 'Electronics', {
-				showcase: true,
-			} );
+			await aboutPage.enterSiteDetails( blogName, 'Electronics' );
 			return await aboutPage.submitForm();
 		} );
 
@@ -111,7 +107,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 					expectedBlogAddresses.indexOf( actualAddress ) > -1,
 					`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
 				);
-				newBlogAddress = actualAddress;
 				return await findADomainComponent.selectFreeAddress();
 			}
 		);
@@ -139,23 +134,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			}
 		);
 
-		step( 'Can see expected Welcome message, URL, title, ', async function() {
-			const viewBlogPage = await ViewBlogPage.Expect( driver );
-			await viewBlogPage.waitForTrampolineWelcomeMessage();
-			let displayed = await viewBlogPage.isTrampolineWelcomeDisplayed();
-			assert.strictEqual( displayed, true, 'The trampoline welcome message is not displayed' );
-			let url = await viewBlogPage.urlDisplayed();
-			assert.strictEqual(
-				url,
-				'https://' + newBlogAddress + '/',
-				'The displayed URL on the view blog page is not as expected'
-			);
-			let title = await viewBlogPage.title();
-			return assert.strictEqual(
-				title,
-				blogName,
-				'The expected blog title is not displaying correctly'
-			);
+		step( 'Can then see the onboarding checklist', async function() {
+			const checklistPage = await ChecklistPage.Expect( driver );
+			const header = await checklistPage.headerExists();
+			const subheader = await checklistPage.subheaderExists();
+
+			assert( header, 'The checklist header does not exist.' );
+
+			return assert( subheader, 'The checklist subheader does not exist.' );
 		} );
 
 		step( 'Can log out and request a magic link', async function() {
@@ -209,7 +195,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Sign up for a free blog and see the onboarding checklist @parallel', function() {
+	describe( 'Sign up for a free site and see the onboarding checklist @parallel', function() {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
@@ -224,9 +210,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can see the "About" page, and enter some site information', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
-			await aboutPage.enterSiteDetails( blogName, 'Electronics', {
-				share: true,
-			} );
+			await aboutPage.enterSiteDetails( blogName, 'Electronics' );
 			return await aboutPage.submitForm();
 		} );
 
@@ -302,7 +286,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Sign up for a non-blog site on a premium paid plan through main flow in USD currency @parallel', function() {
+	describe( 'Sign up for a site on a premium paid plan through main flow in USD currency @parallel', function() {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
@@ -322,192 +306,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can visit the start page', async function() {
 			await StartPage.Visit( driver, StartPage.getStartURL( { culture: locale } ) );
-		} );
-
-		step( 'Can see the "About" page, and enter some site information', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
-			return await aboutPage.enterSiteDetails( blogName, '', {
-				showcase: true,
-			} );
-		} );
-
-		step( 'Can accept defaults for about page', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
-			await aboutPage.submitForm();
-		} );
-
-		step( 'Can then see the domains page ', async function() {
-			const findADomainComponent = await FindADomainComponent.Expect( driver );
-			let displayed = await findADomainComponent.displayed();
-			return assert.strictEqual( displayed, true, 'The choose a domain page is not displayed' );
-		} );
-
-		step(
-			'Can search for a blog name, can see and select a free WordPress.com blog address in results',
-			async function() {
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
-				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
-				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
-					expectedBlogAddresses,
-					blogName
-				);
-				let actualAddress = await findADomainComponent.freeBlogAddress();
-				assert(
-					expectedBlogAddresses.indexOf( actualAddress ) > -1,
-					`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
-				);
-
-				return await findADomainComponent.selectFreeAddress();
-			}
-		);
-
-		step( 'Can then see the plans page and select the premium plan ', async function() {
-			const pickAPlanPage = await PickAPlanPage.Expect( driver );
-			let displayed = await pickAPlanPage.displayed();
-			assert.strictEqual( displayed, true, 'The pick a plan page is not displayed' );
-			return await pickAPlanPage.selectPremiumPlan();
-		} );
-
-		step( 'Can then enter account details', async function() {
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
-			return await createYourAccountPage.enterAccountDetailsAndSubmit(
-				emailAddress,
-				blogName,
-				passwordForTestAccounts
-			);
-		} );
-
-		step(
-			'Can then see the sign up processing page which will automatically move along',
-			async function() {
-				if ( global.browserName === 'Internet Explorer' ) {
-					return;
-				}
-				const signupProcessingPage = await SignupProcessingPage.Expect( driver );
-				return await signupProcessingPage.waitToDisappear();
-			}
-		);
-
-		step(
-			'Can then see the secure payment page with the premium plan in the cart',
-			async function() {
-				const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-				const premiumPlanInCart = await securePaymentComponent.containsPremiumPlan();
-				assert.strictEqual( premiumPlanInCart, true, "The cart doesn't contain the premium plan" );
-				const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
-				return assert.strictEqual(
-					numberOfProductsInCart,
-					1,
-					"The cart doesn't contain the expected number of products"
-				);
-			}
-		);
-
-		step(
-			'Can then see the secure payment page with the expected currency in the cart',
-			async function() {
-				const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-				if ( driverManager.currentScreenSize() === 'desktop' ) {
-					const totalShown = await securePaymentComponent.cartTotalDisplayed();
-					assert.strictEqual(
-						totalShown.indexOf( expectedCurrencySymbol ),
-						0,
-						`The cart total '${ totalShown }' does not begin with '${ expectedCurrencySymbol }'`
-					);
-				}
-				const paymentButtonText = await securePaymentComponent.paymentButtonText();
-				return assert(
-					paymentButtonText.includes( expectedCurrencySymbol ),
-					`The payment button text '${ paymentButtonText }' does not contain the expected currency symbol: '${ expectedCurrencySymbol }'`
-				);
-			}
-		);
-
-		step( 'Can enter and submit test payment details', async function() {
-			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
-			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-			await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
-			await securePaymentComponent.submitPaymentDetails();
-			return await securePaymentComponent.waitForPageToDisappear();
-		} );
-
-		step( 'Can see the secure check out thank you page', async function() {
-			const checkOutThankyouPage = await CheckOutThankyouPage.Expect( driver );
-			let displayed = await checkOutThankyouPage.displayed();
-			return assert.strictEqual( displayed, true, 'The checkout thank you page is not displayed' );
-		} );
-
-		step( 'Can delete the plan', async function() {
-			return ( async () => {
-				const navBarComponent = await NavBarComponent.Expect( driver );
-				await navBarComponent.clickProfileLink();
-				const profilePage = await ProfilePage.Expect( driver );
-				await profilePage.chooseManagePurchases();
-				const purchasesPage = await PurchasesPage.Expect( driver );
-				await purchasesPage.dismissGuidedTour();
-				await purchasesPage.selectPremiumPlan();
-				const managePurchasePage = await ManagePurchasePage.Expect( driver );
-				await managePurchasePage.chooseCancelAndRefund();
-				const cancelPurchasePage = await CancelPurchasePage.Expect( driver );
-				await cancelPurchasePage.clickCancelPurchase();
-				await cancelPurchasePage.completeCancellationSurvey();
-				return await cancelPurchasePage.waitAndDismissSuccessNotice();
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
-		} );
-
-		step( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				const navBarComponent = await NavBarComponent.Expect( driver );
-				await navBarComponent.clickProfileLink();
-				const profilePage = await ProfilePage.Expect( driver );
-				await profilePage.chooseAccountSettings();
-				const accountSettingsPage = await AccountSettingsPage.Expect( driver );
-				await accountSettingsPage.chooseCloseYourAccount();
-				const closeAccountPage = await CloseAccountPage.Expect( driver );
-				await closeAccountPage.chooseCloseAccount();
-				await closeAccountPage.enterAccountNameAndClose( blogName );
-				await LoggedOutMasterbarComponent.Expect( driver );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
-		} );
-	} );
-
-	describe( 'Sign up for a blog on a premium paid plan through main flow in USD currency @parallel', function() {
-		const blogName = dataHelper.getNewBlogName();
-		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
-		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-		const currencyValue = 'USD';
-		const expectedCurrencySymbol = '$';
-
-		before( async function() {
-			return await driverManager.ensureNotLoggedIn( driver );
-		} );
-
-		step( 'We can set the sandbox cookie for payments', async function() {
-			const wPHomePage = await WPHomePage.Visit( driver );
-			await wPHomePage.checkURL( locale );
-			await wPHomePage.setSandboxModeForPayments( sandboxCookieValue );
-			return await wPHomePage.setCurrencyForPayments( currencyValue );
-		} );
-
-		step( 'Can visit the start page', async function() {
-			await StartPage.Visit( driver, StartPage.getStartURL( { culture: locale } ) );
-		} );
-
-		step( 'Can see the "About" page, and enter some site information', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
-			return await aboutPage.enterSiteDetails( blogName, '', {
-				share: true,
-			} );
 		} );
 
 		step( 'Can accept defaults for about page', async function() {
@@ -692,9 +490,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can see the about page and accept defaults', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
-			await aboutPage.enterSiteDetails( blogName, '', {
-				showcase: true,
-			} );
 			return await aboutPage.submitForm();
 		} );
 
@@ -785,8 +580,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		step( 'Can see the secure check out thank you page', async function() {
-			return await CheckOutThankyouPage.Expect( driver );
+		step( 'Can then see the onboarding checklist', async function() {
+			const checklistPage = await ChecklistPage.Expect( driver );
+			const header = await checklistPage.headerExists();
+			const subheader = await checklistPage.subheaderExists();
+
+			assert( header, 'The checklist header does not exist.' );
+
+			return assert( subheader, 'The checklist subheader does not exist.' );
 		} );
 
 		step( 'Can delete the plan', async function() {
@@ -860,9 +661,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can see the about page and accept defaults', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
-			await aboutPage.enterSiteDetails( blogName, '', {
-				showcase: true,
-			} );
 			return await aboutPage.submitForm();
 		} );
 
@@ -957,8 +755,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		step( 'Can see the secure check out thank you page', async function() {
-			return await CheckOutThankyouPage.Expect( driver );
+		step( 'Can then see the onboarding checklist', async function() {
+			const checklistPage = await ChecklistPage.Expect( driver );
+			const header = await checklistPage.headerExists();
+			const subheader = await checklistPage.subheaderExists();
+
+			assert( header, 'The checklist header does not exist.' );
+
+			return assert( subheader, 'The checklist subheader does not exist.' );
 		} );
 
 		step( 'Can delete the plan', async function() {
@@ -1400,94 +1204,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Basic sign up for a free non-blog site @parallel @email @canary @ie11canary', function() {
-		const blogName = dataHelper.getNewBlogName();
-		let newBlogAddress = '';
-
-		before( async function() {
-			return await driverManager.ensureNotLoggedIn( driver );
-		} );
-
-		step( 'Can visit the start page', async function() {
-			await StartPage.Visit( driver, StartPage.getStartURL( { culture: locale } ) );
-		} );
-
-		step( 'Can see the about page and accept defaults', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
-			await aboutPage.enterSiteDetails( blogName, '', {
-				showcase: true,
-			} );
-			return await aboutPage.submitForm();
-		} );
-
-		step(
-			'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
-			async function() {
-				const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
-				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
-				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
-					expectedBlogAddresses,
-					blogName
-				);
-				let actualAddress = await findADomainComponent.freeBlogAddress();
-				assert(
-					expectedBlogAddresses.indexOf( actualAddress ) > -1,
-					`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
-				);
-				newBlogAddress = actualAddress;
-				return await findADomainComponent.selectFreeAddress();
-			}
-		);
-
-		step( 'Can then see the plans page and pick the free plan', async function() {
-			const pickAPlanPage = await PickAPlanPage.Expect( driver );
-			return await pickAPlanPage.selectFreePlan();
-		} );
-
-		step( 'Can then enter account details and continue', async function() {
-			const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
-			return await createYourAccountPage.enterAccountDetailsAndSubmit(
-				emailAddress,
-				blogName,
-				passwordForTestAccounts
-			);
-		} );
-
-		step(
-			"Can then see the sign up processing page -  will finish and show a 'Continue' button which is clicked",
-			async function() {
-				await SignupProcessingPage.hideFloatiesinIE11( driver );
-				const signupProcessingPage = await SignupProcessingPage.Expect( driver );
-				await signupProcessingPage.waitForContinueButtonToBeEnabled();
-				return await signupProcessingPage.continueAlong();
-			}
-		);
-
-		step( 'We are on the view blog page, can see trampoline, our URL and title', async function() {
-			const viewBlogPage = await ViewBlogPage.Expect( driver );
-			viewBlogPage.waitForTrampolineWelcomeMessage();
-			let displayed = await viewBlogPage.isTrampolineWelcomeDisplayed();
-			return assert.strictEqual(
-				displayed,
-				true,
-				'The trampoline welcome message is not displayed'
-			);
-		} );
-
-		step( 'Can see the correct blog URL displayed', async function() {
-			const viewBlogPage = await ViewBlogPage.Expect( driver );
-			const url = await viewBlogPage.urlDisplayed();
-			return assert.strictEqual(
-				url,
-				'https://' + newBlogAddress + '/',
-				'The displayed URL on the view blog page is not as expected'
-			);
-		} );
-	} );
-
-	describe( 'Basic sign up for a free blog @parallel @email', function() {
+	describe( 'Basic sign up for a free site @parallel @email @ie11canary', function() {
 		const blogName = dataHelper.getNewBlogName();
 
 		before( async function() {
@@ -1500,9 +1217,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can see the about page and accept defaults', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
-			await aboutPage.enterSiteDetails( blogName, '', {
-				share: true,
-			} );
 			return await aboutPage.submitForm();
 		} );
 


### PR DESCRIPTION
We no longer need to separate tests into the ones for blog and non-blog sites.

Related: https://github.com/Automattic/wp-calypso/pull/26721