### PR TITLE
Add support for avoiding user first sign up flow

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -73,7 +73,8 @@
 		"plansBannerUpsells",
 		"readerSearchPlaceholder",
 		"showPlanCreditsApplied",
-		"domainManagementSuggestion"
+		"domainManagementSuggestion",
+		"userFirstSignup"
 	],
 	"overrideABTests": [
 		[ "businessPlanDescriptionAT_20170605", "original" ],
@@ -92,6 +93,7 @@
 		[ "plansBannerUpsells_20180824", "control" ],
 		[ "readerSearchPlaceholder_20180830", "justSearch" ],
 		[ "showPlanCreditsApplied_20180903", "control" ],
-		[ "domainManagementSuggestion_20180905", "domainsbot" ]
+		[ "domainManagementSuggestion_20180905", "domainsbot" ],
+		[ "userFirstSignup_20180913", "default" ]
 	]
 }

--- a/lib/pages/signup/jetpack-add-new-site-page.js
+++ b/lib/pages/signup/jetpack-add-new-site-page.js
@@ -14,6 +14,11 @@ export default class JetpackAddNewSitePage extends AsyncBaseContainer {
 		super( driver, By.css( '.jetpack-new-site__main' ), url );
 	}
 
+	async _postInit() {
+		await this.setABTestControlGroupsInLocalStorage();
+		return await this.driver.navigate().refresh();
+	}
+
 	async createNewWordPressDotComSite() {
 		const wpComButtonSelector =
 			screenSize === 'mobile'

--- a/lib/pages/signup/start-page.js
+++ b/lib/pages/signup/start-page.js
@@ -8,8 +8,8 @@ import AsyncBaseContainer from '../../async-base-container';
 
 export default class StartPage extends AsyncBaseContainer {
 	constructor( driver, url ) {
-		const loggedOutRootURL = dataHelper.getCalypsoURL();
-		super( driver, By.css( '#wpcom' ), loggedOutRootURL );
+		const loggedOutThemesURL = dataHelper.getCalypsoURL( 'themes' );
+		super( driver, By.css( '#wpcom' ), loggedOutThemesURL );
 		this.startURL = url;
 	}
 

--- a/lib/pages/signup/start-page.js
+++ b/lib/pages/signup/start-page.js
@@ -3,15 +3,20 @@
 import { By } from 'selenium-webdriver';
 
 import * as dataHelper from '../../data-helper';
+import * as driverHelper from '../../driver-helper';
 import AsyncBaseContainer from '../../async-base-container';
 
 export default class StartPage extends AsyncBaseContainer {
 	constructor( driver, url ) {
-		super( driver, By.css( '.step-wrapper' ), url );
+		const loggedOutRootURL = dataHelper.getCalypsoURL();
+		super( driver, By.css( '#wpcom' ), loggedOutRootURL );
+		this.startURL = url;
 	}
 
 	async _postInit() {
-		return await this.setABTestControlGroupsInLocalStorage();
+		await this.setABTestControlGroupsInLocalStorage();
+		await this.driver.get( this.startURL );
+		return await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.step-wrapper' ) );
 	}
 
 	static getStartURL( { culture = 'en', flow = '', query = '' } = {} ) {


### PR DESCRIPTION
This makes sure we can override the user first sign up flow in https://github.com/Automattic/wp-calypso/pull/27254

Since we don't refresh the start page after setting the AB test groups this means the user first test may show and then the tests will fail

What this does instead:

1. Visits wordpress.com/themes (or whichever env it is using) and sets AB test groups
2. Then visits wordpress.com/start - this will redirect to appropriate start page - this may be user first sign up if the flow is set that way

**To Test**

Run against https://github.com/Automattic/wp-calypso/pull/27254 and make sure sign ups work and we don't encounter the user first sign up flow