### PR TITLE
[WIP] Gutenbergify: Public Posts: Preview and Publish a Public Post

### DIFF
--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -454,3 +454,15 @@ export async function clearTextArea( driver, selector ) {
 		i--;
 	}
 }
+
+export async function dismissAlertIfPresent( driver ) {
+	try {
+		driver
+			.switchTo()
+			.alert()
+			.dismiss();
+		return true;
+	} catch ( error ) {
+		return false;
+	}
+}

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -81,18 +81,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		altTextInput.sendKeys( name );
 	}
 
-	async selectImageBlock() {
-		const appenderSelector = By.css( '.editor-inserter__toggle' );
-		const imageBlockSelector = By.css( '.editor-block-list-item-image' );
-		await driverHelper.clickWhenClickable( this.driver, appenderSelector );
-		return await driverHelper.clickWhenClickable( this.driver, imageBlockSelector );
-	}
-
 	async enterImage( fileDetails ) {
 		const newImageName = fileDetails.imageName;
 		const newFile = fileDetails.file;
 
-		await this.selectImageBlock();
 		await this.sendFile( newImageName, newFile );
 	}
 

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -1,6 +1,7 @@
 /** @format */
 import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper';
+import * as driverManager from '../driver-manager.js';
 import AsyncBaseContainer from '../async-base-container';
 import GutenbergPreviewComponent from './gutenberg-preview-component';
 import webdriver from 'selenium-webdriver';
@@ -66,14 +67,20 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		if ( open && ! sidebarOpen ) {
 			return await driverHelper.clickWhenClickable(
 				this.driver,
-				By.css( "button[aria-label='Settings'" )
+				By.css( "button[aria-label='Settings']" )
 			);
 		}
 
 		if ( ! open && sidebarOpen ) {
+			if ( driverManager.currentScreenSize() === 'desktop' ) {
+				return await driverHelper.clickWhenClickable(
+					this.driver,
+					By.css( ".edit-post-sidebar__panel-tabs button[aria-label='Close settings']" )
+				);
+			}
 			return await driverHelper.clickWhenClickable(
 				this.driver,
-				By.css( "button[aria-label='Close settings'" )
+				By.css( ".edit-post-sidebar-header__small button[aria-label='Close settings']" )
 			);
 		}
 	}

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -172,7 +172,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async ensureSaved() {
-		driverHelper.clickWhenClickable( this.driver, By.css( '.editor-post-save-draft' ) );
+		await driverHelper.clickWhenClickable( this.driver, By.css( '.editor-post-save-draft' ) );
 		const savedSelector = By.css( 'span.is-saved' );
 
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, savedSelector );

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -2,6 +2,7 @@
 import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper';
 import AsyncBaseContainer from '../async-base-container';
+import GutenbergPreviewComponent from './gutenberg-preview-component';
 import webdriver from 'selenium-webdriver';
 
 export default class GutenbergEditorComponent extends AsyncBaseContainer {
@@ -129,15 +130,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async ensureSaved() {
-		driverHelper.clickIfPresent( this.driver, By.css( 'editor-post-save-draft' ) );
+		driverHelper.clickWhenClickable( this.driver, By.css( '.editor-post-save-draft' ) );
 		const savedSelector = By.css( 'span.is-saved' );
 
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, savedSelector );
-	}
-
-	async switchToPreview() {
-		const tabs = await this.driver.getAllWindowHandles();
-		return await this.driver.switchTo().window( tabs[ 1 ] ); // Will crash if preview tab wasn't opened
 	}
 
 	async switchToEditor() {
@@ -151,6 +147,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			By.css( '.editor-post-preview' ),
 			this.explicitWaitMS
 		);
-		return await this.switchToPreview();
+		return await GutenbergPreviewComponent.switchToPreview( this.driver );
 	}
 }

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -80,6 +80,8 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		);
 		let altTextInput = await driver.findElement( By.css( '.components-textarea-control__input' ) );
 		await altTextInput.click();
+		// There's a little time here where the image block seems to refresh, if the alt text is entered before the refresh it will be cleared before saving
+		await this.driver.sleep( 2000 );
 		return await altTextInput.sendKeys( name );
 	}
 
@@ -137,9 +139,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, savedSelector );
 	}
 
