### PR TITLE
Add crowdsignalNameBasedSignup AB tests to knownABTestKeys

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -67,7 +67,8 @@
 		"signupAtomicStoreVsPressable",
 		"krackenRebootM33",
 		"improvedOnboarding",
-		"privateByDefault"
+		"privateByDefault",
+		"crowdsignalNameBasedSignup"
 	],
 	"overrideABTests": [
 		[ "businessPlanDescriptionAT_20170605", "original" ],


### PR DESCRIPTION
This PR adds `crowdsignalNameBasedSignup` to `knownABTestKeys`.  
The test will be introduced in [Automattic/wp-calypso#28546](https://github.com/Automattic/wp-calypso/pull/28546) and will only affect `crowdsignal` signup flow.