### PR TITLE
Add readerSearchPlaceholder to known tests

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -71,7 +71,7 @@
 		"pluginsUpsellLandingPage",
 		"themesUpsellLandingPage",
 		"plansBannerUpsells",
-                "readerSearchPlaceholder"
+		"readerSearchPlaceholder"
 	],
 	"overrideABTests": [
 		[ "businessPlanDescriptionAT_20170605", "original" ],

--- a/config/default.json
+++ b/config/default.json
@@ -70,7 +70,8 @@
 		"themesNudgesUpdates",
 		"pluginsUpsellLandingPage",
 		"themesUpsellLandingPage",
-		"plansBannerUpsells"
+		"plansBannerUpsells",
+                "readerSearchPlaceholder"
 	],
 	"overrideABTests": [
 		[ "businessPlanDescriptionAT_20170605", "original" ],


### PR DESCRIPTION
This is a new A/B test to be added in https://github.com/Automattic/wp-calypso/pull/26969 (copy test only).