### PR TITLE
Add the first create page spec to use Gutenberg

### DIFF
--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -77,16 +77,18 @@ export default class LoginFlow {
 		}
 	}
 
-	async loginAndStartNewPage( site = null ) {
+	async loginAndStartNewPage( site = null, usingGutenberg = false ) {
 		await this.loginAndSelectMySite( site );
 
 		const sidebarComponent = await SidebarComponent.Expect( this.driver );
 		await sidebarComponent.selectAddNewPage();
 
-		this.editorPage = await EditorPage.Expect( this.driver );
+		if ( ! usingGutenberg ) {
+			this.editorPage = await EditorPage.Expect( this.driver );
 
-		let urlDisplayed = await this.driver.getCurrentUrl();
-		return await this.editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
+			let urlDisplayed = await this.driver.getCurrentUrl();
+			return await this.editorPage.setABTestControlGroupsInLocalStorage( urlDisplayed );
+		}
 	}
 
 	async loginAndSelectDomains() {

--- a/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -1,0 +1,65 @@
+/** @format */
+
+import { By } from 'selenium-webdriver';
+import * as driverHelper from '../driver-helper.js';
+import AsyncBaseContainer from '../async-base-container';
+import * as driverManager from '../driver-manager';
+
+export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.block-editor.gutenberg' ) );
+		this.cogSelector = By.css( '[aria-label="Settings"]:not([disabled])' );
+		this.closeSelector = By.css( '[aria-label="Close settings"]:not([disabled])' );
+	}
+
+	async _postInit() {
+		return await this.displayComponentIfNecessary();
+	}
+
+	async displayComponentIfNecessary() {
+		if ( driverManager.currentScreenSize() === 'mobile' ) {
+			const driver = this.driver;
+			let c = await driver.findElement( this.cogSelector ).getAttribute( 'class' );
+			if ( c.indexOf( 'is-toggled' ) < 0 ) {
+				return await driverHelper.clickWhenClickable( driver, this.cogSelector );
+			}
+		}
+	}
+
+	async hideComponentIfNecessary() {
+		if ( driverManager.currentScreenSize() === 'mobile' ) {
+			const driver = this.driver;
+
+			let c = await driver.findElement( this.cogSelector ).getAttribute( 'class' );
+			if ( c.indexOf( 'is-toggled' ) > -1 ) {
+				return await driverHelper.clickWhenClickable( driver, this.closeSelector );
+			}
+		}
+	}
+
+	async chooseDocumentSetttings() {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '[data-label="Document"]' )
+		);
+	}
+
+	async setVisibilityToPasswordProtected( password ) {
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.edit-post-post-visibility__toggle' )
+		);
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.editor-post-visibility__dialog-radio[value="password"]' )
+		);
+		return await driverHelper.setWhenSettable(
+			this.driver,
+			By.css( '.editor-post-visibility__dialog-password-input' ),
+			password,
+			{
+				secureValue: true,
+			}
+		);
+	}
+}

