### PR TITLE
Fix domain mapping spec

### DIFF
--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -119,7 +119,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function(
 	} );
 
 	describe( 'Map a domain to an existing site @parallel', function() {
-		const blogName = 'myawesomedomain.com';
+		const blogName = 'go.com';
 
 		before( async function() {
 			if ( process.env.SKIP_DOMAIN_TESTS === 'true' ) {


### PR DESCRIPTION
This was failing as a message was displayed on the mapping page that the domain was available instead of showing the cart:

<img width="1219" alt="screen shot 2018-10-06 at 2 34 40 pm" src="https://user-images.githubusercontent.com/128826/46574693-55a47d00-c975-11e8-8766-4fc7da9930dc.png">

Updated spec to use a domain already registered (go.com)