### PR TITLE
Add editor canary test back

### DIFF
--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -366,7 +366,7 @@ describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 		} );
 	} );
 
-	describe( 'Basic Public Post @parallel @jetpack', function() {
+	describe( 'Basic Public Post @parallel @jetpack @canary', function() {
 		before( async function() {
 			await driverManager.ensureNotLoggedIn( driver );
 		} );


### PR DESCRIPTION
This was accidentally removed in https://github.com/Automattic/wp-e2e-tests/pull/1444/files#diff-69942226e67f0512a0f85377551dc30eL370