### PR TITLE
Skip video recording if dependencies don't install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Install screen recording dependencies
           command: |
-            sudo apt install -y ffmpeg || echo 'export TEST_VIDEO=false' >> $BASH_ENV
+            sudo apt install -y ffmpe43g || echo 'export TEST_VIDEO=false' >> $BASH_ENV
       - run: ./scripts/randomize.sh specs
       - run: ./scripts/run-wrapper.sh
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,8 @@ jobs:
       - run: npm run lint
       - run:
           name: Install screen recording dependencies
-          command: sudo apt install -y ffmpeg
+          command: |
+            sudo apt install -y ffmpeg || echo 'export TEST_VIDEO=false' >> $BASH_ENV
       - run: ./scripts/randomize.sh specs
       - run: ./scripts/run-wrapper.sh
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Install screen recording dependencies
           command: |
-            sudo apt install -y ffmpe43g || echo 'export TEST_VIDEO=false' >> $BASH_ENV
+            sudo apt install -y ffmpeg || echo 'export TEST_VIDEO=false' >> $BASH_ENV
       - run: ./scripts/randomize.sh specs
       - run: ./scripts/run-wrapper.sh
       - store_test_results:

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -162,7 +162,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 				'The number of newly registered emails is not equal to 2 (activation and magic link)'
 			);
 			for ( let email of emails ) {
-				if ( email.subject.includes( 'WordPreasdfss.com' ) ) {
+				if ( email.subject.includes( 'WordPress.com' ) ) {
 					return ( magicLoginLink = email.html.links[ 0 ].href );
 				}
 			}

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -162,7 +162,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 				'The number of newly registered emails is not equal to 2 (activation and magic link)'
 			);
 			for ( let email of emails ) {
-				if ( email.subject.includes( 'WordPress.com' ) ) {
+				if ( email.subject.includes( 'WordPreasdfss.com' ) ) {
 					return ( magicLoginLink = email.html.links[ 0 ].href );
 				}
 			}


### PR DESCRIPTION
Closes #1543 

If for some reason the dependencies for video recordings fail, we don't want the build to fail, we just want to disable video for that run. This PR does just that
