### PR TITLE
Gutenpack: Add MVP Markdown block test

### DIFF
--- a/lib/gutenberg/blocks/gutenberg-block-component.js
+++ b/lib/gutenberg/blocks/gutenberg-block-component.js
@@ -1,0 +1,27 @@
+/** @format */
+import { By } from 'selenium-webdriver';
+import * as driverHelper from '../../driver-helper';
+import AsyncBaseContainer from '../../async-base-container';
+
+export default class GutenbergBlockComponent extends AsyncBaseContainer {
+	constructor( driver, blockID ) {
+		// Not smart enough :shrug:
+		super( driver, By.css( `#${ blockID }` ) );
+		this.blockID = `#${ blockID }`;
+	}
+
+	static async Expect( driver, blockID ) {
+		const page = new this( driver, blockID );
+		await page._expectInit();
+		return page;
+	}
+
+	async focusBlock() {
+		const selectedBlockSelector = By.css(
+			`${ this.blockID }.editor-block-list__block.is-selected`
+		);
+
+		await driverHelper.clickWhenClickable( this.driver, this.expectedElementSelector );
+		return await driverHelper.waitTillPresentAndDisplayed( this.driver, selectedBlockSelector );
+	}
+}

--- a/lib/gutenberg/blocks/markdown-block-component.js
+++ b/lib/gutenberg/blocks/markdown-block-component.js
@@ -1,0 +1,58 @@
+/** @format */
+import { By } from 'selenium-webdriver';
+import * as driverHelper from '../../driver-helper';
+import GutenbergBlockComponent from './gutenberg-block-component';
+
+export default class MarkdownBlockComponent extends GutenbergBlockComponent {
+	constructor( driver, blockID ) {
+		super( driver, blockID );
+	}
+
+	async setContent( content ) {
+		const inputSelector = By.css( `${ this.blockID } textarea.wp-block-a8c-markdown__editor` );
+
+		await this.focusBlock();
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, inputSelector );
+		return await driverHelper.setWhenSettable( this.driver, inputSelector, content );
+	}
+
+	async revealToolbar() {
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.expectedElementSelector );
+		await driverHelper.clickWhenClickable( this.driver, By.css( '.editor-post-title' ) );
+		return await driverHelper.clickWhenClickable( this.driver, this.expectedElementSelector );
+	}
+
+	async switchMarkdown() {
+		const inputSelector = By.css( `${ this.blockID } textarea.wp-block-a8c-markdown__editor` );
+		return await this._switchMode( inputSelector );
+	}
+
+	async switchPreview() {
+		const previewSelector = By.css( `${ this.blockID } .wp-block-a8c-markdown__preview` );
+		return await this._switchMode( previewSelector );
+	}
+
+	// Caution! make sure you in preview mode before calling this.
+	async getPreviewHTML() {
+		const previewSelector = By.css( `${ this.blockID } .wp-block-a8c-markdown__preview` );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, previewSelector );
+		return await this.driver.findElement( previewSelector ).getAttribute( 'innerHTML' );
+	}
+
+	async _switchMode( expectedSelector ) {
+		await this.revealToolbar();
+		const isVisible = await driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			expectedSelector,
+			1000
+		);
+		if ( isVisible ) {
+			return true;
+		}
+		const switchSelector = By.css(
+			`${ this.blockID } button.components-tab-button:not(.is-active)`
+		);
+		await driverHelper.clickWhenClickable( this.driver, switchSelector );
+		return await driverHelper.waitTillPresentAndDisplayed( this.driver, expectedSelector );
+	}
+}