-	async switchToEditor() {
-		const tabs = await this.driver.getAllWindowHandles();
-		return await this.driver.switchTo().window( tabs[ 0 ] );
+	static async switchToEditor( driver ) {
+		const tabs = await driver.getAllWindowHandles();
+		await driver.switchTo().window( tabs[ 0 ] );
+		return await driver.sleep( 1000 );
 	}
 
 	async launchPreview() {

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -79,7 +79,8 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			By.css( '.components-textarea-control__input' )
 		);
 		let altTextInput = await driver.findElement( By.css( '.components-textarea-control__input' ) );
-		altTextInput.sendKeys( name );
+		await altTextInput.click();
+		return await altTextInput.sendKeys( name );
 	}
 
 	async enterImage( fileDetails ) {

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -2,6 +2,7 @@
 import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper';
 import AsyncBaseContainer from '../async-base-container';
+import webdriver from 'selenium-webdriver';
 
 export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	constructor( driver ) {
@@ -53,6 +54,46 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.clickWhenClickable( this.driver, appenderSelector );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, textSelector );
 		return await this.driver.findElement( textSelector ).sendKeys( text );
+	}
+
+	/*
+		name - name for file to set as alt text
+		path - local path to file
+	 */
+	async sendFile( name, path ) {
+		const fileNameInputSelector = webdriver.By.css(
+			'.components-form-file-upload input[type="file"]'
+		);
+		const driver = this.driver;
+
+		await driverHelper.waitTillPresentAndDisplayed(
+			driver,
+			By.css( '.components-form-file-upload ' )
+		);
+		let filePathInput = await driver.findElement( fileNameInputSelector );
+		await filePathInput.sendKeys( path );
+
+		await driverHelper.clickWhenClickable(
+			driver,
+			By.css( '.components-textarea-control__input' )
+		);
+		let altTextInput = await driver.findElement( By.css( '.components-textarea-control__input' ) );
+		altTextInput.sendKeys( name );
+	}
+
+	async selectImageBlock() {
+		const appenderSelector = By.css( '.editor-inserter__toggle' );
+		const imageBlockSelector = By.css( '.editor-block-list-item-image' );
+		await driverHelper.clickWhenClickable( this.driver, appenderSelector );
+		return await driverHelper.clickWhenClickable( this.driver, imageBlockSelector );
+	}
+
+	async enterImage( fileDetails ) {
+		const newImageName = fileDetails.imageName;
+		const newFile = fileDetails.file;
+
+		await this.selectImageBlock();
+		await this.sendFile( newImageName, newFile );
 	}
 
 	async errorDisplayed() {

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -3,7 +3,6 @@ import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper';
 import AsyncBaseContainer from '../async-base-container';
 import webdriver from 'selenium-webdriver';
-import * as driverManager from '../driver-manager';
 
 export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	constructor( driver ) {
@@ -136,11 +135,22 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, savedSelector );
 	}
 
+	async switchToPreview() {
+		const tabs = await this.driver.getAllWindowHandles();
+		return await this.driver.switchTo().window( tabs[ 1 ] ); // Will crash if preview tab wasn't opened
+	}
+
+	async switchToEditor() {
+		const tabs = await this.driver.getAllWindowHandles();
+		return await this.driver.switchTo().window( tabs[ 0 ] );
+	}
+
 	async launchPreview() {
-		return await driverHelper.clickWhenClickable(
+		await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( '.editor-post-preview' ),
 			this.explicitWaitMS
 		);
+		return await this.switchToPreview();
 	}
 }

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -130,6 +130,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async ensureSaved() {
+		driverHelper.clickIfPresent( this.driver, By.css( 'editor-post-save-draft' ) );
 		const savedSelector = By.css( 'span.is-saved' );
 
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, savedSelector );

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -57,6 +57,35 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return await this.driver.findElement( textSelector ).sendKeys( text );
 	}
 
