### PR TITLE
Replace nudgeAPalooza 5-way test with 4 smaller 2-way tests

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -78,6 +78,9 @@
 		[ "aboutSuggestionMatches_20180704", "control" ],
 		[ "includeDotBlogSubdomainV2_20180813", "no" ],
 		[ "gSuiteDiscountV2_20180822", "control" ],
-		[ "nudgeAPalooza_20180806", "control" ]
+		[ "themesNudgesUpdates_20180824", "control" ],
+		[ "pluginsUpsellLandingPage_20180824", "control" ],
+		[ "themesUpsellLandingPage_20180824", "control" ],
+		[ "plansBannerUpsells_20180824", "control" ]
 	]
 }


### PR DESCRIPTION
This PR adds a set of tests that nudgeAPalooza was split into. After initial round of testing, we need to adjust course a bit and perform a few detailed 50/50 tests instead of one large test. More details in comments under this post: p8Eqe3-sy-p2.

Related PRs:

https://github.com/Automattic/wp-calypso/pull/26868
https://github.com/Automattic/wp-calypso/pull/26869
https://github.com/Automattic/wp-calypso/pull/26873
https://github.com/Automattic/wp-calypso/pull/26877