--- a/lib/gutenberg/gutenberg-editor-header-component.js
+++ b/lib/gutenberg/gutenberg-editor-header-component.js
@@ -1,0 +1,76 @@
+/** @format */
+import { By } from 'selenium-webdriver';
+import * as driverHelper from '../driver-helper';
+import AsyncBaseContainer from '../async-base-container';
+
+export default class GutenbergEditorHeaderComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '#editor.gutenberg__editor .edit-post-header' ) );
+	}
+
+	async publish( { visit = false } = {} ) {
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.editor-post-publish-panel__toggle' )
+		);
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.editor-post-publish-panel__header' )
+		);
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.editor-post-publish-panel__header-publish-button button' )
+		);
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.editor-post-publish-panel__header-published' )
+		);
+		const url = await this.driver
+			.findElement( By.css( '.post-publish-panel__postpublish-header a' ) )
+			.getAttribute( 'href' );
+
+		if ( visit ) {
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( '.post-publish-panel__postpublish-buttons a' )
+			);
+		}
+
+		return url;
+	}
+
+	async removeNUXNotice() {
+		const nuxDismissButtonSelector = By.css( '.nux-dot-tip button.nux-dot-tip__disable' );
+		const isVisible = await driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			nuxDismissButtonSelector
+		);
+		if ( ! isVisible ) {
+			return isVisible;
+		}
+
+		return await driverHelper.clickWhenClickable( this.driver, nuxDismissButtonSelector );
+	}
+
+	// return blockID - top level block id which is looks like `block-b91ce479-fb2d-45b7-ad92-22ae7a58cf04`. Should be used for further interaction with added block.
+	async addBlock( name ) {
+		name = name.charAt( 0 ).toUpperCase() + name.slice( 1 ); // Capitalize block name
+		const inserterToggleSelector = By.css( '.edit-post-header .editor-inserter__toggle' );
+		const inserterMenuSelector = By.css( '.editor-inserter__menu' );
+		const inserterSearchInputSelector = By.css( 'input.editor-inserter__search' );
+		const inserterBlockItemSelector = By.css(
+			`li.editor-block-types-list__list-item button[aria-label='${ name }']`
+		);
+		const insertedBlockSelector = By.css(
+			`.editor-block-list__block.is-selected[aria-label*='${ name }']`
+		);
+
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, inserterToggleSelector );
+		await driverHelper.clickWhenClickable( this.driver, inserterToggleSelector );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, inserterMenuSelector );
+		await driverHelper.setWhenSettable( this.driver, inserterSearchInputSelector, name );
+		await driverHelper.clickWhenClickable( this.driver, inserterBlockItemSelector );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, insertedBlockSelector );
+		return await this.driver.findElement( insertedBlockSelector ).getAttribute( 'id' );
+	}
+}

--- a/lib/pages/frontend/post-area-component.js
+++ b/lib/pages/frontend/post-area-component.js
@@ -1,0 +1,18 @@
+/** @format */
+
+import { By } from 'selenium-webdriver';
+
+import * as driverHelper from '../../driver-helper';
+import AsyncBaseContainer from '../../async-base-container';
+
+export default class PostAreaComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( 'article.post' ) );
+	}
+
+	async getPostHTML() {
+		const postSelector = By.css( '.post .entry-content' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, postSelector );
+		return await this.driver.findElement( postSelector ).getAttribute( 'innerHTML' );
+	}
+}

--- a/lib/pages/wp-admin/wp-admin-sidebar.js
+++ b/lib/pages/wp-admin/wp-admin-sidebar.js
@@ -82,6 +82,13 @@ export default class WPAdminSidebar extends AsyncBaseContainer {
 		return await this._selectMenuItem( postsSelector, itemSelector );
 	}
 
