### PR TITLE
Find element by text and click on it

### DIFF
--- a/lib/components/notifications-component.js
+++ b/lib/components/notifications-component.js
@@ -28,8 +28,8 @@ export default class NotificationsComponent extends AsyncBaseContainer {
 	}
 
 	async selectCommentByText( commentText ) {
-		const commentSelector = by.xpath( `//div[normalize-space(text())='${ commentText }']` );
-		return await driverHelper.clickWhenClickable( this.driver, commentSelector );
+		let commentSelector = by.css( '.wpnc__excerpt' );
+		return await driverHelper.selectElementByText( this.driver, commentSelector, commentText );
 	}
 
 	async trashComment() {

--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -425,3 +425,11 @@ export async function scrollToBottom( driver, selector ) {
 		selectorElement
 	);
 }
+
+export async function selectElementByText( driver, selector, text ) {
+	let element = async () => {
+		let allElements = await driver.findElements( selector );
+		return await webdriver.promise.filter( allElements, async e => ( await e.getText() ) === text );
+	};
+	return await this.clickWhenClickable( driver, element );
+}

--- a/lib/pages/themes-page.js
+++ b/lib/pages/themes-page.js
@@ -80,9 +80,8 @@ export default class ThemesPage extends AsyncBaseContainer {
 	}
 
 	async clickPopoverItem( name ) {
-		const previewThemeSelector = by.xpath( `//*[text()='${ name }']` ); // For multi-sites it's 'button', for single sites it's 'a'.  WEIRD
-		driverHelper.waitTillPresentAndDisplayed( this.driver, previewThemeSelector );
-		return await driverHelper.clickWhenClickable( this.driver, previewThemeSelector );
+		let actionItemSelector = by.css( '.popover__menu-item' );
+		return await driverHelper.selectElementByText( this.driver, actionItemSelector, name );
 	}
 
 	async popOverMenuDisplayed() {
@@ -92,8 +91,6 @@ export default class ThemesPage extends AsyncBaseContainer {
 
 	static _getThemeSelectionXpath( phrase ) {
 		let lowerCasedPhrase = phrase.toLowerCase().replace( ' ', '-' );
-		return by.css(
-			`div[data-e2e-theme*='${ lowerCasedPhrase }']:not(.is-active)`
-		);
+		return by.css( `div[data-e2e-theme*='${ lowerCasedPhrase }']:not(.is-active)` );
 	}
 }


### PR DESCRIPTION
According to discussion from [here](https://github.com/Automattic/wp-calypso/pull/27624#discussion_r223697178) I added [method](https://github.com/Automattic/wp-e2e-tests/compare/try/select-by-text?expand=1#diff-0e3b6a0d13153e063b03d83d728e6521R429) in `driver-helper.js` so that we can find the element by text and click on it. 

It can be useful when we have many elements with the same selector with different content/text, for example, comments in notification sidebar. This way, we don't need to use `xpath` selectors for specific text. [Here](https://github.com/Automattic/wp-e2e-tests/compare/try/select-by-text?expand=1#diff-a8284112885a5346b63bcfc5d1b1789fR30) and [here](https://github.com/Automattic/wp-e2e-tests/compare/try/select-by-text?expand=1#diff-f33fd6bbca9e0118c28fca06ce7e4afaR82) are the examples. And we don't need to add data e2e attributes to wp-calypso. 

To test:
Makse sure that specs `wp-theme-switch-spec.js`, `wp-theme-multisite-spec.js`, `wp-reader-spec.js`, `wp-notification-spec.js` are passing. 
