### PR TITLE
Add prettier ignore command to video recording arguments

### DIFF
--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -146,6 +146,7 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 
 				if ( global.displayNum ) {
 					// Do not update spacing in the variable below. It will break test video
+					// prettier-ignore
 					options.addArguments( `--display=:${global.displayNum}` );
 				}
 


### PR DESCRIPTION
This just makes sure that changes to `lib/driver-manager.js` don't run prettier breaking the line:

`options.addArguments( `--display=:${global.displayNum}` );`

**Testing Instructions**

1. Make local changes to `lib/driver-manager.js`
2. Run prettier formatting
3. Make sure there are no spaces in `options.addArguments( `--display=:${global.displayNum}` );`