### PR TITLE
Disable theme tests that is failing

### DIFF
--- a/specs/wp-theme-multisite-spec.js
+++ b/specs/wp-theme-multisite-spec.js
@@ -149,7 +149,7 @@ describe( `[${ host }] Themes: All sites (${ screenSize })`, function() {
 					return await this.siteSelector.ok();
 				} );
 
-				describe( 'Successful activation dialog', function() {
+				xdescribe( 'Successful activation dialog', function() {
 					step( 'should show the successful activation dialog', async function() {
 						const themeDialogComponent = await ThemeDialogComponent.Expect( driver );
 						return await themeDialogComponent.goToThemeDetail();


### PR DESCRIPTION
This test was broken by https://github.com/Automattic/wp-calypso/pull/27160

Disabling for now