### PR TITLE
Update the signup flow test cases for Business users

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1228,8 +1228,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await gSuiteUpsellPage.declineEmail();
 		} );
 
-		step( 'Can see the secure check out thank you page', async function() {
-			return await CheckOutThankyouPage.Expect( driver );
+		step( 'Can then see the onboarding checklist', async function() {
+			const checklistPage = await ChecklistPage.Expect( driver );
+			const header = await checklistPage.headerExists();
+			const subheader = await checklistPage.subheaderExists();
+
+			assert( header, 'The checklist header does not exist.' );
+
+			return assert( subheader, 'The checklist subheader does not exist.' );
 		} );
 
 		step( 'Can cancel the domain', async function() {


### PR DESCRIPTION
Since we're going to enable the onboarding checklist for the Business(https://github.com/Automattic/wp-calypso/pull/28117), the corresponding test cases should be updated as well.