### PR TITLE
Fix window width on mobile test runs

### DIFF
--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -131,6 +131,7 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 				} );
 				options.setProxy( this.getProxyType() );
 				options.addArguments( '--no-first-run' );
+				options.addArguments( '--kiosk' );
 				options.addArguments( getChromeWindowSize( screenSize ) );
 
 				if ( useCustomUA ) {

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -131,7 +131,6 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 				} );
 				options.setProxy( this.getProxyType() );
 				options.addArguments( '--no-first-run' );
-				options.addArguments( '--kiosk' );
 				options.addArguments( getChromeWindowSize( screenSize ) );
 
 				if ( useCustomUA ) {
@@ -154,6 +153,7 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 				}
 
 				if ( process.env.CI === 'true' ) {
+					options.addArguments( '--kiosk' );
 					options.addArguments( '--app=https://www.wordpress.com' );
 				}
 

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -131,6 +131,7 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 				} );
 				options.setProxy( this.getProxyType() );
 				options.addArguments( '--no-first-run' );
+				options.addArguments( getChromeWindowSize( screenSize ) );
 
 				if ( useCustomUA ) {
 					options.addArguments(
@@ -194,7 +195,7 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 	driver
 		.manage()
 		.setTimeouts( { implicit: webDriverImplicitTimeOutMS, pageLoad: webDriverPageLoadTimeOutMS } );
-	if ( resizeBrowserWindow ) {
+	if ( resizeBrowserWindow && browser.toLowerCase() !== 'chrome' ) {
 		this.resizeBrowser( driver, screenSize );
 	}
 
@@ -242,6 +243,39 @@ export async function resizeBrowser( driver, screenSize ) {
 				'). Supported values are desktop, tablet and mobile.'
 		);
 	}
+}
+
+export function getChromeWindowSize( screenSize ) {
+	let windowSize;
+	if ( typeof screenSize === 'string' ) {
+		switch ( screenSize.toLowerCase() ) {
+			case 'mobile':
+				windowSize = '--window-size=400,1000';
+				break;
+			case 'tablet':
+				windowSize = '--window-size=1024,1000';
+				break;
+			case 'desktop':
+				windowSize = '--window-size=1440,1000';
+				break;
+			case 'laptop':
+				windowSize = '--window-size=1400,790';
+				break;
+			default:
+				throw new Error(
+					'Unsupported screen size specified (' +
+					screenSize +
+					'). Supported values are desktop, tablet and mobile.'
+				);
+		}
+	} else {
+		throw new Error(
+			'Unsupported screen size specified (' +
+			screenSize +
+			'). Supported values are desktop, tablet and mobile.'
+		);
+	}
+	return windowSize;
 }
 
 export async function clearCookiesAndDeleteLocalStorage( driver, siteURL = null ) {

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -152,6 +152,10 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 					options.addArguments( `--display=:${global.displayNum}` );
 				}
 
+				if ( process.env.CI === 'true' ) {
+					options.addArguments( '--app=https://www.wordpress.com' );
+				}
+
 				const service = new chrome.ServiceBuilder( chromedriver.path ).build();
 				chrome.setDefaultService( service );
 


### PR DESCRIPTION
This PR changes the way we size the window for tests. The first thing it does is it uses the `--window-size` argument on Chrome browser. This opens the window at the size we want and doesn't rely on the `resize` functionality which can give unpredictable widths. The second part removes all the toolbars. The toolbars prevent the window from resizing to where we want it in CircleCI (490px instead of 400px). The `--kiosk` argument along with the `--app` argument  handle removing the toolbars while still allowing new windows to be opened, which is needed in some tests. I have it set to only remove the toolbars in CircleCI so that the buttons and urls can still be accessed in local troubleshooting.

To Test:
Run the tests and make sure the width of the browser is the expected width and is consistent across runs. 