--- a/specs/wp-gutenberg-page-editor-spec.js
+++ b/specs/wp-gutenberg-page-editor-spec.js
@@ -306,8 +306,8 @@ describe( `[${ host }] Gutenberg Editor: Pages (${ screenSize })`, function() {
 
 		describe( 'Publish a Password Protected Page', function() {
 			step( 'Can log in', async function() {
-				const loginFlow = new LoginFlow( driver );
-				await loginFlow.loginAndStartNewPage();
+				const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+				await loginFlow.loginAndStartNewPage( null, true );
 			} );
 
 			step( 'Can enter page title and content and set to password protected', async function() {
@@ -325,244 +325,228 @@ describe( `[${ host }] Gutenberg Editor: Pages (${ screenSize })`, function() {
 				const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
 				await postEditorToolbarComponent.publishAndViewContent( { useConfirmStep: true } );
 			} );
-		} );
 
-		describe( 'As a logged in user', function() {
-			describe( 'With no password entered', function() {
-				step( 'Can view page title', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const actualPageTitle = await viewPagePage.pageTitle();
-					assert.strictEqual(
-						actualPageTitle.toUpperCase(),
-						( 'Protected: ' + pageTitle ).toUpperCase()
-					);
-				} );
-
-				step( 'Can see password field', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const isPasswordProtected = await viewPagePage.isPasswordProtected();
-					assert.strictEqual(
-						isPasswordProtected,
-						true,
-						'The page does not appear to be password protected'
-					);
-				} );
-
-				step( "Can't see content when no password is entered", async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const content = await viewPagePage.pageContent();
-					assert.strictEqual(
-						content.indexOf( pageQuote ) === -1,
-						true,
-						'The page content (' +
-							content +
-							') displays the expected content (' +
-							pageQuote +
-							') when it should be password protected.'
-					);
-				} );
+			step( 'As a logged in user, With no password entered, Can view page title', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const actualPageTitle = await viewPagePage.pageTitle();
+				assert.strictEqual(
+					actualPageTitle.toUpperCase(),
+					( 'Protected: ' + pageTitle ).toUpperCase()
+				);
 			} );
 
-			describe( 'With incorrect password entered', function() {
-				step( 'Enter incorrect password', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					await viewPagePage.enterPassword( 'password' );
-				} );
-
-				step( 'Can view page title', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const actualPageTitle = await viewPagePage.pageTitle();
-					assert.strictEqual(
-						actualPageTitle.toUpperCase(),
-						( 'Protected: ' + pageTitle ).toUpperCase()
-					);
-				} );
-
-				step( 'Can see password field', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const isPasswordProtected = await viewPagePage.isPasswordProtected();
-					assert.strictEqual(
-						isPasswordProtected,
-						true,
-						'The page does not appear to be password protected'
-					);
-				} );
-
-				step( "Can't see content when incorrect password is entered", async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const content = await viewPagePage.pageContent();
-					assert.strictEqual(
-						content.indexOf( pageQuote ) === -1,
-						true,
-						'The page content (' +
-							content +
-							') displays the expected content (' +
-							pageQuote +
-							') when it should be password protected.'
-					);
-				} );
+			step( 'Can see password field', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const isPasswordProtected = await viewPagePage.isPasswordProtected();
+				assert.strictEqual(
+					isPasswordProtected,
+					true,
+					'The page does not appear to be password protected'
+				);
 			} );
 
-			describe( 'With correct password entered', function() {
-				step( 'Enter correct password', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					await viewPagePage.enterPassword( postPassword );
-				} );
-
-				step( 'Can view page title', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const actualPageTitle = await viewPagePage.pageTitle();
-					assert.strictEqual(
-						actualPageTitle.toUpperCase(),
-						( 'Protected: ' + pageTitle ).toUpperCase()
-					);
-				} );
-
-				step( "Can't see password field", async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const isPasswordProtected = await viewPagePage.isPasswordProtected();
-					assert.strictEqual(
-						isPasswordProtected,
-						false,
-						'The page still seems to be password protected'
-					);
-				} );
-
-				step( 'Can see page content', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const content = await viewPagePage.pageContent();
-					assert.strictEqual(
-						content.indexOf( pageQuote ) > -1,
-						true,
-						'The page content (' +
-							content +
-							') does not include the expected content (' +
-							pageQuote +
-							')'
-					);
-				} );
+			step( "Can't see content when no password is entered", async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const content = await viewPagePage.pageContent();
+				assert.strictEqual(
+					content.indexOf( pageQuote ) === -1,
+					true,
+					'The page content (' +
+						content +
+						') displays the expected content (' +
+						pageQuote +
+						') when it should be password protected.'
+				);
 			} );
-		} );
 
-		describe( 'As a non-logged in user', function() {
-			step( 'Clear cookies (log out)', async function() {
+			step( 'With incorrect password entered, Enter incorrect password', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				await viewPagePage.enterPassword( 'password' );
+			} );
+
+			step( 'Can view page title', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const actualPageTitle = await viewPagePage.pageTitle();
+				assert.strictEqual(
+					actualPageTitle.toUpperCase(),
+					( 'Protected: ' + pageTitle ).toUpperCase()
+				);
+			} );
+
+			step( 'Can see password field', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const isPasswordProtected = await viewPagePage.isPasswordProtected();
+				assert.strictEqual(
+					isPasswordProtected,
+					true,
+					'The page does not appear to be password protected'
+				);
+			} );
+
+			step( "Can't see content when incorrect password is entered", async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const content = await viewPagePage.pageContent();
+				assert.strictEqual(
+					content.indexOf( pageQuote ) === -1,
+					true,
+					'The page content (' +
+						content +
+						') displays the expected content (' +
+						pageQuote +
+						') when it should be password protected.'
+				);
+			} );
+
+			step( 'With correct password entered, Enter correct password', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				await viewPagePage.enterPassword( postPassword );
+			} );
+
+			step( 'Can view page title', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const actualPageTitle = await viewPagePage.pageTitle();
+				assert.strictEqual(
+					actualPageTitle.toUpperCase(),
+					( 'Protected: ' + pageTitle ).toUpperCase()
+				);
+			} );
+
+			step( "Can't see password field", async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const isPasswordProtected = await viewPagePage.isPasswordProtected();
+				assert.strictEqual(
+					isPasswordProtected,
+					false,
+					'The page still seems to be password protected'
+				);
+			} );
+
+			step( 'Can see page content', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const content = await viewPagePage.pageContent();
+				assert.strictEqual(
+					content.indexOf( pageQuote ) > -1,
+					true,
+					'The page content (' +
+						content +
+						') does not include the expected content (' +
+						pageQuote +
+						')'
+				);
+			} );
+
+			step( 'As a non-logged in user, Clear cookies (log out)', async function() {
 				await driver.manage().deleteAllCookies();
 				await driver.navigate().refresh();
 			} );
 
