### PR TITLE
Import Signup Flow: Fix & re-enable e2e test

### DIFF
--- a/lib/pages/import-page.js
+++ b/lib/pages/import-page.js
@@ -1,5 +1,6 @@
 /** @format */
 
+import assert from 'assert';
 import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper.js';
 
@@ -16,7 +17,12 @@ export default class ImportPage extends AsyncBaseContainer {
 			By.css( '.site-importer__site-preview' )
 		);
 
-		return await driverHelper.imageVisible( this.driver, By.css( '.mini-site-preview__favicon' ) );
+		const isSitePreviewShowing = await driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			By.css( '.mini-site-preview__favicon' )
+		);
+
+		assert( isSitePreviewShowing, 'Site preview should be shown' );
 	}
 
 	async siteImporterInputPane() {
@@ -27,10 +33,20 @@ export default class ImportPage extends AsyncBaseContainer {
 	}
 
 	async siteImporterCanStartImport() {
-		return await driverHelper.waitTillPresentAndDisplayed(
+		await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,
 			// @TODO use a specific classname for this button
 			By.css( '.site-importer__site-importer-confirm-actions .button.is-primary' )
+		);
+
+		const isEmailVerificationGateVisible = await driverHelper.isElementPresent(
+			this.driver,
+			By.css( '.email-verification-gate' )
+		);
+
+		assert(
+			! isEmailVerificationGateVisible,
+			'The email verification gate should not be visible ("Private by default")'
 		);
 	}
 }

--- a/lib/pages/import-page.js
+++ b/lib/pages/import-page.js
@@ -25,4 +25,12 @@ export default class ImportPage extends AsyncBaseContainer {
 			By.css( '.site-importer__site-importer-pane' )
 		);
 	}
+
+	async siteImporterCanStartImport() {
+		return await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			// @TODO use a specific classname for this button
+			By.css( '.site-importer__site-importer-confirm-actions .button.is-primary' )
+		);
+	}
 }

--- a/lib/pages/import-page.js
+++ b/lib/pages/import-page.js
@@ -38,15 +38,5 @@ export default class ImportPage extends AsyncBaseContainer {
 			// @TODO use a specific classname for this button
 			By.css( '.site-importer__site-importer-confirm-actions .button.is-primary' )
 		);
-
-		const isEmailVerificationGateVisible = await driverHelper.isElementPresent(
-			this.driver,
-			By.css( '.email-verification-gate' )
-		);
-
-		assert(
-			! isEmailVerificationGateVisible,
-			'The email verification gate should not be visible ("Private by default")'
-		);
 	}
 }

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1688,7 +1688,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			await importPage.previewSiteToBeImported();
 		} );
 
-		step( 'Can then see the enabled import start button', async function() {
+		step( 'Can then start an import', async function() {
 			const importPage = await ImportPage.Expect( driver );
 			await importPage.siteImporterCanStartImport();
 		} );

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1598,14 +1598,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const emailAddress = dataHelper.getEmailAddress( userName, signupInboxId );
 
 		before( async function() {
-			await SlackNotifier.warn(
-				'The sign up import e2e test is not working due to a recent change and has been disabled',
-				{ suppressDuplicateMessages: true }
-			);
-			return this.skip();
-		} );
-
-		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
@@ -1688,7 +1680,20 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			);
 		} );
 
-		step( 'Can activate my account from an email and go to the importers page', async function() {
+		step( 'Can then see the site importer pane and preview site to be imported', async function() {
+			const importPage = await ImportPage.Expect( driver );
+
+			// Test that we have opened the correct importer and can see the preview.
+			await importPage.siteImporterInputPane();
+			await importPage.previewSiteToBeImported();
+		} );
+
+		step( 'Can then see the enabled import start button', async function() {
+			const importPage = await ImportPage.Expect( driver );
+			await importPage.siteImporterCanStartImport();
+		} );
+
+		step( 'Can activate my account from an email', async function() {
 			const emailClient = new EmailClient( signupInboxId );
 			const validator = emails => emails.find( email => email.subject.includes( 'Activate' ) );
 			let emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
@@ -1700,14 +1705,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			const activationLink = emails[ 0 ].html.links[ 0 ].href;
 			assert( activationLink !== undefined, 'Could not locate the activation link email link' );
 			await driver.get( activationLink );
-		} );
-
-		step( 'Can then see the site importer pane and preview site to be imported', async function() {
-			const importPage = await ImportPage.Expect( driver );
-
-			// Test that we have opened the correct importer and can see the preview.
-			await importPage.siteImporterInputPane();
-			return await importPage.previewSiteToBeImported();
 		} );
 
 		step( 'Can delete our newly created account', async function() {


### PR DESCRIPTION
As [reported](https://github.com/Automattic/wp-calypso/pull/28556#issuecomment-439253201) these tests stopped working around the time we enabled "Private By Default" for our signup flow.

### Changes

* Remove the `before` call that warned and skipped (#1630)
* New function `importPage.siteImporterCanStartImport`
* Refactor the site preview step to use `driverHelper.isEventuallyPresentAndDisplayed`
* Assert that the Email Verification Gate is not shown
* Leverage assertions instead of yielding values for more granular error messages

### To Test

* Configure `YOUR_TEST_ENV`s config file to point against prod
* Check out this branch
* (Optional) limit to just this spec like so:
```
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
-       describe( 'Import a site while signing up @parallel', function() {
+       describe.only( 'Import a site while signing up @parallel', function() {
```
* Open the repo's directory in your terminal & run
  * `HEADLESS=1 env NODE_ENV=$YOUR_TEST_ENV ./node_modules/.bin/mocha specs/wp-signup-spec.js`
* Tests should pass, of course