+	async selectNewPost() {
+		const postsSelector = by.css( '#menu-posts' );
+		const itemSelector = by.css( '#menu-posts a[href*="post-new"]' );
+
+		return await this._selectMenuItem( postsSelector, itemSelector );
+	}
+
 	async _selectMenuItem( menuSelector, menuItemSelector ) {
 		const classes = await this.driver.findElement( menuSelector ).getAttribute( 'class' );
 		if ( ! classes.includes( 'wp-menu-open' ) && ! classes.includes( 'wp-has-current-submenu' ) ) {

--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -14,6 +14,7 @@ const TEMPLATES = {
 	jetpackMaster: `${ jurassicNinjaCreateURL }?shortlived&jetpack-beta`,
 	branch: `${ jurassicNinjaCreateURL }?shortlived&jetpack-beta`,
 	wooCommerceNoJetpack: `${ jurassicNinjaCreateURL }?shortlived&nojetpack&woocommerce`,
+	gutenpack: `${ jurassicNinjaCreateURL }?shortlived&gutenberg&gutenpack`,
 };
 
 const PASSWORD_ELEMENT = By.css( '#jurassic_password' );

--- a/specs-blocks/gutenberg-blocks-spec.js
+++ b/specs-blocks/gutenberg-blocks-spec.js
@@ -1,0 +1,84 @@
+/** @format */
+
+import config from 'config';
+import assert from 'assert';
+
+import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar.js';
+import JetpackConnectFlow from '../lib/flows/jetpack-connect-flow';
+import MarkdownBlockComponent from '../lib/gutenberg/blocks/markdown-block-component.js';
+// import WPAdminLogonPage from '../lib/pages/wp-admin/wp-admin-logon-page.js';
+import PostAreaComponent from '../lib/pages/frontend/post-area-component.js';
+import * as driverManager from '../lib/driver-manager';
+import GutenbergEditorHeaderComponent from '../lib/gutenberg/gutenberg-editor-header-component.js';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+
+let driver;
+
+before( async function() {
+	this.timeout( startBrowserTimeoutMS );
+	driver = await driverManager.startBrowser();
+} );
+
+describe( `Gutenberg blocks: (${ screenSize })`, function() {
+	this.timeout( mochaTimeOut );
+
+	describe( 'Create a post with Markdown block', function() {
+		const expectedHTML = `<h3>Header</h3>
+<p>Some <strong>list</strong>:</p>
+<ul>
+<li>item a</li>
+<li>item b</li>
+<li>item c</li>
+</ul>
+`;
+		// Easy way to run/develop tests against local WP instance
+		// step( 'Can login to WPORG site', async function() {
+		// 	const loginPage = await WPAdminLogonPage.Visit( driver, 'http://wpdev.localhost/' );
+		// 	await loginPage.login( 'wordpress', 'wordpress' );
+		// } );
+
+		step( 'Can create wporg site', async function() {
+			this.timeout( mochaTimeOut * 12 );
+
+			this.jnFlow = new JetpackConnectFlow( driver, null, 'gutenpack' );
+			return await this.jnFlow.createJNSite();
+		} );
+
+		step( 'Can start new post', async function() {
+			await WPAdminSidebar.refreshIfJNError( driver );
+			this.wpAdminSidebar = await WPAdminSidebar.Expect( driver );
+			return await this.wpAdminSidebar.selectNewPost();
+		} );
+
+		step( 'Can insert a markdown block', async function() {
+			const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
+			gHeaderComponent.removeNUXNotice();
+			this.markdownBlockID = await gHeaderComponent.addBlock( 'Markdown' );
+		} );
+
+		step( 'Can fill markdown block with content', async function() {
+			this.markdownBlock = await MarkdownBlockComponent.Expect( driver, this.markdownBlockID );
+			return await this.markdownBlock.setContent(
+				'### Header\nSome **list**:\n\n- item a\n- item b\n- item c\n'
+			);
+		} );
+
+		step( 'Can see rendered content in preview', async function() {
+			await this.markdownBlock.switchPreview();
+			const html = await this.markdownBlock.getPreviewHTML();
+			assert.equal( html, expectedHTML );
+			await this.markdownBlock.switchMarkdown();
+		} );
+
+		step( 'Can publish the post and see its content', async function() {
+			const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
+			await gHeaderComponent.publish( { visit: true } );
+			const postFrontend = await PostAreaComponent.Expect( driver );
+			const html = await postFrontend.getPostHTML();
+			assert( html.includes( expectedHTML ) );
+		} );
+	} );
+} );


### PR DESCRIPTION
This is an MVP test using Markdown block. It uses Jurassic Ninja site for ease of run. 

```
      ✓ Can create wporg site (84062ms)
      ✓ Can start new post (4649ms)
      ✓ Can insert a markdown block (1307ms)
      ✓ Can fill markdown block with content (705ms)
      ✓ Can see rendered content in preview (4526ms)
      ✓ Can publish the post and see its content (1426ms)
```

To test:
- run: `./node_modules/.bin/mocha specs-blocks/gutenberg-blocks-spec.js`

Internal ref: pafL3P-1n-p2