### PR TITLE
Disable video when running in headless mode.

### DIFF
--- a/lib/video-recorder.js
+++ b/lib/video-recorder.js
@@ -1,4 +1,5 @@
 /** @format */
+import config from 'config';
 import path from 'path';
 import fs from 'fs';
 import child_process from 'child_process';
@@ -21,6 +22,11 @@ function createDir( dir ) {
 	}
 }
 
+function isVideoEnabled() {
+	let video = config.has( 'useTestVideo' ) ? config.get( 'useTestVideo' ) : process.env.TEST_VIDEO;
+	return video === 'true';
+}
+
 function getFreeDisplay() {
 	let i = 99 + Math.round( Math.random() * 100 );
 	while ( fs.existsSync( `/tmp/.X${ i }-lock` ) ) {
@@ -30,7 +36,7 @@ function getFreeDisplay() {
 }
 
 export function startDisplay() {
-	if ( process.env.TEST_VIDEO !== 'true' ) {
+	if ( ! isVideoEnabled() ) {
 		return;
 	}
 	getFreeDisplay();
@@ -46,13 +52,13 @@ export function startDisplay() {
 }
 
 export function stopDisplay() {
-	if ( process.env.TEST_VIDEO === 'true' && xvfb ) {
+	if ( isVideoEnabled() && xvfb ) {
 		xvfb.kill();
 	}
 }
 
 export function startVideo() {
-	if ( process.env.TEST_VIDEO !== 'true' ) {
+	if ( ! isVideoEnabled() ) {
 		return;
 	}
 	const dateTime = new Date()
@@ -80,7 +86,7 @@ export function startVideo() {
 }
 
 export function stopVideo( currentTest = null ) {
-	if ( process.env.TEST_VIDEO !== 'true' ) {
+	if ( ! isVideoEnabled() ) {
 		return;
 	}
 	if ( currentTest && ffmpeg ) {

--- a/run.sh
+++ b/run.sh
@@ -160,7 +160,7 @@ while getopts ":a:RpS:B:s:gjWCJH:wzyl:cm:fiIUvxu:h" opt; do
       export JETPACKHOST=$OPTARG
       ;;
     x)
-      NODE_CONFIG_ARGS+=("\"headless\":\"true\"")
+      NODE_CONFIG_ARGS+=("\"headless\":\"true\",\"useTestVideo\":\"false\"")
 #       MAGELLAN="xvfb-run $MAGELLAN"
       ;;
     u)


### PR DESCRIPTION
This PR disables test videos in headless mode. When the `-x` flag is added, a node config variable is added that overrides the `TEST_VIDEO` environment variable. This is to prevent black videos on some CI test runs since some jobs are being run with the `-x-` flag. 

To test:
Try running some different options on the command line.

On Mac terminal
`TEST_VIDEO=true ./run.sh -x -g` - Tests should pass.
`TEST_VIDEO=true ./run.sh -g` - Tests should fail with error about xvfb
`./run.sh -g` - Tests should pass
`./run.sh -x -g` - Tests should pass
