### PR TITLE
Add jetpack Markdown block test for Calypso env

### DIFF
--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -215,15 +215,12 @@ export function getJetpackSiteName() {
 		if ( contents instanceof Buffer ) {
 			contents = contents.toString();
 		}
-		return contents
-			.split( ' ' )[ 0 ]
-			.replace( /^https?:\/\//, '' )
-			.replace( /\/wp-admin/, '' );
+		return this.getSiteSlug( contents.split( ' ' )[ 0 ] );
 	}
 
 	// Other Jetpack site
 	let siteName = this.getAccountConfig( 'jetpackUser' + host )[ 2 ];
-	return siteName.replace( /^https?:\/\//, '' ).replace( /\/wp-admin/, '' );
+	return this.getSiteSlug( siteName );
 }
 
 export function getTestCreditCardDetails() {
@@ -272,4 +269,8 @@ export function _appendQueryString( existingQueryString, queryStringPair ) {
 		return `?${ queryStringPair }`;
 	}
 	return `${ existingQueryString }&${ queryStringPair }`;
+}
+
+export function getSiteSlug( url ) {
+	return url.replace( /^https?:\/\//, '' ).replace( /\/wp-admin/, '' );
 }

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -17,7 +17,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		this.publishingSpinnerSelector = By.css(
 			'.editor-post-publish-panel__content .components-spinner'
 		);
-		this.prePublishButtonSelector = By.css( '.editor-post-publish-panel__toggle' );
+		this.prePublishButtonSelector = By.css( '.editor-post-publish-panel__toggle:not([disabled])' );
 		this.publishHeaderSelector = By.css( '.editor-post-publish-panel__header' );
 	}
 

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -190,7 +190,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async ensureSaved() {
-		await driverHelper.clickIfPresent( this.driver, By.css( '.editor-post-save-draft' ) );
+		await driverHelper.clickWhenClickable( this.driver, By.css( '.editor-post-save-draft' ) );
 		const savedSelector = By.css( 'span.is-saved' );
 
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, savedSelector );

--- a/lib/pages/wp-admin/wp-admin-dashboard-page.js
+++ b/lib/pages/wp-admin/wp-admin-dashboard-page.js
@@ -3,6 +3,7 @@
 import { By } from 'selenium-webdriver';
 
 import * as driverHelper from '../../driver-helper';
+import * as dataHelper from '../../data-helper';
 import AsyncBaseContainer from '../../async-base-container';
 
 export default class WPAdminDashboardPage extends AsyncBaseContainer {
@@ -38,8 +39,7 @@ export default class WPAdminDashboardPage extends AsyncBaseContainer {
 	}
 
 	static getUrl( url ) {
-		url = url.replace( /^https?:\/\//, '' ).replace( /\/wp-admin/, '' );
-		return `https://${ url }/wp-admin`;
+		return `https://${ dataHelper.getSiteSlug( url ) }/wp-admin`;
 	}
 
 	static async refreshIfJNError( driver ) {

--- a/lib/pages/wp-admin/wp-admin-logon-page.js
+++ b/lib/pages/wp-admin/wp-admin-logon-page.js
@@ -3,14 +3,14 @@
 import { By } from 'selenium-webdriver';
 
 import * as driverHelper from '../../driver-helper';
+import * as dataHelper from '../../data-helper';
 import AsyncBaseContainer from '../../async-base-container';
 
 export default class WPAdminLogonPage extends AsyncBaseContainer {
 	constructor( driver, url ) {
 		let wpAdminURL = null;
 		if ( url ) {
-			url = url.replace( /^https?:\/\//, '' ).replace( /\/wp-admin/, '' );
-			wpAdminURL = `http://${ url }/wp-admin`;
+			wpAdminURL = `http://${ dataHelper.getSiteSlug( url ) }/wp-admin`;
 		}
 		super( driver, By.css( '.login' ), wpAdminURL );
 	}

--- a/specs-blocks/gutenberg-markdown-block-spec.js
+++ b/specs-blocks/gutenberg-markdown-block-spec.js
@@ -117,6 +117,7 @@ function markdownTestSteps() {
 
 	step( 'Can publish the post and see its content', async function() {
 		const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+		await gEditorComponent.ensureSaved();
 		await gEditorComponent.publish( { visit: true } );
 		const postFrontend = await PostAreaComponent.Expect( driver );
 		const html = await postFrontend.getPostHTML();

--- a/specs-blocks/gutenberg-markdown-block-spec.js
+++ b/specs-blocks/gutenberg-markdown-block-spec.js
@@ -39,7 +39,7 @@ if ( screenSize !== 'mobile' ) {
 		driver = await driverManager.startBrowser();
 	} );
 
-	describe( `[${ host }] Gutenberg Markdown block: (${ screenSize }) @jetpack`, function() {
+	describe( `[${ host }] Gutenberg Markdown block: (${ screenSize })`, function() {
 		this.timeout( mochaTimeOut );
 
 		before( 'Prepare Site for testing', async function() {
@@ -65,7 +65,7 @@ if ( screenSize !== 'mobile' ) {
 			}
 		} );
 
-		describe( '[WP-Admin] Publish a simple post with Markdown block', function() {
+		describe( '[WP-Admin] Publish a simple post with Markdown block  @parallel @jetpack', function() {
 			step( 'Can login to WPORG site', async function() {
 				const loginPage = await WPAdminLogonPage.Visit( driver, jnFlow.url );
 				await loginPage.login( jnFlow.username, jnFlow.password );
@@ -80,7 +80,7 @@ if ( screenSize !== 'mobile' ) {
 			markdownTestSteps();
 		} );
 
-		describe( '[Calypso] Publish a simple post with Markdown block', function() {
+		describe( '[Calypso] Publish a simple post with Markdown block  @parallel @jetpack', function() {
 			step( 'Can login to WPCOM and start new post', async function() {
 				const loginFlow = new LoginFlow( driver, 'jetpackConnectUser' );
 				await loginFlow.login();

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -103,7 +103,7 @@ describe( `Jetpack Connect: (${ screenSize })`, function() {
 		} );
 
 		step( 'Has site URL in route', async function( done ) {
-			const siteSlug = this.jnFlow.url.replace( /^https?:\/\//, '' );
+			const siteSlug = dataHelper.getSiteSlug( this.jnFlow.url );
 			let url = await driver.getCurrentUrl();
 			if ( url.includes( siteSlug ) ) {
 				return done();


### PR DESCRIPTION
Re-uses existing Markdown block test to run in Calypso environment. 
For now, it works only with Jetpack sites (via JN), but it can be easily ported to WPCOM sites. 

To test:
run `JETPACKHOST=PRESSABLE mocha specs-blocks/`