### PR TITLE
Try doing start page AB test control groups differently

### DIFF
--- a/lib/async-base-container.js
+++ b/lib/async-base-container.js
@@ -20,6 +20,7 @@ export default class AsyncBaseContainer {
 		this.expectedElementSelector = expectedElementSelector;
 		this.url = url;
 		this.explicitWaitMS = waitMS;
+		this.visiting = false;
 	}
 
 	static async Expect( driver ) {
@@ -33,6 +34,7 @@ export default class AsyncBaseContainer {
 		if ( ! page.url ) {
 			throw new Error( `URL is required to visit the ${ page.name }` );
 		}
+		page.visiting = true;
 		await page._visitInit();
 		return page;
 	}

--- a/lib/pages/signup/start-page.js
+++ b/lib/pages/signup/start-page.js
@@ -8,14 +8,16 @@ import AsyncBaseContainer from '../../async-base-container';
 
 export default class StartPage extends AsyncBaseContainer {
 	constructor( driver, url ) {
-		const loggedOutThemesURL = dataHelper.getCalypsoURL( 'themes' );
-		super( driver, By.css( '#wpcom' ), loggedOutThemesURL );
+		const logInURL = dataHelper.getCalypsoURL( 'log-in' ); // we use the log-in page to set the AB test control groups on visit
+		super( driver, By.css( '#wpcom' ), logInURL );
 		this.startURL = url;
 	}
 
 	async _postInit() {
-		await this.setABTestControlGroupsInLocalStorage();
-		await this.driver.get( this.startURL );
+		if ( this.visiting ) {
+			await this.setABTestControlGroupsInLocalStorage();
+			await this.driver.get( this.startURL ); // this is the actual calculated start URL
+		}
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.step-wrapper' ) );
 	}
 


### PR DESCRIPTION
This cleans up setting the AB test control groups for the start page by visiting /log-in first and setting there.

This only does it when calling visit on the start page - I don't think we expect the start page at any point but worth making it clear it won't

**To Test**

Make sure all the sign up test work correctly and assign the AB test groups