### PR TITLE
Activate Jetpack module before adding Markdown block

### DIFF
--- a/lib/pages/wp-admin/wp-admin-jetpack-modules-page.js
+++ b/lib/pages/wp-admin/wp-admin-jetpack-modules-page.js
@@ -1,0 +1,29 @@
+/** @format */
+
+import { By } from 'selenium-webdriver';
+
+import * as driverHelper from '../../driver-helper';
+import AsyncBaseContainer from '../../async-base-container';
+
+export default class WPAdminJetpackModulesPage extends AsyncBaseContainer {
+	constructor( driver, url ) {
+		super( driver, By.css( '.jetpack-modules-list-table-form' ), url );
+	}
+
+	static getPageURL( url ) {
+		return url + '/wp-admin/admin.php?page=jetpack_modules';
+	}
+
+	async activateMarkdown() {
+		const markdownActivateLinkSelector = By.css( '#markdown .activate a' );
+		const isNotActive = await driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			markdownActivateLinkSelector,
+			5000
+		);
+		if ( ! isNotActive ) {
+			return true;
+		}
+		return await driverHelper.followLinkWhenFollowable( this.driver, markdownActivateLinkSelector );
+	}
+}

--- a/specs-blocks/gutenberg-markdown-block-spec.js
+++ b/specs-blocks/gutenberg-markdown-block-spec.js
@@ -10,6 +10,8 @@ import PostAreaComponent from '../lib/pages/frontend/post-area-component.js';
 import GutenbergEditorHeaderComponent from '../lib/gutenberg/gutenberg-editor-header-component.js';
 import * as driverManager from '../lib/driver-manager.js';
 import * as dataHelper from '../lib/data-helper.js';
+import WPAdminJetpackModulesPage from '../lib/pages/wp-admin/wp-admin-jetpack-modules-page.js';
+import WPAdminJetpackPage from '../lib/pages/wp-admin/wp-admin-jetpack-page.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -17,6 +19,7 @@ const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 let driver;
+let url;
 
 // FIXME: Skip mobile tests for now. https://github.com/Automattic/wp-e2e-tests/issues/1509
 if ( screenSize !== 'mobile' ) {
@@ -45,8 +48,20 @@ if ( screenSize !== 'mobile' ) {
 
 			step( 'Can create wporg site and connect Jetpack', async function() {
 				this.timeout( mochaTimeOut * 12 );
+				// const jnFlow = new JetpackConnectFlow( driver, 'jetpackConnectUser' );
 				const jnFlow = new JetpackConnectFlow( driver, 'jetpackConnectUser', 'gutenpack' );
-				return await jnFlow.connectFromWPAdmin();
+				await jnFlow.connectFromWPAdmin();
+				url = jnFlow.url;
+			} );
+
+			step( 'Can activate Markdown module', async function() {
+				await WPAdminSidebar.refreshIfJNError( driver );
+				const jetpackModulesPage = await WPAdminJetpackModulesPage.Visit(
+					driver,
+					WPAdminJetpackModulesPage.getPageURL( url )
+				);
+				await jetpackModulesPage.activateMarkdown();
+				await WPAdminJetpackPage.Expect( driver );
 			} );
 
 			step( 'Can start new post', async function() {


### PR DESCRIPTION
Right now Markdown block needs to be activated before it will become visible in Gutenberg editor. This PR adds module activation.

to test: run `JETPACKHOST=PRESSABLE mocha specs-blocks/`