### PR TITLE
Open the live demo with the theme screenshot

### DIFF
--- a/lib/pages/theme-detail-page.js
+++ b/lib/pages/theme-detail-page.js
@@ -12,7 +12,7 @@ export default class ThemeDetailPage extends AsyncBaseContainer {
 	async openLiveDemo() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( 'a.theme__sheet-preview-link,li.is-theme-preview a' )
+			By.css( '.theme__sheet-screenshot' )
 		);
 	}
 


### PR DESCRIPTION
The Previewing Themes test occasionally fails waiting for the live demo link to be clickable:

https://circleci.com/gh/Automattic/wp-e2e-tests/22364

I'm not entirely sure why that fails — the screenshot and video of the failure both show the link and no apparent cause for it not being clickable. However, as noted at https://github.com/Automattic/wp-calypso/issues/25720#issuecomment-399914516 that live demo link was "low priority" (added mostly for accessibility reasons) since the screenshot is tappable, so I'm switching back to opening the live demo with the theme screenshot instead.