### PR TITLE
Scroll Viewers

### DIFF
--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -408,11 +408,11 @@ export async function refreshIfJNError( driver, timeout = 2000 ) {
 	return await refreshIfNeeded();
 }
 
-export async function scrollIntoView( driver, selector ) {
+export async function scrollIntoView( driver, selector, block = 'center', inline = 'center' ) {
 	let selectorElement = await driver.findElement( selector );
 
 	return await driver.executeScript(
-		'arguments[0].scrollIntoView( { block: "center", inline: "center" } )',
+		'arguments[0].scrollIntoView( { block: "' + block + '", inline: "' + inline + '" } )',
 		selectorElement
 	);
 }

--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -408,11 +408,20 @@ export async function refreshIfJNError( driver, timeout = 2000 ) {
 	return await refreshIfNeeded();
 }
 
-export async function scrollIntoView( driver, selector, block = 'center', inline = 'center' ) {
+export async function scrollIntoView( driver, selector ) {
 	let selectorElement = await driver.findElement( selector );
 
 	return await driver.executeScript(
-		'arguments[0].scrollIntoView( { block: "' + block + '", inline: "' + inline + '" } )',
+		'arguments[0].scrollIntoView( { block: "center", inline: "center" } )',
+		selectorElement
+	);
+}
+
+export async function scrollToBottom( driver, selector ) {
+	let selectorElement = await driver.findElement( selector );
+
+	return await driver.executeScript(
+		'arguments[0].scrollIntoView( { block: "end", inline: "center" } )',
 		selectorElement
 	);
 }

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -146,6 +146,7 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 
 				if ( global.displayNum ) {
 					// Do not update spacing in the variable below. It will break test video
+					// prettier-ignore
 					options.addArguments( `--display=:${global.displayNum}` );
 				}
 

--- a/lib/pages/people-page.js
+++ b/lib/pages/people-page.js
@@ -57,10 +57,32 @@ export default class PeoplePage extends AsyncBaseContainer {
 	}
 
 	async viewerDisplayed( username ) {
+		await DriverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.people-selector__infinite-list' )
+		);
+		await DriverHelper.scrollIntoView(
+			this.driver,
+			By.css( '.people-selector__infinite-list' ),
+			'end'
+		);
 		return DriverHelper.isEventuallyPresentAndDisplayed(
 			this.driver,
 			By.css( `.people-profile__login[data-e2e-login="${ username }"]` )
 		);
+		// for ( let i = 0; i < 10; i++ ) {
+		// 	let displayed = DriverHelper.isEventuallyPresentAndDisplayed(
+		// 		this.driver,
+		// 		By.css( `.people-profile__login[data-e2e-login="${ username }"]` )
+		// 	);
+		// 	if ( displayed ) {
+		// 		return displayed;
+		// 	}
+		// 	else {
+		// 		await DriverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.people-selector__infinite-list' ) );
+		// 		await DriverHelper.scrollIntoView( this.driver, By.css( '.people-selector__infinite-list' ), 'end' );
+		// 	}
+		// }
 	}
 
 	async removeUserByName( username ) {

--- a/lib/pages/people-page.js
+++ b/lib/pages/people-page.js
@@ -29,7 +29,7 @@ export default class PeoplePage extends AsyncBaseContainer {
 			this.driver,
 			By.css( '.section-nav-tabs__list a[href*=viewers]' )
 		);
-		return this.waitForSearchResults();
+		return await this.waitForSearchResults();
 	}
 
 	async selectEmailFollowers() {

--- a/lib/pages/people-page.js
+++ b/lib/pages/people-page.js
@@ -57,12 +57,30 @@ export default class PeoplePage extends AsyncBaseContainer {
 	}
 
 	async viewerDisplayed( username ) {
-		await DriverHelper.scrollToBottom( this.driver, By.css( '.people-selector__infinite-list' ) );
-		return await DriverHelper.isEventuallyPresentAndDisplayed(
-			this.driver,
-			By.css( `.people-profile__login[data-e2e-login="${ username }"]` ),
-			500
+		await DriverHelper.isEventuallyPresentAndDisplayed( this.driver, By.css( '.count' ) );
+		let noOfViewers = parseInt(
+			await this.driver.findElement( By.css( '.section-header__label .count' ) ).getText()
 		);
+
+		let retries = Math.round( noOfViewers / 10 );
+		let displayed;
+
+		for ( let i = 0; i < retries; i++ ) {
+			displayed = await DriverHelper.isEventuallyPresentAndDisplayed(
+				this.driver,
+				By.css( `.people-profile__login[data-e2e-login="${ username }"]` ),
+				500
+			);
+			if ( displayed ) {
+				break;
+			} else {
+				await DriverHelper.scrollToBottom(
+					this.driver,
+					By.css( '.people-selector__infinite-list' )
+				);
+			}
+		}
+		return displayed;
 	}
 
 	async removeUserByName( username ) {

--- a/lib/pages/people-page.js
+++ b/lib/pages/people-page.js
@@ -57,32 +57,12 @@ export default class PeoplePage extends AsyncBaseContainer {
 	}
 
 	async viewerDisplayed( username ) {
-		await DriverHelper.waitTillPresentAndDisplayed(
+		await DriverHelper.scrollToBottom( this.driver, By.css( '.people-selector__infinite-list' ) );
+		return await DriverHelper.isEventuallyPresentAndDisplayed(
 			this.driver,
-			By.css( '.people-selector__infinite-list' )
+			By.css( `.people-profile__login[data-e2e-login="${ username }"]` ),
+			500
 		);
-		await DriverHelper.scrollIntoView(
-			this.driver,
-			By.css( '.people-selector__infinite-list' ),
-			'end'
-		);
-		return DriverHelper.isEventuallyPresentAndDisplayed(
-			this.driver,
-			By.css( `.people-profile__login[data-e2e-login="${ username }"]` )
-		);
-		// for ( let i = 0; i < 10; i++ ) {
-		// 	let displayed = DriverHelper.isEventuallyPresentAndDisplayed(
-		// 		this.driver,
-		// 		By.css( `.people-profile__login[data-e2e-login="${ username }"]` )
-		// 	);
-		// 	if ( displayed ) {
-		// 		return displayed;
-		// 	}
-		// 	else {
-		// 		await DriverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.people-selector__infinite-list' ) );
-		// 		await DriverHelper.scrollIntoView( this.driver, By.css( '.people-selector__infinite-list' ), 'end' );
-		// 	}
-		// }
 	}
 
 	async removeUserByName( username ) {
@@ -90,7 +70,10 @@ export default class PeoplePage extends AsyncBaseContainer {
 			this.driver,
 			By.css( `.people-list-item__remove-button[data-e2e-remove-login="${ username }"]` )
 		);
-		return DriverHelper.clickWhenClickable( this.driver, By.css( '.dialog button.is-primary' ) );
+		return await DriverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.dialog button.is-primary' )
+		);
 	}
 
 	async searchForUser( username ) {

--- a/specs/wp-invite-users-spec.js
+++ b/specs/wp-invite-users-spec.js
@@ -206,6 +206,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 		const newInviteEmailAddress = dataHelper.getEmailAddress( newUserName, inviteInboxId );
 		const siteName = config.get( 'privateSiteForInvites' );
 		const siteUrl = `https://${ siteName }/`;
+		let removedViewerFlag = false;
 		let acceptInviteURL = '';
 
 		step( 'As an anonymous user I can not see a private site', async function() {
@@ -284,6 +285,9 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 			await peoplePage.removeUserByName( newUserName );
 			await peoplePage.waitForSearchResults();
 			displayed = await peoplePage.viewerDisplayed( newUserName );
+			if ( displayed === false ) {
+				removedViewerFlag = true;
+			}
 			return assert.strictEqual(
 				displayed,
 				false,
@@ -300,15 +304,17 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 		} );
 
 		after( async function() {
-			await new LoginFlow( driver, 'privateSiteUser' ).loginAndSelectPeople();
-			const peoplePage = await PeoplePage.Expect( driver );
+			if ( ! removedViewerFlag ) {
+				await new LoginFlow( driver, 'privateSiteUser' ).loginAndSelectPeople();
+				const peoplePage = await PeoplePage.Expect( driver );
 
-			await peoplePage.selectViewers();
-			let displayed = await peoplePage.viewerDisplayed( newUserName );
-			if ( displayed ) {
-				await peoplePage.removeUserByName( newUserName );
+				await peoplePage.selectViewers();
+				let displayed = await peoplePage.viewerDisplayed( newUserName );
+				if ( displayed ) {
+					await peoplePage.removeUserByName( newUserName );
 
-				return await peoplePage.waitForSearchResults();
+					return await peoplePage.waitForSearchResults();
+				}
 			}
 		} );
 	} );


### PR DESCRIPTION
We have an [edge case](https://circleci.com/gh/Automattic/wp-e2e-tests/22836) where removing Viewers from the site didn't work if there were more than 20 of them (even we are removing Viewer in two places - in step and in after block, it's happening that we somehow gather more than 20 Viewers). It's an infinite list of Viewers, and they didn't load all at once. This will also cause a problem if, for example, we want to check that the user is removed and there are 50+ Viewers - we would get the false positive result (if user is the last item in the list). 

With this fix, Viewers list will be scrolled depending on their number, so we'll be sure that user is removed or present (depends on the test).

**To test:** TBD

Fixes #1479