### PR TITLE
Re-enable sign up activation emails in sign up tests

### DIFF
--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -329,9 +329,9 @@ export default class EditorPage extends AsyncBaseContainer {
 	}
 
 	async publishEnabled() {
-		return await driverHelper.isEventuallyPresentAndDisplayed(
+		return await driverHelper.isElementPresent(
 			this.driver,
-			'.editor-publish-button:not([disabled])'
+			by.css( '.editor-publish-button:not([disabled])' )
 		);
 	}
 

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -4,6 +4,7 @@ import webdriver from 'selenium-webdriver';
 
 import * as driverHelper from '../driver-helper.js';
 import * as driverManager from '../driver-manager.js';
+import * as dataHelper from '../data-helper';
 
 const by = webdriver.By;
 const until = webdriver.until;
@@ -11,8 +12,11 @@ const until = webdriver.until;
 import AsyncBaseContainer from '../async-base-container';
 
 export default class EditorPage extends AsyncBaseContainer {
-	constructor( driver ) {
-		super( driver, by.css( '.post-editor' ) );
+	constructor( driver, url ) {
+		if ( ! url ) {
+			url = EditorPage._getUrl();
+		}
+		super( driver, by.css( '.post-editor' ), url );
 		this.editorFrameName = by.css( '.mce-edit-area iframe' );
 	}
 
@@ -338,5 +342,9 @@ export default class EditorPage extends AsyncBaseContainer {
 				'.post-editor__inner .post-editor__content .editor-action-bar .editor-status-label.is-future'
 			)
 		);
+	}
+
+	static _getUrl() {
+		return dataHelper.getCalypsoURL( 'post' );
 	}
 }

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -204,6 +204,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
+		const blogPostTitle = dataHelper.randomPhrase();
+		const blogPostQuote = dataHelper.randomPhrase();
 		let activationLink;
 
 		before( async function() {
@@ -272,9 +274,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can not publish until email is confirmed', async function() {
-			const blogPostTitle = dataHelper.randomPhrase();
-			const blogPostQuote = dataHelper.randomPhrase();
-
 			const editorPage = await EditorPage.Visit( driver );
 			await editorPage.enterTitle( blogPostTitle );
 			await editorPage.enterContent( blogPostQuote + '\n' );
@@ -305,9 +304,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can publish once email is confirmed', async function() {
-			const blogPostTitle = dataHelper.randomPhrase();
-			const blogPostQuote = dataHelper.randomPhrase();
-
 			const editorPage = await EditorPage.Visit( driver );
 			await editorPage.enterTitle( blogPostTitle );
 			await editorPage.enterContent( blogPostQuote + '\n' );

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -200,7 +200,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe.only( 'Sign up for a free site, see the onboarding checklist, activate email and can publish @parallel', function() {
+	describe( 'Sign up for a free site, see the onboarding checklist, activate email and can publish @parallel', function() {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -154,8 +154,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			const emailClient = new EmailClient( signupInboxId );
 			const validator = emails => emails.find( email => email.subject.includes( 'WordPress.com' ) );
 			let emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
-			//Disabled due to a/b test on activation email. See https://github.com/Automattic/wp-e2e-tests/issues/819
-			//assert.strictEqual( emails.length, 2, 'The number of newly registered emails is not equal to 2 (activation and magic link)' );
+			assert.strictEqual(
+				emails.length,
+				2,
+				'The number of newly registered emails is not equal to 2 (activation and magic link)'
+			);
 			for ( let email of emails ) {
 				if ( email.subject.includes( 'WordPress.com' ) ) {
 					return ( magicLoginLink = email.html.links[ 0 ].href );


### PR DESCRIPTION
We no longer delay any sign up emails

Fixes #819

**Testing instructions**

Make sure the new scenario works desktop and mobile