### PR TITLE
Temporarily remove sign up canary test

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1204,7 +1204,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Basic sign up for a free site @parallel @email @ie11canary @canary', function() {
+	describe( 'Basic sign up for a free site @parallel @email @ie11canary', function() {
 		const blogName = dataHelper.getNewBlogName();
 
 		before( async function() {


### PR DESCRIPTION
This is causing problems when run against wpcalypso.wordpress.com

See https://github.com/Automattic/wp-e2e-tests/issues/434