### PR TITLE
Remove unused approvePushToken function

### DIFF
--- a/lib/push-client.js
+++ b/lib/push-client.js
@@ -1,39 +1,6 @@
 /** @format */
 
 import { listen } from 'push-receiver';
-// import request from 'request-promise';
-
-// /**
-//  * Marks a push token as approved on WPCOM API
-//  * @param {String} pushToken push token that recieved via a push notification on an app
-//  * @param {String} bearerToken user bearer token to be used with the API
-//  * @returns {Promise} a request result promise
-//  */
-// TODO: Remove promise when it's enabled
-// export const approvePushToken = ( pushToken, bearerToken ) =>
-// 	request( {
-// 		url: 'https://public-api.wordpress.com/rest/v1.1/me/two-step/push-authentication',
-// 		method: 'POST',
-// 		headers: {
-// 			Authorization: `Bearer ${ bearerToken }`,
-// 			'Content-Type': 'application/x-www-form-urlencoded',
-// 			Accept: 'application/json',
-// 		},
-// 		form: {
-// 			action: 'authorize_login',
-// 			push_token: pushToken,
-// 		},
-// 	} ).then( responseString => {
-// 		const res = JSON.parse( responseString );
-// 		if ( ! res.success ) {
-// 			return Promise.reject(
-// 				new Error(
-// 					`Failed to authnticate via supplied push token ${ pushToken } got ${ responseString }`
-// 				)
-// 			);
-// 		}
-// 		return true;
-// 	} );
 
 /**
  * Extracts specific appData value and notification's persistent id


### PR DESCRIPTION
Part of cleaning TODOs in our e2e tests. 