### PR TITLE
Wait for Store NUX to be present

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -375,6 +375,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			const aboutPage = await AboutPage.Expect( driver );
 			await aboutPage.enterSiteDetails( 'Step Back', 'Store Test Topic', { sell: true } );
 			await aboutPage.submitForm();
+			await driverHelper.waitTillNotPresent( driver, By.css( '.signup is-store-nux' ) ); // Wait for /start/store-nux/themes to load
 			await driver.navigate().back();
 			await aboutPage.unsetCheckBox( { sell: true } );
 			await aboutPage.submitForm();


### PR DESCRIPTION
Test `Sign up for a site on a premium paid plan through main flow in USD currency @parallel @canary`was [failing](https://circleci.com/gh/Automattic/wp-e2e-tests/23695#tests/containers/1) because sometimes `driver.navigate().back()` was executed before /start/store-nux/themes is loaded.

This fix makes sure that /start/store-nux/themes is loaded and after that execute `driver.navigate().back()`