### PR TITLE
Select a Jetpack site before navigating to A/L

### DIFF
--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -448,6 +448,11 @@ describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 			await navBarComponent.clickMySites();
 			let sidebarComponent = await SidebarComponent.Expect( driver );
 			await sidebarComponent.ensureSidebarMenuVisible();
+
+			if ( host !== 'WPCOM' ) {
+				await sidebarComponent.selectSite( dataHelper.getJetpackSiteName() );
+			}
+
 			await sidebarComponent.selectActivity();
 			const activityPage = await ActivityPage.Expect( driver );
 			let displayed = await activityPage.postTitleDisplayed( blogPostTitle );


### PR DESCRIPTION
A/L test for Jetpack BE target is failing because the test is expecting to see a change on "default" site, which is not true for BE site. 

This PR adds optional (and ugly) step for Jetpack specific targets, which fixes an issue. 

To test:
- run `JETPACKHOST=PRESSABLEBLEEDINGEDGE npx mocha specs/wp-post-editor-spec.js -g 'Check Activity Log for Public Post'`
- run `JETPACKHOST=PRESSABLE npx mocha specs/wp-post-editor-spec.js -g 'Check Activity Log for Public Post'`