### PR TITLE
Remove page refresh when a/b test values are set

### DIFF
--- a/lib/async-base-container.js
+++ b/lib/async-base-container.js
@@ -100,8 +100,6 @@ export default class AsyncBaseContainer {
 	async setABTestControlGroupsInLocalStorage() {
 		const overrideABTests = config.get( 'overrideABTests' );
 
-		const startUrl = await this.driver.getCurrentUrl();
-
 		const expectedABTestValue = overrideABTests
 			.map( entry => {
 				return '"' + entry[ 0 ] + '":"' + entry[ 1 ] + '"';
@@ -113,8 +111,6 @@ export default class AsyncBaseContainer {
 		await this.driver.executeScript(
 			`window.localStorage.setItem('ABTests','{${ expectedABTestValue }}');`
 		);
-
-		await this.driver.get( startUrl );
 
 		let abtestsValue = await this.driver.executeScript( 'return window.localStorage.ABTests;' );
 		if ( ! isEqual( JSON.parse( abtestsValue ), JSON.parse( `{${ expectedABTestValue }}` ) ) ) {


### PR DESCRIPTION
The page refresh was causing tests to fail on [this PR](https://github.com/Automattic/wp-calypso/pull/26942). Removing the refresh causes the tests to pass and all other tests pass as well. 

In the issue above, the query string was removed during a new redirect. When the page is reloaded without the query string it doesn't know the context anymore and since the url we saved doesn't have it, it causes a different redirect. 

TO TEST:
Run test suite and ensure that all pass and that there aren't issues with expected A/B tests not matching actual