### PR TITLE
Remove readerSearchPlaceholder from A/B test overrides

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -85,7 +85,6 @@
 		[ "nudgeAPalooza_20180806", "control" ],
 		[ "includeDotBlogSubdomainV2_20180813", "no" ],
 		[ "gSuiteDiscountV2_20180822", "control" ],
-		[ "readerSearchPlaceholder_20180830", "justSearch" ],
 		[ "showPlanCreditsApplied_20180903", "control" ],
 		[ "cartNudgeUpdateToPremium_20180903", "control" ],
 		[ "userFirstSignup_20180913", "default" ],


### PR DESCRIPTION
Removes readerSearchPlaceholder from A/B test overrides.

I previously removed it from the list of A/B tests in 2079d9bdaa6002c5d50518f227d84210075e496a.

The A/B test was removed from Calypso in https://github.com/Automattic/wp-calypso/pull/27700.