### PR TITLE
Activity Log now accessed via side menu

### DIFF
--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -77,6 +77,11 @@ export default class SidebarComponent extends AsyncBaseContainer {
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 
+	async selectActivity() {
+		const selector = By.css( '.sites-navigation [data-tip-target="activity"] a' );
+		return await driverHelper.clickWhenClickable( this.driver, selector );
+	}
+
 	async ensureSidebarMenuVisible() {
 		const allSitesSelector = By.css( '.current-section a' );
 		const sidebarSelector = By.css( '.sidebar' );

--- a/lib/pages/stats-page.js
+++ b/lib/pages/stats-page.js
@@ -11,11 +11,6 @@ export default class StatsPage extends AsyncBaseContainer {
 		super( driver, By.css( '.stats-module' ) );
 	}
 
-	async openActivity() {
-		await this._expandNavIfMobile();
-		await driverHelper.clickWhenClickable( this.driver, By.css( 'a[href*=activity]' ) );
-	}
-
 	async _expandNavIfMobile() {
 		if ( driverManager.currentScreenSize() !== 'mobile' ) {
 			return await this.waitForPage();

--- a/specs-jetpack-calypso/wp-pressable-nux-spec.js
+++ b/specs-jetpack-calypso/wp-pressable-nux-spec.js
@@ -12,7 +12,6 @@ import * as dataHelper from '../lib/data-helper';
 import PressableNUXFlow from '../lib/flows/pressable-nux-flow';
 import ReaderPage from '../lib/pages/reader-page';
 import SidebarComponent from '../lib/components/sidebar-component';
-import StatsPage from '../lib/pages/stats-page';
 import NavBarComponent from '../lib/components/nav-bar-component';
 import JetpackConnectFlow from '../lib/flows/jetpack-connect-flow';
 import LoginFlow from '../lib/flows/login-flow';
@@ -102,9 +101,7 @@ if ( host === 'PRESSABLE' ) {
 				const sidebarComponent = await SidebarComponent.Expect( driver );
 				await sidebarComponent.selectSiteSwitcher();
 				await sidebarComponent.searchForSite( this.siteName );
-				await sidebarComponent.selectStats();
-				const statsPage = await StatsPage.Expect( driver );
-				return await statsPage.openActivity();
+				await sidebarComponent.selectActivity();
 			} );
 
 			// Disabled due to to longer time is required to make a backup.

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -11,7 +11,6 @@ import ViewPostPage from '../lib/pages/view-post-page.js';
 import NotFoundPage from '../lib/pages/not-found-page.js';
 import PostsPage from '../lib/pages/posts-page.js';
 import ReaderPage from '../lib/pages/reader-page';
-import StatsPage from '../lib/pages/stats-page';
 import ActivityPage from '../lib/pages/stats/activity-page';
 import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
 
@@ -450,9 +449,7 @@ describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			await navBarComponent.clickMySites();
 			let sidebarComponent = await SidebarComponent.Expect( driver );
 			await sidebarComponent.ensureSidebarMenuVisible();
-			await sidebarComponent.selectStats();
-			const statsPage = await StatsPage.Expect( driver );
-			await statsPage.openActivity();
+			await sidebarComponent.selectActivity();
 			const activityPage = await ActivityPage.Expect( driver );
 			let displayed = await activityPage.postTitleDisplayed( blogPostTitle );
 			return assert(


### PR DESCRIPTION
Activity log is now via the side menu not via stats

Associated wp-calypso change: https://github.com/Automattic/wp-calypso/pull/26941

This should be merged straight after the wp-calypso change is merged