### PR TITLE
Scroll into view before clicking "Themes" button in sidebar

### DIFF
--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -40,6 +40,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 
 	async selectThemes() {
 		const selector = By.css( '.sites-navigation [data-tip-target="themes"] a[href*=themes]' );
+		await driverHelper.scrollIntoView( this.driver, selector );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 


### PR DESCRIPTION
When the "Activity" button was added into sidebar (https://github.com/Automattic/wp-calypso/pull/26941 / https://github.com/Automattic/wp-e2e-tests/pull/1446) - it makes the "Themes" button not visible anymore, which cause some Jetpack test failures. This PR makes sure we scroll before attempting to click.   
Failed CI job: https://circleci.com/gh/Automattic/wp-e2e-tests-jetpack-be/289

Test:
Make sure CI tests are green