### PR TITLE
i18n tests: Use setRect() instead setSize() to set browser size

### DIFF
--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -133,7 +133,7 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 				options.addArguments( '--no-first-run' );
 				options.addArguments( '--window-size=1600,1200' );
 				options.setMobileEmulation( {
-					deviceMetrics: this.getBrowserSize( screenSize )
+					deviceMetrics: this.getBrowserSize( screenSize ),
 				} );
 				if ( useCustomUA ) {
 					options.addArguments(
@@ -205,32 +205,32 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 	return driver;
 }
 
-export function resizeBrowser( driver, screenSize ) {
+export async function resizeBrowser( driver, screenSize ) {
 	if ( typeof screenSize === 'string' ) {
 		switch ( screenSize.toLowerCase() ) {
 			case 'mobile':
-				driver
+				await driver
 					.manage()
 					.window()
-					.setSize( 400, 1000 );
+					.setRect( { width: 400, height: 1000 } );
 				break;
 			case 'tablet':
-				driver
+				await driver
 					.manage()
 					.window()
-					.setSize( 1024, 1000 );
+					.setRect( { width: 1024, height: 1000 } );
 				break;
 			case 'desktop':
-				driver
+				await driver
 					.manage()
 					.window()
-					.setSize( 1440, 1000 );
+					.setRect( { width: 1440, height: 1000 } );
 				break;
 			case 'laptop':
-				driver
+				await driver
 					.manage()
 					.window()
-					.setSize( 1400, 790 );
+					.setRect( { width: 1400, height: 790 } );
 				break;
 			default:
 				throw new Error(
@@ -252,7 +252,7 @@ export function getBrowserSize( screenSize ) {
 	let deviceMetrics = {
 		width: 1440,
 		height: 1000,
-		pixelRatio: 1
+		pixelRatio: 1,
 	};
 	if ( typeof screenSize === 'string' ) {
 		switch ( screenSize.toLowerCase() ) {
@@ -273,15 +273,15 @@ export function getBrowserSize( screenSize ) {
 			default:
 				throw new Error(
 					'Unsupported screen size specified (' +
-					screenSize +
-					'). Supported values are desktop, tablet and mobile.'
+						screenSize +
+						'). Supported values are desktop, tablet and mobile.'
 				);
 		}
 	} else {
 		throw new Error(
 			'Unsupported screen size specified (' +
-			screenSize +
-			'). Supported values are desktop, tablet and mobile.'
+				screenSize +
+				'). Supported values are desktop, tablet and mobile.'
 		);
 	}
 	return deviceMetrics;


### PR DESCRIPTION
I18n tests are [failing](https://circleci.com/gh/Automattic/wp-e2e-tests-i18n) for several days. The problem was introduced with #1502, when we added selenium 4.0.0-alpha.1. According to [changes](https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/CHANGES.md) in new Selenium `setSize()` is removed, and `setRect()` is added. 