### PR TITLE
Use data-e2e attributes for Sidebar items

### DIFF
--- a/lib/components/nav-bar-component.js
+++ b/lib/components/nav-bar-component.js
@@ -28,7 +28,7 @@ export default class NavBarComponent extends AsyncBaseContainer {
 		);
 	}
 	async clickMySites() {
-		const mySitesSelector = by.css( '.masterbar__item-content' );
+		const mySitesSelector = by.css( 'header.masterbar a.masterbar__item' );
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			mySitesSelector,

--- a/lib/components/nav-bar-component.js
+++ b/lib/components/nav-bar-component.js
@@ -28,7 +28,7 @@ export default class NavBarComponent extends AsyncBaseContainer {
 		);
 	}
 	async clickMySites() {
-		const mySitesSelector = by.css( 'header.masterbar a.masterbar__item' );
+		const mySitesSelector = by.css( '.masterbar__item-content' );
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			mySitesSelector,

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -9,18 +9,18 @@ import * as driverHelper from '../driver-helper.js';
 export default class SidebarComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.sidebar' ) );
-		this.storeSelector = By.css( '.sites-navigation li a[href*=store]' );
-		this.settingsSelector = By.css( '.sites-navigation [data-tip-target="settings"] a' );
-		this.importSelector = By.css( '.sites-navigation [data-tip-target="side-menu-import"] a' );
+		this.storeSelector = By.css( '.menu-link-text[data-e2e-sidebar="Store"]' );
+		this.settingsSelector = By.css( '.menu-link-text[data-e2e-sidebar="Settings"]' );
+		this.importSelector = By.css( '.menu-link-text[data-e2e-sidebar="Import"]' );
 	}
 
 	async selectDomains() {
-		const selector = By.css( '.sites-navigation [data-tip-target="domains"] a' );
+		const selector = By.css( '.menu-link-text[data-e2e-sidebar="Domains"]' );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 
 	async selectPeople() {
-		const selector = By.css( '.sites-navigation [data-tip-target="people"] a' );
+		const selector = By.css( '.menu-link-text[data-e2e-sidebar="People"]' );
 		await driverHelper.scrollIntoView( this.driver, selector );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
@@ -50,7 +50,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectPlan() {
-		const selector = By.css( '.sites-navigation [data-tip-target="plan"] a' );
+		const selector = By.css( '.menu-link-text[data-e2e-sidebar="Plan"]' );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 
@@ -79,7 +79,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectActivity() {
-		const selector = By.css( '.sites-navigation [data-tip-target="activity"] a' );
+		const selector = By.css( '.menu-link-text[data-e2e-sidebar="Activity"]' );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 
@@ -112,14 +112,12 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectViewThisSite() {
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '[data-tip-target="sitePreview"] a' )
-		);
+		const selector = By.css( '.menu-link-text[data-e2e-sidebar="View Site"]' );
+		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 
 	async selectPlugins() {
-		const selector = By.css( '.sites-navigation [data-tip-target="side-menu-plugins"] a' );
+		const selector = By.css( '.menu-link-text[data-e2e-sidebar="Plugins"]' );
 		const dismissNoticeSelector = By.css( '.notice.is-dismissable .notice__dismiss' );
 		const driver = this.driver;
 
@@ -167,14 +165,12 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectPosts() {
-		const selector = By.css(
-			'.sites-navigation [data-post-type="post"] a:not(.sidebar__button) span'
-		);
+		const selector = By.css( '.menu-link-text[data-e2e-sidebar="Blog Posts"]' );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 
 	async selectComments() {
-		const selector = By.css( '.sites-navigation [data-post-type="comments"] a' );
+		const selector = By.css( '.menu-link-text[data-e2e-sidebar="Comments"]' );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 


### PR DESCRIPTION
Occasionally, we have failed e2e tests because wrong item is clicked in the sidebar. For example, _Sharing_ is clicked instead of _People_. Until now, we were getting an element, for example _People_, like this `.sites-navigation [data-tip-target="people"] a`. With this change we could get it like this `.menu-link-text[data-e2e-sidebar="People"]`, and hopefully, this way should be stable.

To test:
Make sure that every item in the sidebar has data e2e attribute `data-e2e-sidebar="<item_name>"`.
While waiting [wp-calypso PR](https://github.com/Automattic/wp-calypso/pull/28031) to me merged, it can be tested on wp-calypso branch `try/sidebar-e2e-selectors`.

Blocked by https://github.com/Automattic/wp-calypso/pull/28031

Fixes https://github.com/Automattic/wp-e2e-tests/issues/1530