### PR TITLE
Make Gutenberg post publish more reliable

### DIFF
--- a/lib/gutenberg/gutenberg-editor-header-component.js
+++ b/lib/gutenberg/gutenberg-editor-header-component.js
@@ -19,7 +19,11 @@ export default class GutenbergEditorHeaderComponent extends AsyncBaseContainer {
 		);
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.editor-post-publish-panel__header-publish-button button' )
+			By.css( '.editor-post-publish-panel__header-publish-button button:not([disabled])' )
+		);
+		await driverHelper.waitTillNotPresent(
+			this.driver,
+			By.css( '.editor-post-publish-panel__content .components-spinner' )
 		);
 		await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,
@@ -48,8 +52,9 @@ export default class GutenbergEditorHeaderComponent extends AsyncBaseContainer {
 		if ( ! isVisible ) {
 			return isVisible;
 		}
-
-		return await driverHelper.clickWhenClickable( this.driver, nuxDismissButtonSelector );
+		// await this.driver.sleep( 1000 ); // Sometimes NUX notice isn't ready yet to click.
+		await driverHelper.clickWhenClickable( this.driver, nuxDismissButtonSelector );
+		return await driverHelper.waitTillNotPresent( this.driver, nuxDismissButtonSelector );
 	}
 
 	// return blockID - top level block id which is looks like `block-b91ce479-fb2d-45b7-ad92-22ae7a58cf04`. Should be used for further interaction with added block.

--- a/lib/gutenberg/gutenberg-editor-header-component.js
+++ b/lib/gutenberg/gutenberg-editor-header-component.js
@@ -52,7 +52,6 @@ export default class GutenbergEditorHeaderComponent extends AsyncBaseContainer {
 		if ( ! isVisible ) {
 			return isVisible;
 		}
-		// await this.driver.sleep( 1000 ); // Sometimes NUX notice isn't ready yet to click.
 		await driverHelper.clickWhenClickable( this.driver, nuxDismissButtonSelector );
 		return await driverHelper.waitTillNotPresent( this.driver, nuxDismissButtonSelector );
 	}

--- a/specs-blocks/gutenberg-blocks-spec.js
+++ b/specs-blocks/gutenberg-blocks-spec.js
@@ -6,7 +6,6 @@ import assert from 'assert';
 import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar.js';
 import JetpackConnectFlow from '../lib/flows/jetpack-connect-flow';
 import MarkdownBlockComponent from '../lib/gutenberg/blocks/markdown-block-component.js';
-// import WPAdminLogonPage from '../lib/pages/wp-admin/wp-admin-logon-page.js';
 import PostAreaComponent from '../lib/pages/frontend/post-area-component.js';
 import * as driverManager from '../lib/driver-manager';
 import GutenbergEditorHeaderComponent from '../lib/gutenberg/gutenberg-editor-header-component.js';
@@ -40,11 +39,10 @@ describe( `Gutenberg blocks: (${ screenSize })`, function() {
 		// 	await loginPage.login( 'wordpress', 'wordpress' );
 		// } );
 
-		step( 'Can create wporg site', async function() {
+		step( 'Can create wporg site and connect Jetpack', async function() {
 			this.timeout( mochaTimeOut * 12 );
-
-			this.jnFlow = new JetpackConnectFlow( driver, null, 'gutenpack' );
-			return await this.jnFlow.createJNSite();
+			this.jnFlow = new JetpackConnectFlow( driver, 'jetpackConnectUser', 'gutenpack' );
+			return await this.jnFlow.connectFromWPAdmin();
 		} );
 
 		step( 'Can start new post', async function() {
@@ -55,7 +53,7 @@ describe( `Gutenberg blocks: (${ screenSize })`, function() {
 
 		step( 'Can insert a markdown block', async function() {
 			const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
-			gHeaderComponent.removeNUXNotice();
+			await gHeaderComponent.removeNUXNotice();
 			this.markdownBlockID = await gHeaderComponent.addBlock( 'Markdown' );
 		} );
 


### PR DESCRIPTION
Minor change which makes Gutenberg publishing a bit more reliable. Also, We need to connect Jetpack to be able to use Jetpack blocks, so the test is updated accordingly.