+	async toggleSidebar( open = true ) {
+		const sidebarSelector = '.edit-post-sidebar-header';
+		const sidebarOpen = await driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			By.css( sidebarSelector )
+		);
+		if ( open && ! sidebarOpen ) {
+			return await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( "button[aria-label='Settings'" )
+			);
+		}
+
+		if ( ! open && sidebarOpen ) {
+			return await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( "button[aria-label='Close settings'" )
+			);
+		}
+	}
+
+	async openSidebar() {
+		return await this.toggleSidebar( true );
+	}
+
+	async closeSidebar() {
+		return await this.toggleSidebar( false );
+	}
+
 	/*
 		name - name for file to set as alt text
 		path - local path to file
@@ -74,6 +103,8 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		let filePathInput = await driver.findElement( fileNameInputSelector );
 		await filePathInput.sendKeys( path );
 
+		await this.openSidebar();
+
 		await driverHelper.clickWhenClickable(
 			driver,
 			By.css( '.components-textarea-control__input' )
@@ -82,7 +113,8 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await altTextInput.click();
 		// There's a little time here where the image block seems to refresh, if the alt text is entered before the refresh it will be cleared before saving
 		await this.driver.sleep( 2000 );
-		return await altTextInput.sendKeys( name );
+		await altTextInput.sendKeys( name );
+		return await this.closeSidebar();
 	}
 
 	async enterImage( fileDetails ) {

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -3,6 +3,7 @@ import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper';
 import AsyncBaseContainer from '../async-base-container';
 import webdriver from 'selenium-webdriver';
+import * as driverManager from '../driver-manager';
 
 export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	constructor( driver ) {
@@ -126,5 +127,19 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.clickWhenClickable( this.driver, inserterBlockItemSelector );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, insertedBlockSelector );
 		return await this.driver.findElement( insertedBlockSelector ).getAttribute( 'id' );
+	}
+
+	async ensureSaved() {
+		const savedSelector = By.css( 'span.is-saved' );
+
+		return await driverHelper.waitTillPresentAndDisplayed( this.driver, savedSelector );
+	}
+
+	async launchPreview() {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.editor-post-preview' ),
+			this.explicitWaitMS
+		);
 	}
 }

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -3,7 +3,7 @@ import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper';
 import AsyncBaseContainer from '../async-base-container';
 
-export default class GutenbergEditorHeaderComponent extends AsyncBaseContainer {
+export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '#editor.gutenberg__editor .edit-post-header' ) );
 	}

--- a/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -75,6 +75,8 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 	}
 
 	async _expandOrCollapseSection( sectionNumber, expand = true ) {
+		// Without the pause it doesn't wait to find all the sections, only picking up the last 3
+		await this.driver.sleep( 2000 );
 		const sidebarButtons = await this.sidebarSections();
 		const sectionButton = sidebarButtons[ sectionNumber ];
 

--- a/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -1,5 +1,5 @@
 /** @format */
-import { By } from 'selenium-webdriver';
+import { By, Key } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper';
 import AsyncBaseContainer from '../async-base-container';
 
@@ -111,5 +111,16 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 			driver,
 			By.xpath( `//label[contains(text(), '${ category }')]` )
 		);
+	}
+
+	async addNewTag( tag ) {
+		const tagEntrySelector = By.css( 'input.components-form-token-field__input' );
+
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, tagEntrySelector );
+		await driverHelper.scrollIntoView( this.driver, tagEntrySelector );
+		await driverHelper.waitForFieldClearable( this.driver, tagEntrySelector );
+		let tagEntryElement = await this.driver.findElement( tagEntrySelector );
+		await tagEntryElement.sendKeys( tag );
+		return await tagEntryElement.sendKeys( Key.ENTER );
 	}
 }

