### PR TITLE
Update ie11 config to fix broken sauce labs tests

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -53,9 +53,9 @@
 			"browserName": "Internet Explorer",
 			"platform": "Windows 10",
 			"screenResolution": "2560x1600",
-			"version": "11.103",
-		  	"iedriverVersion": "3.11.0",
-		  	"seleniumVersion": "3.11.0"
+			"version": "11.285",
+		  	"iedriverVersion": "3.141.0",
+		  	"seleniumVersion": "3.141.0"
 		}
 	},
 	"knownABTestKeys": [

--- a/config/default.json
+++ b/config/default.json
@@ -53,7 +53,9 @@
 			"browserName": "Internet Explorer",
 			"platform": "Windows 10",
 			"screenResolution": "2560x1600",
-			"version": "11.103"
+			"version": "11.103",
+		  	"iedriverVersion": "3.12.0",
+		  	"seleniumVersion": "3.12.0"
 		}
 	},
 	"knownABTestKeys": [

--- a/config/default.json
+++ b/config/default.json
@@ -54,8 +54,8 @@
 			"platform": "Windows 10",
 			"screenResolution": "2560x1600",
 			"version": "11.103",
-		  	"iedriverVersion": "3.12.0",
-		  	"seleniumVersion": "3.12.0"
+		  	"iedriverVersion": "3.11.0",
+		  	"seleniumVersion": "3.11.0"
 		}
 	},
 	"knownABTestKeys": [

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -66,7 +66,7 @@ export function getProxyType() {
 	}
 }
 
-export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true } = {} ) {
+export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = true } = {} ) {
 	if ( global.__BROWSER__ ) {
 		return global.__BROWSER__;
 	}
@@ -197,11 +197,11 @@ export function startBrowser( { useCustomUA = true, resizeBrowserWindow = true }
 				);
 		}
 	}
-	driver
+	await driver
 		.manage()
 		.setTimeouts( { implicit: webDriverImplicitTimeOutMS, pageLoad: webDriverPageLoadTimeOutMS } );
 	if ( resizeBrowserWindow && browser.toLowerCase() !== 'chrome' ) {
-		this.resizeBrowser( driver, screenSize );
+		await this.resizeBrowser( driver, screenSize );
 	}
 
 	return driver;
@@ -290,7 +290,7 @@ export async function clearCookiesAndDeleteLocalStorage( driver, siteURL = null 
 	let url = await driver.getCurrentUrl();
 	await driver.manage().deleteAllCookies();
 	if ( url.startsWith( 'data:' ) === false && url !== 'about:blank' ) {
-		return driver.executeScript( 'window.localStorage.clear();' );
+		return await driver.executeScript( 'window.localStorage.clear();' );
 	}
 }
 

--- a/lib/mocha-hooks.js
+++ b/lib/mocha-hooks.js
@@ -37,7 +37,7 @@ afterEach( function() {
 } );
 
 // Take Screenshot
-afterEach( function() {
+afterEach( async function() {
 	this.timeout( afterHookTimeoutMS );
 	if ( ! this.currentTest ) {
 		return;
@@ -79,7 +79,7 @@ afterEach( function() {
 		return;
 	}
 
-	return driver.takeScreenshot().then(
+	return await driver.takeScreenshot().then(
 		data => {
 			return driver.getCurrentUrl().then( url => {
 				return mediaHelper.writeScreenshot( data, filenameCallback, { url } );
@@ -129,12 +129,12 @@ afterEach( async function() {
 } );
 
 // Push SauceLabs job status update (if applicable)
-after( function() {
+after( async function() {
 	this.timeout( afterHookTimeoutMS );
 	const driver = global.__BROWSER__;
 
 	if ( config.has( 'sauce' ) && config.get( 'sauce' ) ) {
-		driver.executeScript( 'sauce:job-result=' + driver.allPassed );
+		await driver.executeScript( 'sauce:job-result=' + driver.allPassed );
 	}
 } );
 


### PR DESCRIPTION
For some reason, deleteAllCookies stopped working on Sauce Labs IE. Changing the iedriverVersion and Selenium version makes it work again. Fixes #1605 

To Test:
Run locally: `./run.sh -z`