### PR TITLE
Adds a sign up for site scenario for logged in customer

### DIFF
--- a/lib/components/no-sites-component.js
+++ b/lib/components/no-sites-component.js
@@ -3,9 +3,17 @@
 import { By } from 'selenium-webdriver';
 
 import AsyncBaseContainer from '../async-base-container';
+import * as driverHelper from '../driver-helper.js';
 
 export default class NoSitesComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.empty-content' ) );
+	}
+
+	async createSite() {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.empty-content__action.button.is-primary' )
+		);
 	}
 }


### PR DESCRIPTION
This extends the sign up for a free account to then add a new site to the account.

This makes sure we can sign up from a logged in state

Fixes #1557

**Testing Instructions**

Make sure "Sign up for an account only (no site) then add a site" is running and passing desktop and mobile