--- a/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -1,0 +1,115 @@
+/** @format */
+import { By } from 'selenium-webdriver';
+import * as driverHelper from '../driver-helper';
+import AsyncBaseContainer from '../async-base-container';
+
+export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.edit-post-sidebar' ) );
+	}
+
+	async sidebarSections() {
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.components-panel__body-toggle' )
+		);
+		return await this.driver.findElements( By.css( '.components-panel__body-toggle' ) );
+	}
+
+	async selectTab( name ) {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( `.edit-post-sidebar__panel-tab[data-label='${ name }'` )
+		);
+	}
+	async selectDocumentTab() {
+		return await this.selectTab( 'Document' );
+	}
+
+	async expandStatusAndVisibility() {
+		return this._expandOrCollapseSection( 0, true );
+	}
+
+	async expandCategories() {
+		return this._expandOrCollapseSection( 1, true );
+	}
+
+	async expandTags() {
+		return this._expandOrCollapseSection( 2, true );
+	}
+
+	async expandFeaturedImage() {
+		return this._expandOrCollapseSection( 3, true );
+	}
+
+	async expandExcerpt() {
+		return this._expandOrCollapseSection( 4, true );
+	}
+
+	async expandDiscussion() {
+		return this._expandOrCollapseSection( 5, true );
+	}
+
+	async collapseStatusAndVisibility() {
+		return this._expandOrCollapseSection( 0, false );
+	}
+
+	async collapseCategories() {
+		return this._expandOrCollapseSection( 1, false );
+	}
+
+	async collapseTags() {
+		return this._expandOrCollapseSection( 2, false );
+	}
+
+	async collapseFeaturedImage() {
+		return this._expandOrCollapseSection( 3, false );
+	}
+
+	async collapseExcerpt() {
+		return this._expandOrCollapseSection( 4, false );
+	}
+
+	async collapseDiscussion() {
+		return this._expandOrCollapseSection( 5, false );
+	}
+
+	async _expandOrCollapseSection( sectionNumber, expand = true ) {
+		const sidebarButtons = await this.sidebarSections();
+		const sectionButton = sidebarButtons[ sectionNumber ];
+
+		let c = await sectionButton.getAttribute( 'aria-expanded' );
+		if ( expand && c === 'false' ) {
+			// TODO: Scroll into view
+			return await sectionButton.click();
+		}
+		if ( ! expand && c === 'true' ) {
+			// TODO: Scroll into view
+			return await sectionButton.click();
+		}
+	}
+
+	async addNewCategory( category ) {
+		const addNewCategoryButtonSelector = By.css(
+			'.editor-post-taxonomies__hierarchical-terms-add'
+		);
+		const categoryNameInputSelector = By.css(
+			'input.editor-post-taxonomies__hierarchical-terms-input[type=text]'
+		);
+		const saveCategoryButtonSelector = By.css(
+			'button.editor-post-taxonomies__hierarchical-terms-submit'
+		);
+		const driver = this.driver;
+
+		driver.sleep( 500 );
+		await driverHelper.clickWhenClickable( driver, addNewCategoryButtonSelector );
+		await driverHelper.waitForFieldClearable( driver, categoryNameInputSelector );
+		driver.sleep( 500 );
+		await driverHelper.setWhenSettable( driver, categoryNameInputSelector, category );
+		await driverHelper.clickWhenClickable( driver, saveCategoryButtonSelector );
+		return await driverHelper.waitTillPresentAndDisplayed(
+			driver,
+			By.xpath( `//label[contains(text(), '${ category }')]` )
+		);
+	}
+}

--- a/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -6,7 +6,7 @@ import * as driverManager from '../driver-manager';
 
 export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.edit-post-sidebar' ) );
+		super( driver, By.css( '.block-editor.gutenberg' ) );
 		this.cogSelector = By.css( '[aria-label="Settings"]:not([disabled])' );
 		this.closeSelector = By.css( '[aria-label="Close settings"]:not([disabled])' );
 	}
@@ -155,10 +155,7 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 	}
 
 	async chooseDocumentSetttings() {
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '[data-label="Document"]' )
-		);
+		return await this.selectDocumentTab();
 	}
 
 	async setVisibilityToPasswordProtected( password ) {

--- a/lib/gutenberg/gutenberg-preview-component.js
+++ b/lib/gutenberg/gutenberg-preview-component.js
@@ -30,4 +30,10 @@ export default class GutenbergPreviewComponent extends AsyncBaseContainer {
 		this.viewPostPage = await ViewPostPage.Expect( this.driver );
 		return await this.viewPostPage.categoryDisplayed();
 	}
+
+	async imageDisplayed( fileDetails ) {
+		await GutenbergPreviewComponent.switchToPreview( this.driver );
+		this.viewPagePage = await ViewPostPage.Expect( this.driver );
+		return await this.viewPagePage.imageDisplayed( fileDetails );
+	}
 }

--- a/lib/gutenberg/gutenberg-preview-component.js
+++ b/lib/gutenberg/gutenberg-preview-component.js
@@ -1,17 +1,33 @@
 /** @format */
 import { By } from 'selenium-webdriver';
 import AsyncBaseContainer from '../async-base-container';
+import ViewPostPage from '../pages/view-post-page';
 
 export default class GutenbergPreviewComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '#main.site-main' ) );
 	}
 
