### PR TITLE
Override `improvedOnboarding` abtest as `main`

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -82,6 +82,7 @@
 		[ "aboutSuggestionMatches_20180704", "control" ],
 		[ "nudgeAPalooza_20180806", "control" ],
 		[ "includeDotBlogSubdomainV2_20180813", "no" ],
+		[ "improvedOnboarding_20181023", "main" ],
 		[ "gSuiteDiscountV2_20180822", "control" ],
 		[ "showPlanCreditsApplied_20180903", "control" ],
 		[ "cartNudgeUpdateToPremium_20180903", "control" ],


### PR DESCRIPTION
## Summary
Reflecting the newly-added abtest in https://github.com/Automattic/wp-calypso/pull/27983, this PR override `improvedOnboarding` abtest variation as `main`.