### PR TITLE
Update retry number and get screenshots working for IE11

### DIFF
--- a/lib/mocha-hooks.js
+++ b/lib/mocha-hooks.js
@@ -64,7 +64,7 @@ afterEach( async function() {
 			return null;
 		}
 
-		driver.getCurrentUrl().then(
+		await driver.getCurrentUrl().then(
 			url => console.log( `FAILED: Taking screenshot of: '${ url }'` ),
 			err => {
 				slackNotifier.warn( `Could not capture the URL when taking a screenshot: '${ err }'` );
@@ -80,9 +80,9 @@ afterEach( async function() {
 	}
 
 	return await driver.takeScreenshot().then(
-		data => {
-			return driver.getCurrentUrl().then( url => {
-				return mediaHelper.writeScreenshot( data, filenameCallback, { url } );
+		async data => {
+			return await driver.getCurrentUrl().then( async url => {
+				return await mediaHelper.writeScreenshot( data, filenameCallback, { url } );
 			} );
 		},
 		err => {

--- a/magellan-ie11-canary.json
+++ b/magellan-ie11-canary.json
@@ -4,7 +4,7 @@
   ],
   "mocha_opts": "test/mocha.opts",
   "mocha_args": "-R spec-xunit-reporter",
-  "max_test_attempts": 3,
+  "max_test_attempts": 6,
   "max_workers": 1,
   "suiteTag": "ie11canary",
   "sauce": false,

--- a/magellan-ie11.json
+++ b/magellan-ie11.json
@@ -4,7 +4,7 @@
   ],
   "mocha_opts": "test/mocha.opts",
   "mocha_args": "-R spec-xunit-reporter",
-  "max_test_attempts": 3,
+  "max_test_attempts": 6,
   "max_workers": 1,
   "suiteTag": "ie11canary",
   "sauce": false,


### PR DESCRIPTION
We are still getting random stale element errors on ie11. I have been unable to get around them at this point, but in the meantime, this PR gets the screenshots working again and increases the retry count