### PR TITLE
Adding ability to run all test suites on PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,3 +38,6 @@ jobs:
           path: reports/
       - store_artifacts:
           path: screenshots/
+notify:
+  webhooks:
+  - url: https://6578b9f2.ngrok.io/circleciwebhook

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,4 +40,4 @@ jobs:
           path: screenshots/
 notify:
   webhooks:
-  - url: https://6578b9f2.ngrok.io/circleciwebhook
+  - url: https://a8c-gh-e2e-bridge.go-vip.co/circleciwebhook

--- a/README.md
+++ b/README.md
@@ -58,5 +58,3 @@ See the information on [how to run tests](docs/running-tests.md) where you'll fi
 ## Other information
 
 See the [other information](docs/miscellaneous.md) documentation for other details that may be of interest.
-
-just a change

--- a/README.md
+++ b/README.md
@@ -58,3 +58,5 @@ See the information on [how to run tests](docs/running-tests.md) where you'll fi
 ## Other information
 
 See the [other information](docs/miscellaneous.md) documentation for other details that may be of interest.
+
+just a change


### PR DESCRIPTION
Adds a webhook for CircleCI to call when the build is complete to update the test status. A new webhook will need to be added to this Repo when this change is merged. This corresponds with https://github.com/Automattic/wp-e2e-tests-gh-bridge/pull/54 and should be merged after that one.