+	static async switchToPreview( driver ) {
+		const tabs = await driver.getAllWindowHandles();
+		return await driver.switchTo().window( tabs[ 1 ] ); // Will crash if preview tab wasn't opened
+	}
+
 	async postTitle() {
-		return await this.driver.findElement( By.css( '.entry-title,.post-title' ) ).getText();
+		await GutenbergPreviewComponent.switchToPreview( this.driver );
+		this.viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await this.viewPostPage.postTitle();
 	}
 
 	async postContent() {
-		return await this.driver.findElement( By.css( '.entry-content,.post-content' ) ).getText();
+		await GutenbergPreviewComponent.switchToPreview( this.driver );
+		this.viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await this.viewPostPage.postContent();
+	}
+
+	async categoryDisplayed() {
+		await GutenbergPreviewComponent.switchToPreview( this.driver );
+		this.viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await this.viewPostPage.categoryDisplayed();
 	}
 }

--- a/lib/gutenberg/gutenberg-preview-component.js
+++ b/lib/gutenberg/gutenberg-preview-component.js
@@ -1,10 +1,17 @@
 /** @format */
-import { By, Key } from 'selenium-webdriver';
-import * as driverHelper from '../driver-helper';
+import { By } from 'selenium-webdriver';
 import AsyncBaseContainer from '../async-base-container';
 
 export default class GutenbergPreviewComponent extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '#main' ) );
+		super( driver, By.css( '#main.site-main' ) );
+	}
+
+	async postTitle() {
+		return await this.driver.findElement( By.css( '.entry-title,.post-title' ) ).getText();
+	}
+
+	async postContent() {
+		return await this.driver.findElement( By.css( '.entry-content,.post-content' ) ).getText();
 	}
 }

--- a/lib/gutenberg/gutenberg-preview-component.js
+++ b/lib/gutenberg/gutenberg-preview-component.js
@@ -1,0 +1,10 @@
+/** @format */
+import { By, Key } from 'selenium-webdriver';
+import * as driverHelper from '../driver-helper';
+import AsyncBaseContainer from '../async-base-container';
+
+export default class GutenbergPreviewComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '#main' ) );
+	}
+}

--- a/specs-blocks/gutenberg-markdown-block-spec.js
+++ b/specs-blocks/gutenberg-markdown-block-spec.js
@@ -7,7 +7,7 @@ import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar.js';
 import JetpackConnectFlow from '../lib/flows/jetpack-connect-flow.js';
 import MarkdownBlockComponent from '../lib/gutenberg/blocks/markdown-block-component.js';
 import PostAreaComponent from '../lib/pages/frontend/post-area-component.js';
-import GutenbergEditorHeaderComponent from '../lib/gutenberg/gutenberg-editor-header-component.js';
+import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component.js';
 import * as driverManager from '../lib/driver-manager.js';
 import * as dataHelper from '../lib/data-helper.js';
 import WPAdminJetpackModulesPage from '../lib/pages/wp-admin/wp-admin-jetpack-modules-page.js';
@@ -71,7 +71,7 @@ if ( screenSize !== 'mobile' ) {
 			} );
 
 			step( 'Can insert a markdown block', async function() {
-				const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
+				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
 				await gHeaderComponent.removeNUXNotice();
 				this.markdownBlockID = await gHeaderComponent.addBlock( 'Markdown' );
 			} );
