### PR TITLE
Run Gutenpack tests against JN site which includes PR changes

### DIFF
--- a/docs/running-tests.md
+++ b/docs/running-tests.md
@@ -50,23 +50,28 @@ Or you can use the -s option on the run.sh script:
 The `run.sh` script takes the following parameters, which can be combined to execute a variety of suites
 
     -a [workers]  - Number of parallel workers in Magellan (defaults to 3)
-    -R      - Use custom Slack/Spec/XUnit reporter, otherwise just use Spec reporter
-    -p      - Execute the tests in parallel via CircleCI envvars (implies -g -s mobile,desktop)
-    -S [commitHash]  - Run tests against given commit via https://calypso.live
-    -b [branch]   - Run tests on given branch via https://calypso.live
-    -s      - Screensizes in a comma-separated list (defaults to mobile,desktop)
-    -g      - Execute general tests in the specs/ directory
-    -j      - Execute Jetpack tests in the specs-jetpack-calypso/ directory (desktop and mobile)
-    -W      - Execute WooCommerce tests in the specs-woocommerce/ directory (desktop and mobile)
-    -H [host]   - Specify an alternate host for Jetpack tests
-    -w      - Only execute signup tests on Windows/IE11, not compatible with -g flag
-    -l [config]   - Execute the tests via Sauce Labs with the given configuration
-    -c      - Exit with status code 0 regardless of test results
-    -I      - Execute i18n tests in the specs-i18n/ directory (desktop)
-    -i      - Execute i18n signup screenshot tests, not compatible with -g flag
-    -x      - Execute the tests using the --headless flag in Chrome
+    -R  - Use custom Slack/Spec/XUnit reporter, otherwise just use Spec reporter
+    -p  - Execute the tests in parallel via CircleCI envvars (implies -g -s mobile,desktop)
+    -S [commitHash]   - Run tests against given commit via https://calypso.live
+    -B [branch]  - Run Jetpack tests on given Jetpack branch via https://jurassic.ninja
+    -s  - Screensizes in a comma-separated list (defaults to mobile,desktop)
+    -g  - Execute general tests in the specs/ directory
+    -j  - Execute Jetpack tests in the specs-jetpack-calypso/ directory (desktop and mobile)
+    -W  - Execute WooCommerce tests in the specs-woocommerce/ directory (desktop and mobile)
+    -C  - Execute tests tagged with @canary
+    -J  - Execute Jetpack connect tests tagged with @canary
+    -H [host]  - Specify an alternate host for Jetpack tests
+    -w - Only execute signup tests on Windows/IE11, not compatible with -g flag
+    -z  - Only execute canary tests on Windows/IE11, not compatible with -g flag
+    -y  - Only execute canary tests on Safari 10 on Mac, not compatible with -g flag
+    -l [config]  - Execute the tests via Sauce Labs with the given configuration
+    -c  - Exit with status code 0 regardless of test results
+    -m [browsers]  - Execute the multi-browser visual-diff tests with the given list of browsers via grunt.  Specify browsers in comma-separated list or 'all'
+    -i  - Execute i18n NUX screenshot tests, not compatible with -g flag
+    -I  - Execute tests in specs-i18n/ directory
+    -x  - Execute the tests from the context of xvfb-run
     -u [baseUrl]  - Override the calypsoBaseURL config
-    -h      - This help listing
+    -h  - This help listing
 
 ## To run headlessly
 

--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -70,9 +70,6 @@ export function isRunningOnJetpackBranch() {
 export function adjustInviteLinkToCorrectEnvironment( acceptInviteURL ) {
 	const calypsoBaseUrl = this.configGet( 'calypsoBaseURL' );
 	acceptInviteURL = acceptInviteURL.replace( 'https://wordpress.com', calypsoBaseUrl );
-	// if ( this.isRunningOnLiveBranch() ) {
-	// 	acceptInviteURL = acceptInviteURL + '?' + this.getCalypsoLiveQuery();
-	// }
 	return acceptInviteURL;
 }
 
@@ -248,15 +245,6 @@ export function getTestDomainRegistarDetails( emailAddress ) {
 	};
 }
 
