### PR TITLE
Fix Jetpack SSO issue

### DIFF
--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -199,7 +199,9 @@ describe( `Jetpack Connect: (${ screenSize })`, function() {
 		} );
 
 		step( 'Can log into site via Jetpack SSO', async function() {
-			return await new LoginFlow( driver ).login( { jetpackSSO: true } );
+			// return await new LoginFlow( driver ).login( { jetpackSSO: true } );
+			const loginPage = await WPAdminLogonPage.Visit( driver, dataHelper.getJetpackSiteName() );
+			return await loginPage.logonSSO();
 		} );
 
 		step( 'Add new user as Subscriber in wp-admin', async function() {

--- a/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -24,6 +24,7 @@ import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar';
 import ProfilePage from '../lib/pages/profile-page.js';
 import PurchasesPage from '../lib/pages/purchases-page.js';
 import ManagePurchasePage from '../lib/pages/manage-purchase-page.js';
+import WPAdminLogonPage from '../lib/pages/wp-admin/wp-admin-logon-page';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -51,7 +52,9 @@ describe( `[${ host }] Jetpack Plans: (${ screenSize }) @jetpack`, function() {
 		} );
 
 		step( 'Can log into site via Jetpack SSO', async function() {
-			return await this.loginFlow.login( { jetpackSSO: true } );
+			// return await this.loginFlow.login( { jetpackSSO: true } );
+			const loginPage = await WPAdminLogonPage.Visit( driver, dataHelper.getJetpackSiteName() );
+			return await loginPage.logonSSO();
 		} );
 
 		step( 'Can open Jetpack dashboard', async function() {

--- a/specs/wp-log-in-out-spec.js
+++ b/specs/wp-log-in-out-spec.js
@@ -22,6 +22,7 @@ import LoggedOutMasterbarComponent from '../lib/components/logged-out-masterbar-
 
 import LoginFlow from '../lib/flows/login-flow';
 import LoginPage from '../lib/pages/login-page';
+import WPAdminLogonPage from '../lib/pages/wp-admin/wp-admin-logon-page.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -71,12 +72,14 @@ describe( `[${ host }] Authentication: (${ screenSize }) @parallel @jetpack`, fu
 		// Test Jetpack SSO
 		if ( host !== 'WPCOM' ) {
 			describe( 'Can Log via Jetpack SSO', function() {
-				step( 'Can log into site via Jetpack SSO', async () => {
-					let loginFlow = new LoginFlow( driver );
-					return await loginFlow.login( { jetpackSSO: true } );
+				step( 'Can log into site via Jetpack SSO', async function() {
+					// let loginFlow = new LoginFlow( driver );
+					// return await loginFlow.login( { jetpackSSO: true } );
+					const loginPage = await WPAdminLogonPage.Visit( driver, dataHelper.getJetpackSiteName() );
+					return await loginPage.logonSSO();
 				} );
 
-				step( 'Can return to Reader', async () => {
+				step( 'Can return to Reader', async function() {
 					return await ReaderPage.Visit( driver );
 				} );
 			} );


### PR DESCRIPTION
Fixing failing Jetpack SSO login which was introduced in https://github.com/Automattic/wp-e2e-tests/commit/de7ed56fdd2196e24492fc4c6b39d5edcb677770#diff-4ca0eaf1cd2d615618e924f572fd062aR51

Also I extracting SSO login from `LoginFlow` class since it is not related to calypso login flow

To test:
- JETPACKHOST=PRESSABLE mocha specs-jetpack-calypso/wp-jetpack-plans-spec.js -g 'Purchase Premium Plan'
- JETPACKHOST=PRESSABLE mocha specs-jetpack-calypso/wp-jetpack-connect-spec.js -g 'Connect via SSO'