### PR TITLE
Skip test if domain registration is unavailable #2

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -2,8 +2,10 @@
 
 import config from 'config';
 import assert from 'assert';
+import { By } from 'selenium-webdriver';
 
 import * as driverManager from '../lib/driver-manager.js';
+import * as driverHelper from '../lib/driver-helper.js';
 import * as dataHelper from '../lib/data-helper.js';
 
 import WPHomePage from '../lib/pages/wp-home-page.js';
@@ -935,11 +937,9 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 					checkOutPage = await CheckOutPage.Expect( driver );
 				} catch ( err ) {
 					//TODO: Check this code once more when domain registration is not available
-					const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-					let numberOfItems = await securePaymentComponent.numberOfProductsInCart();
-					if ( numberOfItems === 0 ) {
+					if ( driverHelper.isEventuallyPresentAndDisplayed( driver, By.css( '.empty-content' ) ) ) {
 						await SlackNotifier.warn(
-							'OOPS! Something went wrong! Check if domains registrations is available.'
+							'OOPS! Something went wrong, you don\'t have any site! Check if domains registrations is available.'
 						);
 						return this.skip();
 					}

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -939,7 +939,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 					//TODO: Check this code once more when domain registration is not available
 					if ( driverHelper.isEventuallyPresentAndDisplayed( driver, By.css( '.empty-content' ) ) ) {
 						await SlackNotifier.warn(
-							'OOPS! Something went wrong, you don\'t have any site! Check if domains registrations is available.'
+							'OOPS! Something went wrong, you don\'t have a site! Check if domains registrations is available.'
 						);
 						return this.skip();
 					}


### PR DESCRIPTION
This is the second try of #1401

Referencing to [this](https://circleci.com/gh/Automattic/wp-e2e-tests-for-branches/13087#artifacts/containers/0) failure I'm checking if there are no sites instead of empty cart. 

To test:
It's still unable to test properly, so we'll need to check if test is skipped when domain registration is really unavailable. 
I tested it this way:
- pause test before [this](https://github.com/Automattic/wp-e2e-tests/blob/try/skip-signup-test/specs/wp-signup-spec.js#L937) line 
- delete site
- page "You don't have any WordPress sites yet" will appear
- test will skip all next steps

According to the video of the failed test, this scenario should work 🤞