-			describe( 'With no password entered', function() {
-				step( 'Can view page title', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const actualPageTitle = await viewPagePage.pageTitle();
-					assert.strictEqual(
-						actualPageTitle.toUpperCase(),
-						( 'Protected: ' + pageTitle ).toUpperCase()
-					);
-				} );
-
-				step( 'Can see password field', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const isPasswordProtected = await viewPagePage.isPasswordProtected();
-					assert.strictEqual(
-						isPasswordProtected,
-						true,
-						'The page does not appear to be password protected'
-					);
-				} );
-
-				step( "Can't see content when no password is entered", async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const content = await viewPagePage.pageContent();
-					assert.strictEqual(
-						content.indexOf( pageQuote ) === -1,
-						true,
-						'The page content (' +
-							content +
-							') displays the expected content (' +
-							pageQuote +
-							') when it should be password protected.'
-					);
-				} );
+			step( 'With no password entered, Can view page title', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const actualPageTitle = await viewPagePage.pageTitle();
+				assert.strictEqual(
+					actualPageTitle.toUpperCase(),
+					( 'Protected: ' + pageTitle ).toUpperCase()
+				);
 			} );
 
-			describe( 'With incorrect password entered', function() {
-				step( 'Enter incorrect password', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					await viewPagePage.enterPassword( 'password' );
-				} );
-
-				step( 'Can view page title', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const actualPageTitle = await viewPagePage.pageTitle();
-					assert.strictEqual(
-						actualPageTitle.toUpperCase(),
-						( 'Protected: ' + pageTitle ).toUpperCase()
-					);
-				} );
-
-				step( 'Can see password field', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const isPasswordProtected = await viewPagePage.isPasswordProtected();
-					assert.strictEqual(
-						isPasswordProtected,
-						true,
-						'The page does not appear to be password protected'
-					);
-				} );
-
-				step( "Can't see content when incorrect password is entered", async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const content = await viewPagePage.pageContent();
-					assert.strictEqual(
-						content.indexOf( pageQuote ) === -1,
-						true,
-						'The page content (' +
-							content +
-							') displays the expected content (' +
-							pageQuote +
-							') when it should be password protected.'
-					);
-				} );
+			step( 'Can see password field', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const isPasswordProtected = await viewPagePage.isPasswordProtected();
+				assert.strictEqual(
+					isPasswordProtected,
+					true,
+					'The page does not appear to be password protected'
+				);
 			} );
 
-			describe( 'With correct password entered', function() {
-				step( 'Enter correct password', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					await viewPagePage.enterPassword( postPassword );
-				} );
+			step( "Can't see content when no password is entered", async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const content = await viewPagePage.pageContent();
+				assert.strictEqual(
+					content.indexOf( pageQuote ) === -1,
+					true,
+					'The page content (' +
+						content +
+						') displays the expected content (' +
+						pageQuote +
+						') when it should be password protected.'
+				);
+			} );
 
-				step( 'Can view page title', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const actualPageTitle = await viewPagePage.pageTitle();
-					assert.strictEqual(
-						actualPageTitle.toUpperCase(),
-						( 'Protected: ' + pageTitle ).toUpperCase()
-					);
-				} );
+			step( 'With incorrect password entered, Enter incorrect password', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				await viewPagePage.enterPassword( 'password' );
+			} );
 
