### PR TITLE
Remove mobile emulation

### DIFF
--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -194,7 +194,7 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 	driver
 		.manage()
 		.setTimeouts( { implicit: webDriverImplicitTimeOutMS, pageLoad: webDriverPageLoadTimeOutMS } );
-	if( resizeBrowserWindow ) {
+	if ( resizeBrowserWindow ) {
 		this.resizeBrowser( driver, screenSize );
 	}
 

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -131,10 +131,7 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 				} );
 				options.setProxy( this.getProxyType() );
 				options.addArguments( '--no-first-run' );
-				//options.addArguments( '--window-size=1600,1200' );
-				//options.setMobileEmulation( {
-				//	deviceMetrics: this.getBrowserSize( screenSize ),
-				//} );
+
 				if ( useCustomUA ) {
 					options.addArguments(
 						'user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36'
@@ -198,9 +195,7 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 		.manage()
 		.setTimeouts( { implicit: webDriverImplicitTimeOutMS, pageLoad: webDriverPageLoadTimeOutMS } );
 
-	//if ( resizeBrowserWindow && browser.toLowerCase() !== 'chrome' ) {
-		this.resizeBrowser( driver, screenSize );
-	//}
+	this.resizeBrowser( driver, screenSize );
 
 	return driver;
 }
@@ -246,45 +241,6 @@ export async function resizeBrowser( driver, screenSize ) {
 				'). Supported values are desktop, tablet and mobile.'
 		);
 	}
-}
-
-export function getBrowserSize( screenSize ) {
-	let deviceMetrics = {
-		width: 1440,
-		height: 1000,
-		pixelRatio: 1,
-	};
-	if ( typeof screenSize === 'string' ) {
-		switch ( screenSize.toLowerCase() ) {
-			case 'mobile':
-				deviceMetrics.height = 1000;
-				deviceMetrics.width = 400;
-				break;
-			case 'tablet':
-				deviceMetrics.height = 1000;
-				deviceMetrics.width = 1024;
-				break;
-			case 'desktop':
-				break;
-			case 'laptop':
-				deviceMetrics.height = 790;
-				deviceMetrics.width = 1400;
-				break;
-			default:
-				throw new Error(
-					'Unsupported screen size specified (' +
-						screenSize +
-						'). Supported values are desktop, tablet and mobile.'
-				);
-		}
-	} else {
-		throw new Error(
-			'Unsupported screen size specified (' +
-				screenSize +
-				'). Supported values are desktop, tablet and mobile.'
-		);
-	}
-	return deviceMetrics;
 }
 
 export async function clearCookiesAndDeleteLocalStorage( driver, siteURL = null ) {

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -131,10 +131,10 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 				} );
 				options.setProxy( this.getProxyType() );
 				options.addArguments( '--no-first-run' );
-				options.addArguments( '--window-size=1600,1200' );
-				options.setMobileEmulation( {
-					deviceMetrics: this.getBrowserSize( screenSize ),
-				} );
+				//options.addArguments( '--window-size=1600,1200' );
+				//options.setMobileEmulation( {
+				//	deviceMetrics: this.getBrowserSize( screenSize ),
+				//} );
 				if ( useCustomUA ) {
 					options.addArguments(
 						'user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36'
@@ -198,9 +198,9 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 		.manage()
 		.setTimeouts( { implicit: webDriverImplicitTimeOutMS, pageLoad: webDriverPageLoadTimeOutMS } );
 
-	if ( resizeBrowserWindow && browser.toLowerCase() !== 'chrome' ) {
+	//if ( resizeBrowserWindow && browser.toLowerCase() !== 'chrome' ) {
 		this.resizeBrowser( driver, screenSize );
-	}
+	//}
 
 	return driver;
 }

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -194,8 +194,9 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 	driver
 		.manage()
 		.setTimeouts( { implicit: webDriverImplicitTimeOutMS, pageLoad: webDriverPageLoadTimeOutMS } );
-
-	this.resizeBrowser( driver, screenSize );
+	if( resizeBrowserWindow ) {
+		this.resizeBrowser( driver, screenSize );
+	}
 
 	return driver;
 }


### PR DESCRIPTION
Mobile emulation is causing issues with test stability. This goes back to using the resized browser window. The negative with this is that we aren't using true mobile widths.