@@ -91,7 +91,7 @@ if ( screenSize !== 'mobile' ) {
 			} );
 
 			step( 'Can publish the post and see its content', async function() {
-				const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
+				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
 				await gHeaderComponent.publish( { visit: true } );
 				const postFrontend = await PostAreaComponent.Expect( driver );
 				const html = await postFrontend.getPostHTML();

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -123,7 +123,7 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Can see correct post content in preview', async function() {
-			const gPreviewComponent = GutenbergPreviewComponent.Expect( driver );
+			const gPreviewComponent = await GutenbergPreviewComponent.Expect( driver );
 			let content = await gPreviewComponent.postContent();
 			assert.strictEqual(
 				content.indexOf( blogPostQuote ) > -1,
@@ -137,7 +137,7 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Can see the post category in preview', async function() {
-			const gPreviewComponent = GutenbergPreviewComponent.Expect( driver );
+			const gPreviewComponent = await GutenbergPreviewComponent.Expect( driver );
 			let categoryDisplayed = await gPreviewComponent.categoryDisplayed();
 			assert.strictEqual(
 				categoryDisplayed.toUpperCase(),

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -41,7 +41,7 @@ before( async function() {
 	driver = await driverManager.startBrowser();
 } );
 
-describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
+xdescribe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
 	xdescribe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -6,7 +6,7 @@ import config from 'config';
 import LoginFlow from '../lib/flows/login-flow.js';
 
 import EditorPage from '../lib/pages/editor-page.js';
-import TwitterFeedPage from '../lib/pages/twitter-feed-page.js';
+// import TwitterFeedPage from '../lib/pages/twitter-feed-page.js';
 import ViewPostPage from '../lib/pages/view-post-page.js';
 import NotFoundPage from '../lib/pages/not-found-page.js';
 import PostsPage from '../lib/pages/posts-page.js';
@@ -42,14 +42,14 @@ before( async function() {
 describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
-	xdescribe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
+	describe.only( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
 		let fileDetails;
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =
 			'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
-		const newCategoryName = 'Category ' + new Date().getTime().toString();
-		const newTagName = 'Tag ' + new Date().getTime().toString();
-		const publicizeMessage = dataHelper.randomPhrase();
+		// const newCategoryName = 'Category ' + new Date().getTime().toString();
+		// const newTagName = 'Tag ' + new Date().getTime().toString();
+		// const publicizeMessage = dataHelper.randomPhrase();
 
 		// Create image file for upload
 		before( async function() {
@@ -63,12 +63,14 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Can enter post title and text content', async function() {
-			const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
-			await gHeaderComponent.removeNUXNotice();
-			await gHeaderComponent.enterTitle( blogPostTitle );
-			await gHeaderComponent.enterText( blogPostQuote );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.removeNUXNotice();
+			await gEditorComponent.enterTitle( blogPostTitle );
+			await gEditorComponent.enterText( blogPostQuote );
 
-			let errorShown = await gHeaderComponent.errorDisplayed();
+			await gEditorComponent.enterImage( fileDetails );
+
+			let errorShown = await gEditorComponent.errorDisplayed();
 			return assert.strictEqual(
 				errorShown,
 				false,

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -215,6 +215,7 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			if ( fileDetails ) {
 				await mediaHelper.deleteFile( fileDetails );
 			}
+			await driverHelper.dismissAlertIfPresent();
 		} );
 	} );
 
@@ -256,6 +257,10 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 					blogPostTitle.toLowerCase(),
 					'The published blog post title is not correct'
 				);
+			} );
+
+			after( async function() {
+				await driverHelper.dismissAlertIfPresent();
 			} );
 		} );
 	} );
@@ -303,6 +308,10 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 				displayed,
 				`The published post title '${ blogPostTitle }' was not displayed in activity log after publishing`
 			);
+		} );
+
+		after( async function() {
+			await driverHelper.dismissAlertIfPresent();
 		} );
 	} );
 
@@ -948,6 +957,10 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 					'The Posts page success notice for deleting the post is not displayed'
 				);
 			} );
+
+			after( async function() {
+				await driverHelper.dismissAlertIfPresent();
+			} );
 		} );
 	} );
 
@@ -1044,6 +1057,10 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 							'The published blog post title is not correct'
 						);
 					} );
