### PR TITLE
Simulate browser Back button during sign up

### DIFF
--- a/lib/pages/signup/about-page.js
+++ b/lib/pages/signup/about-page.js
@@ -43,4 +43,30 @@ export default class AboutPage extends AsyncBaseContainer {
 			await driverHelper.setCheckbox( this.driver, By.css( '#promote' ) );
 		}
 	}
+
+	async unsetCheckBox( {
+		showcase = false,
+		share = false,
+		sell = false,
+		educate = false,
+		promote = false,
+	} ) {
+		// Wait before click and unset checkbox
+		await driverHelper.waitForFieldClearable( this.driver, By.css( '#siteTitle' ) );
+		if ( showcase === true ) {
+			await driverHelper.unsetCheckbox( this.driver, By.css( '#showcase' ) );
+		}
+		if ( share === true ) {
+			await driverHelper.unsetCheckbox( this.driver, By.css( '#share' ) );
+		}
+		if ( sell === true ) {
+			await driverHelper.unsetCheckbox( this.driver, By.css( '#sell' ) );
+		}
+		if ( educate === true ) {
+			await driverHelper.unsetCheckbox( this.driver, By.css( '#educate' ) );
+		}
+		if ( promote === true ) {
+			await driverHelper.unsetCheckbox( this.driver, By.css( '#promote' ) );
+		}
+	}
 }

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -361,6 +361,10 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can accept defaults for about page', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
+			await aboutPage.enterSiteDetails( 'Step Back', 'Store Test Topic', { sell: true } );
+			await aboutPage.submitForm();
+			await driver.navigate().back();
+			await aboutPage.unsetCheckBox( { sell: true } );
 			await aboutPage.submitForm();
 		} );
 


### PR DESCRIPTION
Regarding request #832 we needed to simulate browser 'Back' button during sign up flow. Two options were here:
1. Add completely new _sign up_ test with 'Back' button option and see is it working
2. Simulate 'Back' in some existing _sign up_ test

I choose second one since tests execution is longer for only 1-2 seconds.

Steps added:
- select store during sign up
- submit form
- press browser's 'Back' button
- unselect store

Test should continue execution as usual.

Fixes #832