### PR TITLE
Add LGTM code quality badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Automated end-to-end acceptance tests for the [wp-calypso](https://github.com/Automattic/wp-calypso) client and WordPress.com in general.
 
 [![Circle CI](https://circleci.com/gh/Automattic/wp-e2e-tests/tree/master.svg?style=svg)](https://circleci.com/gh/Automattic/wp-e2e-tests/tree/master)
+[![Code Quality: Javascript](https://img.shields.io/lgtm/grade/javascript/g/Automattic/wp-e2e-tests.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/Automattic/wp-e2e-tests/context:javascript)
+[![Total Alerts](https://img.shields.io/lgtm/alerts/g/Automattic/wp-e2e-tests.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/Automattic/wp-e2e-tests/alerts)
 
 ## Table of contents
 


### PR DESCRIPTION
Hi there!

I thought you might be interested in adding these [code quality badges](https://lgtm.com/projects/g/Automattic/wp-e2e-tests/ci/#badges) to your project. They will indicate a very high code quality to potential users and contributors.
To get an idea of the analyses reflected by these grades, check the [alerts discovered by LGTM](https://lgtm.com/projects/g/Automattic/wp-e2e-tests).

N.B.: I am on the team behind LGTM.com, I'd appreciate your feedback on this initiative, whether you're interested or not, if you find time to drop me a line. Thanks.
