### PR TITLE
Adding back in ability to use hash query param

### DIFF
--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -252,6 +252,9 @@ export function getCalypsoLiveQuery() {
 	if ( config.has( 'branchName' ) ) {
 		return 'branch=' + config.get( 'branchName' );
 	}
+	if ( config.has( 'hash' ) ) {
+		return 'hash=' + config.get( 'hash' );
+	}
 }
 
 export function getCalypsoURL( route = '', queryStrings = [] ) {


### PR DESCRIPTION
Fixes #1487 

Adds back the ability to specify a hash for calypso.live urls.

To Test-
Add the following values to config and run tests. Ensure that they pass.

  "calypsoBaseURL": "https://calypso.live",
  "liveBranch": true,
  "hash": "4a75c6ef30d61bef298211406c1ecf4073f7c2d5",

*Hash is the commit hash from a wp-calypso commit for a branch that still exists