### PR TITLE
Remove media upload workaround for calypso.live

### DIFF
--- a/specs/wp-media-upload-spec.js
+++ b/specs/wp-media-upload-spec.js
@@ -10,7 +10,6 @@ import PostEditorSidebarComponent from '../lib/components/post-editor-sidebar-co
 import * as driverManager from '../lib/driver-manager.js';
 import * as mediaHelper from '../lib/media-helper.js';
 import * as dataHelper from '../lib/data-helper';
-import * as SlackNotifier from '../lib/slack-notifier';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -29,16 +28,6 @@ describe( `[${ host }] Editor: Media Upload (${ screenSize }) @parallel @jetpack
 
 	describe( 'Image Upload:', function() {
 		let editorPage;
-
-		beforeEach( async function() {
-			if ( dataHelper.getCalypsoURL().indexOf( 'calypso.live' ) > -1 ) {
-				await SlackNotifier.warn(
-					'Media upload tests are being skipped on calypso.live due to https://github.com/Automattic/dserve/issues/69',
-					{ suppressDuplicateMessages: true }
-				);
-				return this.skip();
-			}
-		} );
 
 		before( async function() {
 			const loginFlow = new LoginFlow( driver );

--- a/specs/wp-page-editor-spec.js
+++ b/specs/wp-page-editor-spec.js
@@ -18,7 +18,6 @@ import * as mediaHelper from '../lib/media-helper.js';
 import * as dataHelper from '../lib/data-helper.js';
 import * as driverHelper from '../lib/driver-helper';
 import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
-import * as SlackNotifier from '../lib/slack-notifier';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -40,16 +39,6 @@ describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 		const pageTitle = dataHelper.randomPhrase();
 		const pageQuote =
 			'If you have the same problem for a long time, maybe it’s not a problem. Maybe it’s a fact..\n— Itzhak Rabin';
-
-		before( async function() {
-			if ( dataHelper.getCalypsoURL().indexOf( 'calypso.live' ) > -1 ) {
-				await SlackNotifier.warn(
-					'Media upload tests are being skipped on calypso.live due to https://github.com/Automattic/dserve/issues/69',
-					{ suppressDuplicateMessages: true }
-				);
-				return this.skip();
-			}
-		} );
 
 		// Create image file for upload
 		before( async function() {

--- a/specs/wp-post-editor-spec.js
+++ b/specs/wp-post-editor-spec.js
@@ -25,7 +25,6 @@ import * as driverManager from '../lib/driver-manager';
 import * as driverHelper from '../lib/driver-helper';
 import * as mediaHelper from '../lib/media-helper';
 import * as dataHelper from '../lib/data-helper';
-import * as SlackNotifier from '../lib/slack-notifier';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -50,16 +49,6 @@ describe( `[${ host }] Editor: Posts (${ screenSize })`, function() {
 		const newCategoryName = 'Category ' + new Date().getTime().toString();
 		const newTagName = 'Tag ' + new Date().getTime().toString();
 		const publicizeMessage = dataHelper.randomPhrase();
-
-		beforeEach( async function() {
-			if ( dataHelper.getCalypsoURL().indexOf( 'calypso.live' ) > -1 ) {
-				await SlackNotifier.warn(
-					'Media upload tests are being skipped on calypso.live due to https://github.com/Automattic/dserve/issues/69',
-					{ suppressDuplicateMessages: true }
-				);
-				return this.skip();
-			}
-		} );
 
 		// Create image file for upload
 		before( async function() {


### PR DESCRIPTION
Corresponding PR: https://github.com/Automattic/wp-calypso/pull/28185

**Testing Instructions**

1. Once wp-calypso PR is merged re-run tests and media ones should pass against calypso.live