### PR TITLE
Add the `calypsoifyGutenberg` key to known tests.

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -64,6 +64,7 @@
 		"cartNudgeUpdateToPremium",
 		"signupAtomicStoreVsPressable",
 		"krackenRebootM33",
+		"calypsoifyGutenberg",
 		"improvedOnboarding"
 	],
 	"overrideABTests": [

--- a/config/default.json
+++ b/config/default.json
@@ -75,6 +75,7 @@
 		[ "improvedOnboarding_20181023", "main" ],
 		[ "cartNudgeUpdateToPremium_20180903", "control" ],
 		[ "signupAtomicStoreVsPressable_20171101", "atomic" ],
-		[ "krackenRebootM33_20181108", "domainsbot_front" ]
+		[ "krackenRebootM33_20181108", "domainsbot_front" ],
+		[ "calypsoifyGutenberg_20181112", "no" ]
 	]
 }


### PR DESCRIPTION
See: https://github.com/Automattic/wp-calypso/pull/28374