### PR TITLE
Reader: add a check that a reader comment appears

### DIFF
--- a/lib/pages/reader-page.js
+++ b/lib/pages/reader-page.js
@@ -32,6 +32,13 @@ export default class ReaderPage extends AsyncBaseContainer {
 		return await driverHelper.clickWhenClickable( this.driver, by.css( '.comments__form button' ) );
 	}
 
+	async waitForCommentToAppear( comment ) {
+		return await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			by.xpath( `//div[@class='comments__comment-content']//p[text()='${ comment }']` )
+		);
+	}
+
 	static getReaderURL() {
 		return dataHelper.getCalypsoURL( 'read' );
 	}

--- a/specs/wp-reader-spec.js
+++ b/specs/wp-reader-spec.js
@@ -53,10 +53,11 @@ describe( 'Reader: (' + screenSize + ') @parallel', function() {
 				);
 			} );
 
-			step( 'Can comment on the latest post', async function() {
+			step( 'Can comment on the latest post and see the comment appear', async function() {
 				this.comment = dataHelper.randomPhrase();
 				const readerPage = await ReaderPage.Expect( driver );
 				await readerPage.commentOnLatestPost( this.comment );
+				await readerPage.waitForCommentToAppear( this.comment );
 			} );
 
 			describe( 'Delete the new comment', function() {


### PR DESCRIPTION
Fixes #603

It looks like https://github.com/Automattic/wp-calypso/issues/14781 is fixed so we can add a check back in

cc @rachelmcr