+				} );
+
+				after( async function() {
+					await driverHelper.dismissAlertIfPresent();
 				} );
 			} );
 		} );

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -43,13 +43,13 @@ before( async function() {
 describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
-	describe.only( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
+	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
 		let fileDetails;
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =
 			'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
 		const newCategoryName = 'Category ' + new Date().getTime().toString();
-		// const newTagName = 'Tag ' + new Date().getTime().toString();
+		const newTagName = 'Tag ' + new Date().getTime().toString();
 		// const publicizeMessage = dataHelper.randomPhrase();
 
 		// Create image file for upload
@@ -81,8 +81,6 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Expand Categories and Tags', async function() {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			await gEditorComponent.removeNUXNotice();
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.selectDocumentTab();
 			await gEditorSidebarComponent.collapseStatusAndVisibility(); // Status and visibility starts opened
@@ -94,6 +92,29 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.addNewCategory( newCategoryName );
 		} );
+
+		step( 'Can add a new tag', async function() {
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			await gEditorSidebarComponent.addNewTag( newTagName );
+		} );
+
+		step( 'Close categories and tags', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.removeNUXNotice();
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			await gEditorSidebarComponent.selectDocumentTab();
+			await gEditorSidebarComponent.collapseCategories();
+			await gEditorSidebarComponent.collapseTags();
+		} );
+
+		step( 'Can launch post preview', async function() {
+			let gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.ensureSaved();
+			await gEditorComponent.launchPreview();
+		} );
+
+		// step( 'Can see correct post title in preview', async function() {
+		// } );
 
 		after( async function() {
 			if ( fileDetails ) {

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -99,8 +99,6 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Close categories and tags', async function() {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			await gEditorComponent.removeNUXNotice();
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.selectDocumentTab();
 			await gEditorSidebarComponent.collapseCategories();

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -27,6 +27,7 @@ import * as driverHelper from '../lib/driver-helper';
 import * as mediaHelper from '../lib/media-helper';
 import * as dataHelper from '../lib/data-helper';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
+import GutenbergPreviewComponent from '../lib/gutenberg/gutenberg-preview-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -43,7 +44,7 @@ before( async function() {
 describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
-	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
+	describe.only( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
 		let fileDetails;
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =
@@ -106,13 +107,44 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Can launch post preview', async function() {
-			let gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.ensureSaved();
 			await gEditorComponent.launchPreview();
 		} );
 
-		// step( 'Can see correct post title in preview', async function() {
-		// } );
+		step( 'Can see correct post title in preview', async function() {
+			const gPreviewComponent = await GutenbergPreviewComponent.Expect( driver );
+			let postTitle = await gPreviewComponent.postTitle();
+			assert.strictEqual(
+				postTitle.toLowerCase(),
+				blogPostTitle.toLowerCase(),
+				'The blog post preview title is not correct'
+			);
+		} );
+
+		step( 'Can see correct post content in preview', async function() {
+			const gPreviewComponent = GutenbergPreviewComponent.Expect( driver );
+			let content = await gPreviewComponent.postContent();
+			assert.strictEqual(
+				content.indexOf( blogPostQuote ) > -1,
+				true,
+				'The post preview content (' +
+					content +
+					') does not include the expected content (' +
+					blogPostQuote +
+					')'
+			);
+		} );
+
+		step( 'Can see the post category in preview', async function() {
+			const gPreviewComponent = GutenbergPreviewComponent.Expect( driver );
+			let categoryDisplayed = await gPreviewComponent.categoryDisplayed();
+			assert.strictEqual(
+				categoryDisplayed.toUpperCase(),
+				newCategoryName.toUpperCase(),
+				'The category: ' + newCategoryName + ' is not being displayed on the post'
+			);
+		} );
 
 		after( async function() {
 			if ( fileDetails ) {

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -44,7 +44,7 @@ before( async function() {
 describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
-	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
+	xdescribe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
 		let fileDetails;
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -146,6 +146,12 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			);
 		} );
 
+		step( 'Can see the image in preview', async function() {
+			const gPreviewComponent = await GutenbergPreviewComponent.Expect( driver );
+			let imageDisplayed = await gPreviewComponent.imageDisplayed( fileDetails );
+			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the web preview' );
+		} );
+
 		after( async function() {
 			if ( fileDetails ) {
 				await mediaHelper.deleteFile( fileDetails );

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -81,6 +81,8 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Expand Categories and Tags', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.openSidebar();
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.selectDocumentTab();
 			await gEditorSidebarComponent.collapseStatusAndVisibility(); // Status and visibility starts opened
@@ -99,10 +101,12 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Close categories and tags', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.selectDocumentTab();
 			await gEditorSidebarComponent.collapseCategories();
 			await gEditorSidebarComponent.collapseTags();
+			await gEditorComponent.closeSidebar();
 		} );
 
 		step( 'Can launch post preview', async function() {

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -44,14 +44,13 @@ before( async function() {
 describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
-	describe.only( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
+	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
 		let fileDetails;
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =
 			'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
 		const newCategoryName = 'Category ' + new Date().getTime().toString();
 		const newTagName = 'Tag ' + new Date().getTime().toString();
-		// const publicizeMessage = dataHelper.randomPhrase();
 
 		// Create image file for upload
 		before( async function() {
@@ -152,6 +151,61 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the web preview' );
 		} );
 
+		step( 'Can publish and view content', async function() {
+			await GutenbergEditorComponent.switchToEditor( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.publish( { visit: true } );
+		} );
+
+		step( 'Can see correct post title', async function() {
+			const viewPostPage = await ViewPostPage.Expect( driver );
+			let postTitle = await viewPostPage.postTitle();
+			assert.strictEqual(
+				postTitle.toLowerCase(),
+				blogPostTitle.toLowerCase(),
+				'The published blog post title is not correct'
+			);
+		} );
+
+		step( 'Can see correct post content', async function() {
+			const viewPostPage = await ViewPostPage.Expect( driver );
+			let content = await viewPostPage.postContent();
+			assert.strictEqual(
+				content.indexOf( blogPostQuote ) > -1,
+				true,
+				'The post content (' +
+					content +
+					') does not include the expected content (' +
+					blogPostQuote +
+					')'
+			);
+		} );
+
+		step( 'Can see correct post category', async function() {
+			const viewPostPage = await ViewPostPage.Expect( driver );
+			let categoryDisplayed = await viewPostPage.categoryDisplayed();
+			assert.strictEqual(
+				categoryDisplayed.toUpperCase(),
+				newCategoryName.toUpperCase(),
+				'The category: ' + newCategoryName + ' is not being displayed on the post'
+			);
+		} );
+
+		step( 'Can see correct post tag', async function() {
+			const viewPostPage = await ViewPostPage.Expect( driver );
+			let tagDisplayed = await viewPostPage.tagDisplayed();
+			assert.strictEqual(
+				tagDisplayed.toUpperCase(),
+				newTagName.toUpperCase(),
+				'The tag: ' + newTagName + ' is not being displayed on the post'
+			);
+		} );
+
+		step( 'Can see the image published', async function() {
+			const viewPostPage = await ViewPostPage.Expect( driver );
+			let imageDisplayed = await viewPostPage.imageDisplayed( fileDetails );
+			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the published post' );
+		} );
 		after( async function() {
 			if ( fileDetails ) {
 				await mediaHelper.deleteFile( fileDetails );

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -26,6 +26,7 @@ import * as driverManager from '../lib/driver-manager';
 import * as driverHelper from '../lib/driver-helper';
 import * as mediaHelper from '../lib/media-helper';
 import * as dataHelper from '../lib/data-helper';
+import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -47,7 +48,7 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =
 			'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
-		// const newCategoryName = 'Category ' + new Date().getTime().toString();
+		const newCategoryName = 'Category ' + new Date().getTime().toString();
 		// const newTagName = 'Tag ' + new Date().getTime().toString();
 		// const publicizeMessage = dataHelper.randomPhrase();
 
@@ -62,11 +63,12 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
-		step( 'Can enter post title and text content', async function() {
+		step( 'Can enter post title, content and image', async function() {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.removeNUXNotice();
 			await gEditorComponent.enterTitle( blogPostTitle );
 			await gEditorComponent.enterText( blogPostQuote );
+			await gEditorComponent.addBlock( 'Image' );
 
 			await gEditorComponent.enterImage( fileDetails );
 
@@ -76,6 +78,21 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 				false,
 				'There is an error shown on the Gutenberg editor page!'
 			);
+		} );
+
+		step( 'Expand Categories and Tags', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.removeNUXNotice();
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			await gEditorSidebarComponent.selectDocumentTab();
+			await gEditorSidebarComponent.collapseStatusAndVisibility(); // Status and visibility starts opened
+			await gEditorSidebarComponent.expandCategories();
+			await gEditorSidebarComponent.expandTags();
+		} );
+
+		step( 'Can add a new category', async function() {
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			await gEditorSidebarComponent.addNewCategory( newCategoryName );
 		} );
 
 		after( async function() {


### PR DESCRIPTION
There's a lot of steps in this test and I wanted to get some eyes on this as I'm about midway. There are a few things I did so far and a few that may cause conflicts.  @Stojdza @alisterscott @bsessions85  

* Renamed `GutenbergEditorHeaderComponent` to `GutenbergEditorComponent - did this because we were doing things with the editor in general and not just the header and thought the name was a little misleading
* Created components for Sidebar and Preview 
* Removed the Sharing step in the original step as that's no longer in the sidebar for the Gutenberg editor(actually not sure how a user would replicate this functionality from the original editor)
* Category and tags now have there own section in the sidebar so separated the method for expanding and collapsing. 
* Categories and tags no longer appear on the sidebar as they did after their saved so couldn't verify it in the same way we did originally
* No longer seeing tags when previewing(not sure if I'm just missing it)
* Chrome level notification about leaving page stops test from progressing to next test even though it's saved before launching the preview. 

Part of #1620 