-// export function getCalypsoLiveQuery() {
-// 	if ( config.has( 'branchName' ) ) {
-// 		return 'branch=' + config.get( 'branchName' );
-// 	}
-// 	if ( config.has( 'hash' ) ) {
-// 		return 'hash=' + config.get( 'hash' );
-// 	}
-// }
-
 export function getCalypsoURL( route = '', queryStrings = [] ) {
 	let queryString = '';
 	let url = this.configGet( 'calypsoBaseURL' ) + '/' + route;
@@ -265,14 +253,6 @@ export function getCalypsoURL( route = '', queryStrings = [] ) {
 		queryString = this._appendQueryString( queryString, qs );
 	}
 
-	// if ( this.isRunningOnLiveBranch() ) {
-	// 	if ( url.indexOf( 'calypso.live' ) < 0 ) {
-	// 		throw new Error(
-	// 			`It looks like live branches are being used on a non calypso.live URL: '${ url }'`
-	// 		);
-	// 	}
-	// 	queryString = this._appendQueryString( queryString, this.getCalypsoLiveQuery() );
-	// }
 	return url + queryString;
 }
 

--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -70,9 +70,9 @@ export function isRunningOnJetpackBranch() {
 export function adjustInviteLinkToCorrectEnvironment( acceptInviteURL ) {
 	const calypsoBaseUrl = this.configGet( 'calypsoBaseURL' );
 	acceptInviteURL = acceptInviteURL.replace( 'https://wordpress.com', calypsoBaseUrl );
-	if ( this.isRunningOnLiveBranch() ) {
-		acceptInviteURL = acceptInviteURL + '?' + this.getCalypsoLiveQuery();
-	}
+	// if ( this.isRunningOnLiveBranch() ) {
+	// 	acceptInviteURL = acceptInviteURL + '?' + this.getCalypsoLiveQuery();
+	// }
 	return acceptInviteURL;
 }
 
@@ -248,14 +248,14 @@ export function getTestDomainRegistarDetails( emailAddress ) {
 	};
 }
 
-export function getCalypsoLiveQuery() {
-	if ( config.has( 'branchName' ) ) {
-		return 'branch=' + config.get( 'branchName' );
-	}
-	if ( config.has( 'hash' ) ) {
-		return 'hash=' + config.get( 'hash' );
-	}
-}
+// export function getCalypsoLiveQuery() {
+// 	if ( config.has( 'branchName' ) ) {
+// 		return 'branch=' + config.get( 'branchName' );
+// 	}
+// 	if ( config.has( 'hash' ) ) {
+// 		return 'hash=' + config.get( 'hash' );
+// 	}
+// }
 
 export function getCalypsoURL( route = '', queryStrings = [] ) {
 	let queryString = '';
@@ -265,14 +265,14 @@ export function getCalypsoURL( route = '', queryStrings = [] ) {
 		queryString = this._appendQueryString( queryString, qs );
 	}
 
-	if ( this.isRunningOnLiveBranch() ) {
-		if ( url.indexOf( 'calypso.live' ) < 0 ) {
-			throw new Error(
-				`It looks like live branches are being used on a non calypso.live URL: '${ url }'`
-			);
-		}
-		queryString = this._appendQueryString( queryString, this.getCalypsoLiveQuery() );
-	}
+	// if ( this.isRunningOnLiveBranch() ) {
+	// 	if ( url.indexOf( 'calypso.live' ) < 0 ) {
+	// 		throw new Error(
+	// 			`It looks like live branches are being used on a non calypso.live URL: '${ url }'`
+	// 		);
+	// 	}
+	// 	queryString = this._appendQueryString( queryString, this.getCalypsoLiveQuery() );
+	// }
 	return url + queryString;
 }
 

