### PR TITLE
Disable Pressable NUX flow

### DIFF
--- a/specs-jetpack-calypso/wp-pressable-nux-spec.js
+++ b/specs-jetpack-calypso/wp-pressable-nux-spec.js
@@ -24,7 +24,10 @@ const host = dataHelper.getJetpackHost();
 
 let driver;
 
-if ( host === 'PRESSABLE' ) {
+// Disabled due to p1535659602000200-slack-e2e-testing-discuss
+// tl;dr: There is a bug in my.pressable.com which cause some noise/warnings/errors
+// We shouldn't create new Pressable sites for every test.
+if ( host === false ) {
 	before( async function() {
 		this.timeout( startBrowserTimeoutMS );
 		driver = await driverManager.startBrowser();

--- a/specs-jetpack-calypso/wp-pressable-nux-spec.js
+++ b/specs-jetpack-calypso/wp-pressable-nux-spec.js
@@ -27,7 +27,7 @@ let driver;
 // Disabled due to p1535659602000200-slack-e2e-testing-discuss
 // tl;dr: There is a bug in my.pressable.com which cause some noise/warnings/errors
 // We shouldn't create new Pressable sites for every test.
-if ( host === false ) {
+if ( false ) {
 	before( async function() {
 		this.timeout( startBrowserTimeoutMS );
 		driver = await driverManager.startBrowser();


### PR DESCRIPTION
Disabling Pressable NUX flow due to p1535659602000200-slack-e2e-testing-discuss.

It might be re-enabled after https://github.com/Automattic/wp-e2e-tests/issues/1453