### PR TITLE
Fix test run videos

### DIFF
--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -145,7 +145,8 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 				}
 
 				if ( global.displayNum ) {
-					options.addArguments( `--display=:${ global.displayNum }` );
+					// Do not update spacing in the variable below. It will break test video
+					options.addArguments( `--display=:${global.displayNum}` );
 				}
 
 				const service = new chrome.ServiceBuilder( chromedriver.path ).build();

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -292,7 +292,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			let emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
 			assert.strictEqual(
 				emails.length,
-				1,
+				2,
 				'The number of newly registered emails is not equal to 1 (activation)'
 			);
 			activationLink = emails[ 0 ].html.links[ 0 ].href;

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -292,7 +292,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			let emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
 			assert.strictEqual(
 				emails.length,
-				2,
+				1,
 				'The number of newly registered emails is not equal to 1 (activation)'
 			);
 			activationLink = emails[ 0 ].html.links[ 0 ].href;


### PR DESCRIPTION
The tests are showing just a black screen. It seems to be related to a change that added spaces in the brackets for a variable the screen recording was using. I changed it back and added a note that it should not be adjusted. 

I added a broken test in https://github.com/Automattic/wp-e2e-tests/commit/364a42a6359ef47ec4ecea833d04a14a7ea02019 to verify the fix. 