### PR TITLE
Fix Theme purchase test/cleanup

### DIFF
--- a/lib/flows/delete-plan-flow.js
+++ b/lib/flows/delete-plan-flow.js
@@ -26,6 +26,8 @@ export default class DeletePlanFlow {
 				await purchasesPage.selectPremiumPlan();
 			} else if ( planName === 'personal' ) {
 				await purchasesPage.selectPersonalPlan();
+			} else if ( planName === 'theme' ) {
+				await purchasesPage.selectTheme();
 			}
 
 			const managePurchasePage = await ManagePurchasePage.Expect( this.driver );

--- a/lib/pages/purchases-page.js
+++ b/lib/pages/purchases-page.js
@@ -32,6 +32,14 @@ export default class PurchasesPage extends AsyncBaseContainer {
 		return await this._selectPlanOnConnectedSite( 'premium' );
 	}
 
+	async selectTheme() {
+		await this._waitForPurchases();
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			by.css( 'a.purchase-item svg.gridicons-themes' )
+		);
+	}
+
 	async dismissGuidedTour() {
 		return await driverHelper.clickIfPresent(
 			this.driver,

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -52,6 +52,7 @@ import EmailClient from '../lib/email-client.js';
 import NewUserRegistrationUnavailableComponent from '../lib/components/new-user-domain-registration-unavailable-component';
 import DeleteAccountFlow from '../lib/flows/delete-account-flow';
 import DeletePlanFlow from '../lib/flows/delete-plan-flow';
+import ThemeDialogComponent from '../lib/components/theme-dialog-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -1388,6 +1389,23 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 				);
 			}
 		);
+
+		step( 'Can submit test payment details', async function() {
+			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
+			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
+			await securePaymentComponent.submitPaymentDetails();
+			return await securePaymentComponent.waitForPageToDisappear();
+		} );
+
+		step( 'Can see the theme thanks dialog', async function() {
+			const themeDialogComponent = await ThemeDialogComponent.Expect( driver );
+			await themeDialogComponent.goToThemeDetail();
+		} );
+
+		step( 'Can delete the plan', async function() {
+			return await new DeletePlanFlow( driver ).deletePlan( 'theme' );
+		} );
 
 		step( 'Can delete our newly created account', async function() {
 			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );


### PR DESCRIPTION
Slack was showing some failed cleanup messages. They were occurring because this test wasn't being left in a state to clean it up. I finished the flow and added the ability to delete the plan for themes as well.

To Test:
Make sure it passes and that there aren't any console message/slack messages about account cleanup failing