--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -77,6 +77,9 @@ export default class WporgCreatorPage extends AsyncBaseContainer {
 		if ( dataHelper.isRunningOnJetpackBranch() ) {
 			url += `&branch=${ config.get( 'jetpackBranchName' ) }`;
 		}
+		if ( template === 'gutenpack' && dataHelper.isRunningOnLiveBranch() ) {
+			url += `&calypsobranch=${ config.get( 'branchName' ) }`;
+		}
 		return url;
 	}
 }

--- a/run.sh
+++ b/run.sh
@@ -86,7 +86,7 @@ while getopts ":a:RpS:b:B:s:gjWCJH:wzyl:cm:fiIUvxu:h" opt; do
       ;;
     S)
       export LIVEBRANCHES="true"
-      NODE_CONFIG_ARGS+=("\"liveBranch\":\"true\",\"calypsoBaseURL\":\"https://hash-$OPTARG.calypso.live\"")
+      NODE_CONFIG_ARGS+=("\"liveBranch\":\"true\",\"calypsoBaseURL\":\"https://hash-$OPTARG.calypso.live\",\"branchName\":\"$BRANCHNAME\"")
       continue
       ;;
     b)

--- a/run.sh
+++ b/run.sh
@@ -38,7 +38,6 @@ usage () {
 -R		  - Use custom Slack/Spec/XUnit reporter, otherwise just use Spec reporter
 -p 		  - Execute the tests in parallel via CircleCI envvars (implies -g -s mobile,desktop)
 -S [commitHash]   - Run tests against given commit via https://calypso.live
--b [branch]	  - Run tests on given branch via https://calypso.live
 -B [branch]	  - Run Jetpack tests on given Jetpack branch via https://jurassic.ninja
 -s		  - Screensizes in a comma-separated list (defaults to mobile,desktop)
 -g		  - Execute general tests in the specs/ directory
@@ -66,7 +65,7 @@ if [ $# -eq 0 ]; then
   usage
 fi
 
-while getopts ":a:RpS:b:B:s:gjWCJH:wzyl:cm:fiIUvxu:h" opt; do
+while getopts ":a:RpS:B:s:gjWCJH:wzyl:cm:fiIUvxu:h" opt; do
   case $opt in
     a)
       WORKERS=$OPTARG
@@ -87,11 +86,6 @@ while getopts ":a:RpS:b:B:s:gjWCJH:wzyl:cm:fiIUvxu:h" opt; do
     S)
       export LIVEBRANCHES="true"
       NODE_CONFIG_ARGS+=("\"liveBranch\":\"true\",\"calypsoBaseURL\":\"https://hash-$OPTARG.calypso.live\",\"branchName\":\"$BRANCHNAME\"")
-      continue
-      ;;
-    b)
-      export LIVEBRANCHES="true"
-      NODE_CONFIG_ARGS+=("\"liveBranch\":\"true\",\"branchName\":\"$OPTARG\",\"calypsoBaseURL\":\"https://calypso.live\"")
       continue
       ;;
     B)

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -38,14 +38,6 @@ elif [ "$CIRCLE_BRANCH" == "master" ]; then
   TESTARGS="-R -p" # Parallel execution, implies -g -s mobile,desktop
 fi
 
-if [ "$liveBranches" == "true" ]; then
-  TESTARGS+=" -b $branchName"
-
-  if [ $hash != "" ]; then
-    TESTARGS+=" -S $hash"
-  fi
-fi
-
 # If on CI and the -x flag is not yet set, set it
 #if [ "$CI" == "true" ] && [[ "$TESTARGS" != *"-x"* ]]; then
 #  TESTARGS+=" -x"


### PR DESCRIPTION
To run Gutenberg tests against calypso PR - we need to pass calypso branch argument into JN site creation URL. This PR makes it possible. 

One thing that I not certain about - usage of `branchName` outside of `-b` context. So, a bit of review there would be very helpful. 