### PR TITLE
Add 'Delete plan' flow

### DIFF
--- a/lib/flows/delete-plan-flow.js
+++ b/lib/flows/delete-plan-flow.js
@@ -1,0 +1,44 @@
+/** @format */
+
+import ManagePurchasePage from '../pages/manage-purchase-page';
+import CancelPurchasePage from '../pages/cancel-purchase-page';
+import * as SlackNotifier from '../slack-notifier';
+import NavBarComponent from '../components/nav-bar-component';
+import ProfilePage from '../pages/profile-page';
+import PurchasesPage from '../pages/purchases-page';
+
+export default class DeletePlanFlow {
+	constructor( driver ) {
+		this.driver = driver;
+	}
+	async deletePlan( planName ) {
+		return ( async () => {
+			const navBarComponent = await NavBarComponent.Expect( this.driver );
+			await navBarComponent.clickProfileLink();
+			const profilePage = await ProfilePage.Expect( this.driver );
+			await profilePage.chooseManagePurchases();
+			const purchasesPage = await PurchasesPage.Expect( this.driver );
+			await purchasesPage.dismissGuidedTour();
+
+			if ( planName === 'business' ) {
+				await purchasesPage.selectBusinessPlan();
+			} else if ( planName === 'premium' ) {
+				await purchasesPage.selectPremiumPlan();
+			} else if ( planName === 'personal' ) {
+				await purchasesPage.selectPersonalPlan();
+			}
+
+			const managePurchasePage = await ManagePurchasePage.Expect( this.driver );
+			await managePurchasePage.chooseCancelAndRefund();
+			const cancelPurchasePage = await CancelPurchasePage.Expect( this.driver );
+			await cancelPurchasePage.clickCancelPurchase();
+			await cancelPurchasePage.completeCancellationSurvey();
+			return await cancelPurchasePage.waitAndDismissSuccessNotice();
+		} )().catch( err => {
+			SlackNotifier.warn(
+				`There was an error in the hooks that clean up the test account (delete plan) but since it is cleaning up we really don't care: '${ err }'`,
+				{ suppressDuplicateMessages: true }
+			);
+		} );
+	}
+}

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -51,6 +51,7 @@ import * as SlackNotifier from '../lib/slack-notifier';
 import EmailClient from '../lib/email-client.js';
 import NewUserRegistrationUnavailableComponent from '../lib/components/new-user-domain-registration-unavailable-component';
 import DeleteAccountFlow from '../lib/flows/delete-account-flow';
+import DeletePlanFlow from '../lib/flows/delete-plan-flow';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -531,26 +532,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can delete the plan', async function() {
-			return ( async () => {
-				const navBarComponent = await NavBarComponent.Expect( driver );
-				await navBarComponent.clickProfileLink();
-				const profilePage = await ProfilePage.Expect( driver );
-				await profilePage.chooseManagePurchases();
-				const purchasesPage = await PurchasesPage.Expect( driver );
-				await purchasesPage.dismissGuidedTour();
-				await purchasesPage.selectPremiumPlan();
-				const managePurchasePage = await ManagePurchasePage.Expect( driver );
-				await managePurchasePage.chooseCancelAndRefund();
-				const cancelPurchasePage = await CancelPurchasePage.Expect( driver );
-				await cancelPurchasePage.clickCancelPurchase();
-				await cancelPurchasePage.completeCancellationSurvey();
-				return await cancelPurchasePage.waitAndDismissSuccessNotice();
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeletePlanFlow( driver ).deletePlan( 'premium' );
 		} );
 
 		step( 'Can delete our newly created account', async function() {
@@ -686,26 +668,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can delete the plan', async function() {
-			return ( async () => {
-				const navBarComponent = await NavBarComponent.Expect( driver );
-				await navBarComponent.clickProfileLink();
-				const profilePage = await ProfilePage.Expect( driver );
-				await profilePage.chooseManagePurchases();
-				const purchasesPage = await PurchasesPage.Expect( driver );
-				await purchasesPage.dismissGuidedTour();
-				await purchasesPage.selectPremiumPlan();
-				const managePurchasePage = await ManagePurchasePage.Expect( driver );
-				await managePurchasePage.chooseCancelAndRefund();
-				const cancelPurchasePage = await CancelPurchasePage.Expect( driver );
-				await cancelPurchasePage.clickCancelPurchase();
-				await cancelPurchasePage.completeCancellationSurvey();
-				return await cancelPurchasePage.waitAndDismissSuccessNotice();
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeletePlanFlow( driver ).deletePlan( 'premium' );
 		} );
 
 		step( 'Can delete our newly created account', async function() {
@@ -841,26 +804,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can delete the plan', async function() {
-			return ( async () => {
-				const navBarComponent = await NavBarComponent.Expect( driver );
-				await navBarComponent.clickProfileLink();
-				const profilePage = await ProfilePage.Expect( driver );
-				await profilePage.chooseManagePurchases();
-				const purchasesPage = await PurchasesPage.Expect( driver );
-				await purchasesPage.dismissGuidedTour();
-				await purchasesPage.selectPersonalPlan();
-				const managePurchasePage = await ManagePurchasePage.Expect( driver );
-				await managePurchasePage.chooseCancelAndRefund();
-				const cancelPurchasePage = await CancelPurchasePage.Expect( driver );
-				await cancelPurchasePage.clickCancelPurchase();
-				await cancelPurchasePage.completeCancellationSurvey();
-				return await cancelPurchasePage.waitAndDismissSuccessNotice();
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeletePlanFlow( driver ).deletePlan( 'personal' );
 		} );
 
 		step( 'Can delete our newly created account', async function() {


### PR DESCRIPTION
Similar as #1585 - adding new _Delete plan_ flow, so we can use it where is necessary.

Background: We have [`Can delete the plan`](https://github.com/Automattic/wp-e2e-tests/blob/master/specs/wp-signup-spec.js#L533) steps in several tests and all of them are identical. The only difference is which plan should be deleted.

With this new flow is much easier to add a new step for plan deletion. 

To test: Make sure that tests from `wp-signup-spec.js` work as usual. 