### PR TITLE
Fix Coupon tests failing on Jetpack Hosts

### DIFF
--- a/lib/pages/plans-page.js
+++ b/lib/pages/plans-page.js
@@ -4,6 +4,7 @@ import webdriver from 'selenium-webdriver';
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 import * as dataHelper from '../data-helper';
+import { currentScreenSize } from '../driver-manager';
 
 const by = webdriver.By;
 const host = dataHelper.getJetpackHost();
@@ -48,23 +49,19 @@ export default class PlansPage extends AsyncBaseContainer {
 		);
 	}
 
-	// Duplicate-ish function in purchases-page
 	async selectBusinessPlan() {
-		await driverHelper.waitTillPresentAndDisplayed(
-			this.driver,
-			by.css( 'button.is-business-plan' )
-		);
-
-		// 3 elements have this locator on the page including the mobile element
-		let elements = await this.driver.findElements( by.css( 'button.is-business-plan' ) );
-		for ( let i = 0; i < elements.length; i++ ) {
-			let element = elements[ i ];
-			element.click().then(
-				function() {
-					return true;
-				},
-				function() {}
+		// Wait a little for loading animation
+		await this.driver.sleep( 1000 );
+		if ( currentScreenSize() === 'mobile' ) {
+			return await driverHelper.clickWhenClickable(
+				this.driver,
+				by.css( '.plan-features__mobile button.is-business-plan' )
 			);
 		}
+
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			by.css( 'td.is-top-buttons button.is-business-plan' )
+		);
 	}
 }

--- a/specs/wp-plan-purchase-spec.js
+++ b/specs/wp-plan-purchase-spec.js
@@ -68,7 +68,7 @@ describe( `[${ host }] Plans: (${ screenSize }) @parallel @jetpack`, function() 
 		}
 	} );
 
-	describe.only( 'Viewing a specific plan with coupon:', function() {
+	describe( 'Viewing a specific plan with coupon:', function() {
 		let originalCartAmount, loginFlow;
 
 		before( async function() {

--- a/specs/wp-plan-purchase-spec.js
+++ b/specs/wp-plan-purchase-spec.js
@@ -88,8 +88,15 @@ describe( `[${ host }] Plans: (${ screenSize }) @parallel @jetpack`, function() 
 		} );
 
 		step( 'Can Select Plans tab', async function() {
-			let route = `plans/${ loginFlow.account.loginURL }`;
-			return await driver.get( dataHelper.getCalypsoURL( route ) );
+			const plansPage = await PlansPage.Expect( driver );
+			if ( host === 'WPCOM' ) {
+				await plansPage.openPlansTab();
+				return await plansPage.waitForComparison();
+			}
+
+			// Jetpack
+			const displayed = await plansPage.planTypesShown( 'jetpack' );
+			return assert( displayed, 'The Jetpack plans are NOT displayed' );
 		} );
 
 		step( 'Select Business Plan', async function() {

--- a/specs/wp-plan-purchase-spec.js
+++ b/specs/wp-plan-purchase-spec.js
@@ -68,7 +68,7 @@ describe( `[${ host }] Plans: (${ screenSize }) @parallel @jetpack`, function() 
 		}
 	} );
 
-	describe( 'Viewing a specific plan with coupon:', function() {
+	describe.only( 'Viewing a specific plan with coupon:', function() {
 		let originalCartAmount, loginFlow;
 
 		before( async function() {


### PR DESCRIPTION
Coupon tests were failing on Jetpack hosts because of the way the test was selecting the Plans tab. A simple check for WPCOM vs Jetpack host resolved this. 

To Test:
`JETPACKHOST=PRESSABLE mocha specs/wp-plan-purchase-spec.js -g 'Viewing a specific plan with coupon'`