-				step( "Can't see password field", async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const isPasswordProtected = await viewPagePage.isPasswordProtected();
-					assert.strictEqual(
-						isPasswordProtected,
-						false,
-						'The page still seems to be password protected'
-					);
-				} );
+			step( 'Can view page title', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const actualPageTitle = await viewPagePage.pageTitle();
+				assert.strictEqual(
+					actualPageTitle.toUpperCase(),
+					( 'Protected: ' + pageTitle ).toUpperCase()
+				);
+			} );
 
-				step( 'Can see page content', async function() {
-					const viewPagePage = await ViewPagePage.Expect( driver );
-					const content = await viewPagePage.pageContent();
-					assert.strictEqual(
-						content.indexOf( pageQuote ) > -1,
-						true,
-						'The page content (' +
-							content +
-							') does not include the expected content (' +
-							pageQuote +
-							')'
-					);
-				} );
+			step( 'Can see password field', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const isPasswordProtected = await viewPagePage.isPasswordProtected();
+				assert.strictEqual(
+					isPasswordProtected,
+					true,
+					'The page does not appear to be password protected'
+				);
+			} );
+
+			step( "Can't see content when incorrect password is entered", async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const content = await viewPagePage.pageContent();
+				assert.strictEqual(
+					content.indexOf( pageQuote ) === -1,
+					true,
+					'The page content (' +
+						content +
+						') displays the expected content (' +
+						pageQuote +
+						') when it should be password protected.'
+				);
+			} );
+
+			step( 'With correct password entered, Enter correct password', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				await viewPagePage.enterPassword( postPassword );
+			} );
+
+			step( 'Can view page title', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const actualPageTitle = await viewPagePage.pageTitle();
+				assert.strictEqual(
+					actualPageTitle.toUpperCase(),
+					( 'Protected: ' + pageTitle ).toUpperCase()
+				);
+			} );
+
+			step( "Can't see password field", async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const isPasswordProtected = await viewPagePage.isPasswordProtected();
+				assert.strictEqual(
+					isPasswordProtected,
+					false,
+					'The page still seems to be password protected'
+				);
+			} );
+
+			step( 'Can see page content', async function() {
+				const viewPagePage = await ViewPagePage.Expect( driver );
+				const content = await viewPagePage.pageContent();
+				assert.strictEqual(
+					content.indexOf( pageQuote ) > -1,
+					true,
+					'The page content (' +
+						content +
+						') does not include the expected content (' +
+						pageQuote +
+						')'
+				);
 			} );
 		} );
 	} );

--- a/specs/wp-gutenberg-page-editor-spec.js
+++ b/specs/wp-gutenberg-page-editor-spec.js
@@ -20,6 +20,7 @@ import * as driverHelper from '../lib/driver-helper';
 import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
 import GutenbergEditorHeaderComponent from '../lib/gutenberg/gutenberg-editor-header-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
+import * as SlackNotifier from '../lib/slack-notifier';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -307,6 +308,16 @@ describe( `[${ host }] Gutenberg Editor: Pages (${ screenSize })`, function() {
 		const postPassword = 'e2e' + new Date().getTime().toString();
 
 		describe( 'Publish a Password Protected Page', function() {
+			before( async function() {
+				if ( driverManager.currentScreenSize() === 'mobile' ) {
+					await SlackNotifier.warn(
+						'Gutenberg password protected page spec currently not supported on mobile due to Gutenberg bug',
+						{ suppressDuplicateMessages: true }
+					);
+					return this.skip();
+				}
+			} );
+
 			step( 'Can log in', async function() {
 				const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
 				await loginFlow.loginAndStartNewPage( null, true );

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -347,7 +347,7 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 				await gHeaderComponent.enterTitle( blogPostTitle );
 				await gHeaderComponent.enterText( blogPostQuote );
 
-				let errorShown = await gHeaderComponent.errorDisplayed();
+				const errorShown = await gHeaderComponent.errorDisplayed();
 				return assert.strictEqual(
 					errorShown,
 					false,


### PR DESCRIPTION
This adds a Gutenberg editor spec which adds a password protected page

**Testing Instructions**

Make sure `env BROWSERSIZE=desktop ./node_modules/.bin/mocha specs/wp-gutenberg-page-editor-spec.js`

and `env BROWSERSIZE=mobile ./node_modules/.bin/mocha specs/wp-gutenberg-page-editor-spec.js` works