### PR TITLE
Use mobile emulation in Chrome to get better screen size emulation

### DIFF
--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -131,6 +131,10 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 				} );
 				options.setProxy( this.getProxyType() );
 				options.addArguments( '--no-first-run' );
+				options.addArguments( '--window-size=1600,1200' );
+				options.setMobileEmulation( {
+					deviceMetrics: this.getBrowserSize( screenSize )
+				} );
 				if ( useCustomUA ) {
 					options.addArguments(
 						'user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36'
@@ -194,7 +198,7 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 		.manage()
 		.setTimeouts( { implicit: webDriverImplicitTimeOutMS, pageLoad: webDriverPageLoadTimeOutMS } );
 
-	if ( resizeBrowserWindow ) {
+	if ( resizeBrowserWindow && browser.toLowerCase() !== 'chrome' ) {
 		this.resizeBrowser( driver, screenSize );
 	}
 
@@ -242,6 +246,45 @@ export function resizeBrowser( driver, screenSize ) {
 				'). Supported values are desktop, tablet and mobile.'
 		);
 	}
+}
+
+export function getBrowserSize( screenSize ) {
+	let deviceMetrics = {
+		width: 1440,
+		height: 1000,
+		pixelRatio: 1
+	};
+	if ( typeof screenSize === 'string' ) {
+		switch ( screenSize.toLowerCase() ) {
+			case 'mobile':
+				deviceMetrics.height = 1000;
+				deviceMetrics.width = 400;
+				break;
+			case 'tablet':
+				deviceMetrics.height = 1000;
+				deviceMetrics.width = 1024;
+				break;
+			case 'desktop':
+				break;
+			case 'laptop':
+				deviceMetrics.height = 790;
+				deviceMetrics.width = 1400;
+				break;
+			default:
+				throw new Error(
+					'Unsupported screen size specified (' +
+					screenSize +
+					'). Supported values are desktop, tablet and mobile.'
+				);
+		}
+	} else {
+		throw new Error(
+			'Unsupported screen size specified (' +
+			screenSize +
+			'). Supported values are desktop, tablet and mobile.'
+		);
+	}
+	return deviceMetrics;
 }
 
 export async function clearCookiesAndDeleteLocalStorage( driver, siteURL = null ) {

--- a/lib/video-recorder.js
+++ b/lib/video-recorder.js
@@ -41,7 +41,7 @@ export function startDisplay() {
 			':' + global.displayNum,
 			'-screen',
 			'0',
-			'1600x12000x16',
+			'1600x1200x24',
 			'+extension',
 			'RANDR'
 		]


### PR DESCRIPTION
Fixes  #1477 

The resize wasn't working on Chrome and even setting the window size wasn't getting the correct window size. I switched it over to using the mobile emulation functionality and now it uses the correct, expected viewable area.

To Test:
Run tests in desktop and mobile view and make sure they pass and viewable area is correct.