### PR TITLE
Gutenberg: Revert to draft test

### DIFF
--- a/lib/gutenberg/gutenberg-editor-header-component.js
+++ b/lib/gutenberg/gutenberg-editor-header-component.js
@@ -117,4 +117,30 @@ export default class GutenbergEditorHeaderComponent extends AsyncBaseContainer {
 		const element = await this.driver.findElement( titleSelector );
 		return await element.getAttribute( 'value' );
 	}
+
+	async revertToDraft() {
+		let revertDraftSelector = By.css( 'button.editor-post-switch-to-draft' );
+		await driverHelper.clickWhenClickable( this.driver, revertDraftSelector );
+		const revertAlert = await this.driver.switchTo().alert();
+		return await revertAlert.accept();
+	}
+
+	async isDraft() {
+		const hasPublishButton = await driverHelper.isElementPresent(
+			this.driver,
+			By.css( 'button.editor-post-publish-panel__toggle' )
+		);
+		const hasRevertButton = await driverHelper.isElementPresent(
+			this.driver,
+			By.css( 'button.editor-post-switch-to-draft' )
+		);
+		return hasPublishButton && !hasRevertButton;
+	}
+
+	async closeSidebar() {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.editor-post-publish-panel__header button.components-button.components-icon-button' )
+		);
+	}
 }

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -22,12 +22,12 @@ import PostEditorToolbarComponent from '../lib/components/post-editor-toolbar-co
 import EditorConfirmationSidebarComponent from '../lib/components/editor-confirmation-sidebar-component';
 import GutenbergEditorHeaderComponent from '../lib/gutenberg/gutenberg-editor-header-component';
 import WPAdminPostsPage from '../lib/pages/wp-admin/wp-admin-posts-page';
+import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
 
 import * as driverManager from '../lib/driver-manager';
 import * as driverHelper from '../lib/driver-helper';
 import * as mediaHelper from '../lib/media-helper';
 import * as dataHelper from '../lib/data-helper';
-import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -1293,49 +1293,43 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 	} );
 
-	xdescribe( 'Revert a post to draft: @parallel', function() {
+	describe( 'Revert a post to draft: @parallel', function() {
 		describe( 'Publish a new post', function() {
 			const originalBlogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =
 				'To really be of help to others we need to be guided by compassion.\n— Dalai Lama\n';
 
 			step( 'Can log in', async function() {
-				this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await this.loginFlow.loginAndStartNewPost();
+				const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+				return await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			step( 'Can enter post title and content', async function() {
-				this.editorPage = await EditorPage.Expect( driver );
-				await this.editorPage.enterTitle( originalBlogPostTitle );
-				await this.editorPage.enterContent( blogPostQuote );
+				const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
+				await gHeaderComponent.removeNUXNotice();
+				await gHeaderComponent.enterTitle( originalBlogPostTitle );
+				await gHeaderComponent.enterText( blogPostQuote );
 
-				let errorShown = await this.editorPage.errorDisplayed();
+				const errorShown = await gHeaderComponent.errorDisplayed();
 				return assert.strictEqual(
 					errorShown,
 					false,
-					'There is an error shown on the editor page!'
+					'There is an error shown on the Gutenberg editor page!'
 				);
 			} );
 
 			step( 'Can publish the post', async function() {
-				this.postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
-				await this.postEditorToolbarComponent.ensureSaved();
-				await this.postEditorToolbarComponent.publishThePost( { useConfirmStep: true } );
-
-				await this.postEditorToolbarComponent.waitForSuccessViewPostNotice();
-				const postPreviewComponent = await PostPreviewComponent.Expect( driver );
-
-				return await postPreviewComponent.edit();
+				const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
+				await gHeaderComponent.publish();
+				return await gHeaderComponent.closeSidebar();
 			} );
 		} );
 
 		describe( 'Revert the post to draft', function() {
 			step( 'Can revert the post to draft', async function() {
-				let postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
-				const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
-				await postEditorSidebarComponent.revertToDraft();
-				await postEditorToolbarComponent.waitForIsDraftStatus();
-				let isDraft = await postEditorToolbarComponent.statusIsDraft();
+				const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
+				await gHeaderComponent.revertToDraft();
+				let isDraft = await gHeaderComponent.isDraft();
 				assert.strictEqual( isDraft, true, 'The post is not set as draft' );
 			} );
 		} );


### PR DESCRIPTION
Updates the revert to draft test to work with Gutenberg

part of #1620 

To Test:
Confirm test passes on desktop and mobile