### PR TITLE
Revert "Add pauseBetweenKeysMS to setWhenSettable()"

### DIFF
--- a/lib/components/secure-payment-component.js
+++ b/lib/components/secure-payment-component.js
@@ -32,7 +32,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 	} ) {
 		// This PR introduced an issue with older browsers, specifically IE11:
 		//   https://github.com/Automattic/wp-calypso/pull/22239
-		const pauseBetweenKeysMS = global.browserName === 'Internet Explorer' ? 10 : 5;
+		const pauseBetweenKeysMS = global.browserName === 'Internet Explorer' ? 1 : 0;
 
 		await driverHelper.setWhenSettable( this.driver, By.id( 'name' ), cardHolder, {
 			pauseBetweenKeysMS: pauseBetweenKeysMS,

--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -207,7 +207,7 @@ export async function setWhenSettable(
 	driver,
 	selector,
 	value,
-	{ secureValue = false, pauseBetweenKeysMS = 5 } = {}
+	{ secureValue = false, pauseBetweenKeysMS = 0 } = {}
 ) {
 	const self = this;
 	const logValue = secureValue === true ? '*********' : value;


### PR DESCRIPTION
Reverts Automattic/wp-e2e-tests#1547

IE tests fail when this is merged