### PR TITLE
[Gutenberg] Public Posts: Preview and Publish a Public Post

### DIFF
--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -454,3 +454,15 @@ export async function clearTextArea( driver, selector ) {
 		i--;
 	}
 }
+
+export async function dismissAlertIfPresent( driver ) {
+	try {
+		driver
+			.switchTo()
+			.alert()
+			.dismiss();
+		return true;
+	} catch ( error ) {
+		return false;
+	}
+}

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -1,7 +1,10 @@
 /** @format */
 import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper';
+import * as driverManager from '../driver-manager.js';
 import AsyncBaseContainer from '../async-base-container';
+import GutenbergPreviewComponent from './gutenberg-preview-component';
+import webdriver from 'selenium-webdriver';
 
 export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	constructor( driver ) {
@@ -116,5 +119,96 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, titleSelector );
 		const element = await this.driver.findElement( titleSelector );
 		return await element.getAttribute( 'value' );
+	}
+
+	async sendFile( name, path ) {
+		const fileNameInputSelector = webdriver.By.css(
+			'.components-form-file-upload input[type="file"]'
+		);
+		const driver = this.driver;
+
+		await driverHelper.waitTillPresentAndDisplayed(
+			driver,
+			By.css( '.components-form-file-upload ' )
+		);
+		let filePathInput = await driver.findElement( fileNameInputSelector );
+		await filePathInput.sendKeys( path );
+
+		await this.openSidebar();
+
+		await driverHelper.clickWhenClickable(
+			driver,
+			By.css( '.components-textarea-control__input' )
+		);
+		let altTextInput = await driver.findElement( By.css( '.components-textarea-control__input' ) );
+		await altTextInput.click();
+		// There's a little time here where the image block seems to refresh, if the alt text is entered before the refresh it will be cleared before saving
+		await this.driver.sleep( 2000 );
+		await altTextInput.sendKeys( name );
+		return await this.closeSidebar();
+	}
+
+	async enterImage( fileDetails ) {
+		const newImageName = fileDetails.imageName;
+		const newFile = fileDetails.file;
+
+		await this.sendFile( newImageName, newFile );
+	}
+
+	async toggleSidebar( open = true ) {
+		const sidebarSelector = '.edit-post-sidebar-header';
+		const sidebarOpen = await driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			By.css( sidebarSelector )
+		);
+		if ( open && ! sidebarOpen ) {
+			return await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( "button[aria-label='Settings']" )
+			);
+		}
+
+		if ( ! open && sidebarOpen ) {
+			if ( driverManager.currentScreenSize() === 'desktop' ) {
+				return await driverHelper.clickWhenClickable(
+					this.driver,
+					By.css( ".edit-post-sidebar__panel-tabs button[aria-label='Close settings']" )
+				);
+			}
+			return await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( ".edit-post-sidebar-header__small button[aria-label='Close settings']" )
+			);
+		}
+	}
+
+	async openSidebar() {
+		return await this.toggleSidebar( true );
+	}
+
+	async closeSidebar() {
+		return await this.toggleSidebar( false );
+	}
+
+	async ensureSaved() {
+		await driverHelper.clickWhenClickable( this.driver, By.css( '.editor-post-save-draft' ) );
+		const savedSelector = By.css( 'span.is-saved' );
+
+		return await driverHelper.waitTillPresentAndDisplayed( this.driver, savedSelector );
+	}
+
+	static async switchToEditor( driver ) {
+		const tabs = await driver.getAllWindowHandles();
+		await driver.switchTo().window( tabs[ 0 ] );
+		return await driver.sleep( 1000 );
+	}
+
+	async launchPreview() {
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.editor-post-preview' ),
+			this.explicitWaitMS
+		);
+		return await GutenbergPreviewComponent.switchToPreview( this.driver );
 	}
 }

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -3,7 +3,6 @@ import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper';
 import * as driverManager from '../driver-manager.js';
 import AsyncBaseContainer from '../async-base-container';
-import GutenbergPreviewComponent from './gutenberg-preview-component';
 import webdriver from 'selenium-webdriver';
 
 export default class GutenbergEditorComponent extends AsyncBaseContainer {
@@ -157,7 +156,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async toggleSidebar( open = true ) {
 		const sidebarSelector = '.edit-post-sidebar-header';
-		const sidebarOpen = await driverHelper.isEventuallyPresentAndDisplayed(
+		const sidebarOpen = await driverHelper.isElementPresent(
 			this.driver,
 			By.css( sidebarSelector )
 		);
@@ -197,18 +196,11 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, savedSelector );
 	}
 
-	static async switchToEditor( driver ) {
-		const tabs = await driver.getAllWindowHandles();
-		await driver.switchTo().window( tabs[ 0 ] );
-		return await driver.sleep( 1000 );
-	}
-
 	async launchPreview() {
-		await driverHelper.clickWhenClickable(
+		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( '.editor-post-preview' ),
 			this.explicitWaitMS
 		);
-		return await GutenbergPreviewComponent.switchToPreview( this.driver );
 	}
 }

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -3,7 +3,7 @@ import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper';
 import AsyncBaseContainer from '../async-base-container';
 
-export default class GutenbergEditorHeaderComponent extends AsyncBaseContainer {
+export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '#editor.gutenberg__editor .edit-post-header' ) );
 	}

--- a/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -1,6 +1,6 @@
 /** @format */
 
-import { By } from 'selenium-webdriver';
+import { By, Key } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper.js';
 import AsyncBaseContainer from '../async-base-container';
 import * as driverManager from '../driver-manager';
@@ -10,6 +10,124 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 		super( driver, By.css( '.block-editor.gutenberg' ) );
 		this.cogSelector = By.css( '[aria-label="Settings"]:not([disabled])' );
 		this.closeSelector = By.css( '[aria-label="Close settings"]:not([disabled])' );
+	}
+
+	async sidebarSections() {
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.components-panel__body-toggle' )
+		);
+		return await this.driver.findElements( By.css( '.components-panel__body-toggle' ) );
+	}
+
+	async selectTab( name ) {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( `.edit-post-sidebar__panel-tab[data-label='${ name }'` )
+		);
+	}
+	async selectDocumentTab() {
+		return await this.selectTab( 'Document' );
+	}
+
+	async expandStatusAndVisibility() {
+		return this._expandOrCollapseSection( 0, true );
+	}
+
+	async expandCategories() {
+		return this._expandOrCollapseSection( 1, true );
+	}
+
+	async expandTags() {
+		return this._expandOrCollapseSection( 2, true );
+	}
+
+	async expandFeaturedImage() {
+		return this._expandOrCollapseSection( 3, true );
+	}
+
+	async expandExcerpt() {
+		return this._expandOrCollapseSection( 4, true );
+	}
+
+	async expandDiscussion() {
+		return this._expandOrCollapseSection( 5, true );
+	}
+
+	async collapseStatusAndVisibility() {
+		return this._expandOrCollapseSection( 0, false );
+	}
+
+	async collapseCategories() {
+		return this._expandOrCollapseSection( 1, false );
+	}
+
+	async collapseTags() {
+		return this._expandOrCollapseSection( 2, false );
+	}
+
+	async collapseFeaturedImage() {
+		return this._expandOrCollapseSection( 3, false );
+	}
+
+	async collapseExcerpt() {
+		return this._expandOrCollapseSection( 4, false );
+	}
+
+	async collapseDiscussion() {
+		return this._expandOrCollapseSection( 5, false );
+	}
+
+	async _expandOrCollapseSection( sectionNumber, expand = true ) {
+		// Without the pause it doesn't wait to find all the sections, only picking up the last 3
+		await this.driver.sleep( 2000 );
+		const sidebarButtons = await this.sidebarSections();
+		const sectionButton = sidebarButtons[ sectionNumber ];
+
+		let c = await sectionButton.getAttribute( 'aria-expanded' );
+		if ( expand && c === 'false' ) {
+			// TODO: Scroll into view
+			return await sectionButton.click();
+		}
+		if ( ! expand && c === 'true' ) {
+			// TODO: Scroll into view
+			return await sectionButton.click();
+		}
+	}
+
+	async addNewCategory( category ) {
+		const addNewCategoryButtonSelector = By.css(
+			'.editor-post-taxonomies__hierarchical-terms-add'
+		);
+		const categoryNameInputSelector = By.css(
+			'input.editor-post-taxonomies__hierarchical-terms-input[type=text]'
+		);
+		const saveCategoryButtonSelector = By.css(
+			'button.editor-post-taxonomies__hierarchical-terms-submit'
+		);
+		const driver = this.driver;
+
+		driver.sleep( 500 );
+		await driverHelper.clickWhenClickable( driver, addNewCategoryButtonSelector );
+		await driverHelper.waitForFieldClearable( driver, categoryNameInputSelector );
+		driver.sleep( 500 );
+		await driverHelper.setWhenSettable( driver, categoryNameInputSelector, category );
+		await driverHelper.clickWhenClickable( driver, saveCategoryButtonSelector );
+		return await driverHelper.waitTillPresentAndDisplayed(
+			driver,
+			By.xpath( `//label[contains(text(), '${ category }')]` )
+		);
+	}
+
+	async addNewTag( tag ) {
+		const tagEntrySelector = By.css( 'input.components-form-token-field__input' );
+
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, tagEntrySelector );
+		await driverHelper.scrollIntoView( this.driver, tagEntrySelector );
+		await driverHelper.waitForFieldClearable( this.driver, tagEntrySelector );
+		let tagEntryElement = await this.driver.findElement( tagEntrySelector );
+		await tagEntryElement.sendKeys( tag );
+		return await tagEntryElement.sendKeys( Key.ENTER );
 	}
 
 	async _postInit() {

--- a/lib/gutenberg/gutenberg-preview-component.js
+++ b/lib/gutenberg/gutenberg-preview-component.js
@@ -1,0 +1,39 @@
+/** @format */
+import { By } from 'selenium-webdriver';
+import AsyncBaseContainer from '../async-base-container';
+import ViewPostPage from '../pages/view-post-page';
+
+export default class GutenbergPreviewComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '#main.site-main' ) );
+	}
+
+	static async switchToPreview( driver ) {
+		const tabs = await driver.getAllWindowHandles();
+		return await driver.switchTo().window( tabs[ 1 ] ); // Will crash if preview tab wasn't opened
+	}
+
+	async postTitle() {
+		await GutenbergPreviewComponent.switchToPreview( this.driver );
+		this.viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await this.viewPostPage.postTitle();
+	}
+
+	async postContent() {
+		await GutenbergPreviewComponent.switchToPreview( this.driver );
+		this.viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await this.viewPostPage.postContent();
+	}
+
+	async categoryDisplayed() {
+		await GutenbergPreviewComponent.switchToPreview( this.driver );
+		this.viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await this.viewPostPage.categoryDisplayed();
+	}
+
+	async imageDisplayed( fileDetails ) {
+		await GutenbergPreviewComponent.switchToPreview( this.driver );
+		this.viewPagePage = await ViewPostPage.Expect( this.driver );
+		return await this.viewPagePage.imageDisplayed( fileDetails );
+	}
+}

--- a/lib/gutenberg/gutenberg-preview-component.js
+++ b/lib/gutenberg/gutenberg-preview-component.js
@@ -8,32 +8,23 @@ export default class GutenbergPreviewComponent extends AsyncBaseContainer {
 		super( driver, By.css( '#main.site-main' ) );
 	}
 
-	static async switchToPreview( driver ) {
-		const tabs = await driver.getAllWindowHandles();
-		return await driver.switchTo().window( tabs[ 1 ] ); // Will crash if preview tab wasn't opened
-	}
-
 	async postTitle() {
-		await GutenbergPreviewComponent.switchToPreview( this.driver );
-		this.viewPostPage = await ViewPostPage.Expect( this.driver );
-		return await this.viewPostPage.postTitle();
+		const viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await viewPostPage.postTitle();
 	}
 
 	async postContent() {
-		await GutenbergPreviewComponent.switchToPreview( this.driver );
-		this.viewPostPage = await ViewPostPage.Expect( this.driver );
-		return await this.viewPostPage.postContent();
+		const viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await viewPostPage.postContent();
 	}
 
 	async categoryDisplayed() {
-		await GutenbergPreviewComponent.switchToPreview( this.driver );
-		this.viewPostPage = await ViewPostPage.Expect( this.driver );
-		return await this.viewPostPage.categoryDisplayed();
+		const viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await viewPostPage.categoryDisplayed();
 	}
 
 	async imageDisplayed( fileDetails ) {
-		await GutenbergPreviewComponent.switchToPreview( this.driver );
-		this.viewPagePage = await ViewPostPage.Expect( this.driver );
-		return await this.viewPagePage.imageDisplayed( fileDetails );
+		const viewPagePage = await ViewPostPage.Expect( this.driver );
+		return await viewPagePage.imageDisplayed( fileDetails );
 	}
 }

--- a/specs-blocks/gutenberg-markdown-block-spec.js
+++ b/specs-blocks/gutenberg-markdown-block-spec.js
@@ -7,7 +7,7 @@ import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar.js';
 import JetpackConnectFlow from '../lib/flows/jetpack-connect-flow.js';
 import MarkdownBlockComponent from '../lib/gutenberg/blocks/markdown-block-component.js';
 import PostAreaComponent from '../lib/pages/frontend/post-area-component.js';
-import GutenbergEditorHeaderComponent from '../lib/gutenberg/gutenberg-editor-header-component.js';
+import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component.js';
 import * as driverManager from '../lib/driver-manager.js';
 import * as dataHelper from '../lib/data-helper.js';
 import WPAdminJetpackModulesPage from '../lib/pages/wp-admin/wp-admin-jetpack-modules-page.js';
@@ -71,7 +71,7 @@ if ( screenSize !== 'mobile' ) {
 			} );
 
 			step( 'Can insert a markdown block', async function() {
-				const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
+				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
 				await gHeaderComponent.removeNUXNotice();
 				this.markdownBlockID = await gHeaderComponent.addBlock( 'Markdown' );
 			} );
@@ -91,7 +91,7 @@ if ( screenSize !== 'mobile' ) {
 			} );
 
 			step( 'Can publish the post and see its content', async function() {
-				const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
+				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
 				await gHeaderComponent.publish( { visit: true } );
 				const postFrontend = await PostAreaComponent.Expect( driver );
 				const html = await postFrontend.getPostHTML();

--- a/specs/wp-gutenberg-page-editor-spec.js
+++ b/specs/wp-gutenberg-page-editor-spec.js
@@ -18,7 +18,7 @@ import * as mediaHelper from '../lib/media-helper.js';
 import * as dataHelper from '../lib/data-helper.js';
 import * as driverHelper from '../lib/driver-helper';
 import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
-import GutenbergEditorHeaderComponent from '../lib/gutenberg/gutenberg-editor-header-component';
+import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
 import * as SlackNotifier from '../lib/slack-notifier';
 
@@ -324,7 +324,7 @@ describe( `[${ host }] Gutenberg Editor: Pages (${ screenSize })`, function() {
 			} );
 
 			step( 'Can enter page title and content and set to password protected', async function() {
-				let gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
+				let gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
 				await gHeaderComponent.removeNUXNotice();
 				await gHeaderComponent.enterTitle( pageTitle );
 
@@ -340,12 +340,12 @@ describe( `[${ host }] Gutenberg Editor: Pages (${ screenSize })`, function() {
 				await gSidebarComponent.setVisibilityToPasswordProtected( postPassword );
 				await gSidebarComponent.hideComponentIfNecessary();
 
-				gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
+				gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
 				return await gHeaderComponent.enterText( pageQuote );
 			} );
 
 			step( 'Can publish and view content', async function() {
-				const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
+				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
 				await gHeaderComponent.publish( { visit: true } );
 			} );
 

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -44,7 +44,7 @@ before( async function() {
 describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
-	xdescribe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
+	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
 		let fileDetails;
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =
@@ -195,15 +195,15 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			);
 		} );
 
-		step( 'Can see correct post tag', async function() {
-			const viewPostPage = await ViewPostPage.Expect( driver );
-			let tagDisplayed = await viewPostPage.tagDisplayed();
-			assert.strictEqual(
-				tagDisplayed.toUpperCase(),
-				newTagName.toUpperCase(),
-				'The tag: ' + newTagName + ' is not being displayed on the post'
-			);
-		} );
+		// step( 'Can see correct post tag', async function() {
+		// 	const viewPostPage = await ViewPostPage.Expect( driver );
+		// 	let tagDisplayed = await viewPostPage.tagDisplayed();
+		// 	assert.strictEqual(
+		// 		tagDisplayed.toUpperCase(),
+		// 		newTagName.toUpperCase(),
+		// 		'The tag: ' + newTagName + ' is not being displayed on the post'
+		// 	);
+		// } );
 
 		step( 'Can see the image published', async function() {
 			const viewPostPage = await ViewPostPage.Expect( driver );

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -6,7 +6,6 @@ import config from 'config';
 import LoginFlow from '../lib/flows/login-flow.js';
 
 import EditorPage from '../lib/pages/editor-page.js';
-import TwitterFeedPage from '../lib/pages/twitter-feed-page.js';
 import ViewPostPage from '../lib/pages/view-post-page.js';
 import NotFoundPage from '../lib/pages/not-found-page.js';
 import PostsPage from '../lib/pages/posts-page.js';
@@ -28,6 +27,7 @@ import * as driverHelper from '../lib/driver-helper';
 import * as mediaHelper from '../lib/media-helper';
 import * as dataHelper from '../lib/data-helper';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
+import GutenbergPreviewComponent from '../lib/gutenberg/gutenberg-preview-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -48,10 +48,9 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		let fileDetails;
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =
-			'The foolish man seeketh happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
+			'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
 		const newCategoryName = 'Category ' + new Date().getTime().toString();
 		const newTagName = 'Tag ' + new Date().getTime().toString();
-		const publicizeMessage = dataHelper.randomPhrase();
 
 		// Create image file for upload
 		before( async function() {
@@ -60,109 +59,65 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Can log in', async function() {
-			let loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-			return await loginFlow.loginAndStartNewPost();
+			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		step( 'Can enter post title, content and image', async function() {
-			let editorPage = await EditorPage.Expect( driver );
-			await editorPage.enterTitle( blogPostTitle );
-			await editorPage.enterContent( blogPostQuote + '\n' );
-			await editorPage.enterPostImage( fileDetails );
-			await editorPage.waitUntilImageInserted( fileDetails );
-			let errorShown = await editorPage.errorDisplayed();
-			assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.removeNUXNotice();
+			await gEditorComponent.enterTitle( blogPostTitle );
+			await gEditorComponent.enterText( blogPostQuote );
+			await gEditorComponent.addBlock( 'Image' );
+
+			await gEditorComponent.enterImage( fileDetails );
+
+			let errorShown = await gEditorComponent.errorDisplayed();
+			return assert.strictEqual(
+				errorShown,
+				false,
+				'There is an error shown on the Gutenberg editor page!'
+			);
 		} );
 
 		step( 'Expand Categories and Tags', async function() {
-			const postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
-			await postEditorSidebarComponent.expandCategoriesAndTags();
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.openSidebar();
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			await gEditorSidebarComponent.selectDocumentTab();
+			await gEditorSidebarComponent.collapseStatusAndVisibility(); // Status and visibility starts opened
+			await gEditorSidebarComponent.expandCategories();
+			await gEditorSidebarComponent.expandTags();
 		} );
 
 		step( 'Can add a new category', async function() {
-			const postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
-			await postEditorSidebarComponent.addNewCategory( newCategoryName );
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			await gEditorSidebarComponent.addNewCategory( newCategoryName );
 		} );
 
 		step( 'Can add a new tag', async function() {
-			const postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
-			await postEditorSidebarComponent.addNewTag( newTagName );
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			await gEditorSidebarComponent.addNewTag( newTagName );
 		} );
 
 		step( 'Close categories and tags', async function() {
-			const postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
-			await postEditorSidebarComponent.closeCategoriesAndTags();
-		} );
-
-		step( 'Verify categories and tags present after save', async function() {
-			const postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
-			const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
-			await postEditorSidebarComponent.hideComponentIfNecessary();
-			await postEditorToolbarComponent.ensureSaved();
-			await postEditorSidebarComponent.displayComponentIfNecessary();
-			let subtitle = await postEditorSidebarComponent.getCategoriesAndTags();
-			assert(
-				! subtitle.match( /Uncategorized/ ),
-				'Post still marked Uncategorized after adding new category AFTER SAVE'
-			);
-			assert( subtitle.match( `#${ newTagName }` ), `New tag #${ newTagName } not applied` );
-		} );
-
-		step( 'Expand sharing section', async function() {
-			let postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
-			await postEditorSidebarComponent.expandSharingSection();
-		} );
-
-		if ( host !== 'CI' && host !== 'JN' ) {
-			step( 'Can see the publicise to twitter account', async function() {
-				const publicizeTwitterAccount = config.has( 'publicizeTwitterAccount' )
-					? config.get( 'publicizeTwitterAccount' )
-					: '';
-				let postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
-				let accountDisplayed = await postEditorSidebarComponent.publicizeToTwitterAccountDisplayed();
-				assert.strictEqual(
-					accountDisplayed,
-					publicizeTwitterAccount,
-					'Could not see see the publicize to twitter account ' +
-						publicizeTwitterAccount +
-						' in the editor'
-				);
-			} );
-
-			step( 'Can see the default publicise message', async function() {
-				let postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
-				let messageDisplayed = await postEditorSidebarComponent.publicizeMessageDisplayed();
-				assert.strictEqual(
-					messageDisplayed,
-					blogPostTitle,
-					"The publicize message is not defaulting to the post's title"
-				);
-			} );
-
-			step( 'Can set a custom publicise message', async function() {
-				let postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
-				await postEditorSidebarComponent.setPublicizeMessage( publicizeMessage );
-			} );
-		}
-
-		step( 'Close sharing section', async function() {
-			let postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
-			await postEditorSidebarComponent.closeSharingSection();
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			await gEditorSidebarComponent.selectDocumentTab();
+			await gEditorSidebarComponent.collapseCategories();
+			await gEditorSidebarComponent.collapseTags();
+			await gEditorComponent.closeSidebar();
 		} );
 
 		step( 'Can launch post preview', async function() {
-			let postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
-			await postEditorSidebarComponent.hideComponentIfNecessary();
-
-			this.postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
-			await this.postEditorToolbarComponent.ensureSaved();
-			await this.postEditorToolbarComponent.launchPreview();
-			this.postPreviewComponent = await PostPreviewComponent.Expect( driver );
-			return await this.postPreviewComponent.displayed();
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.ensureSaved();
+			await gEditorComponent.launchPreview();
 		} );
 
 		step( 'Can see correct post title in preview', async function() {
-			let postTitle = await this.postPreviewComponent.postTitle();
+			const gPreviewComponent = await GutenbergPreviewComponent.Expect( driver );
+			let postTitle = await gPreviewComponent.postTitle();
 			assert.strictEqual(
 				postTitle.toLowerCase(),
 				blogPostTitle.toLowerCase(),
@@ -171,7 +126,8 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Can see correct post content in preview', async function() {
-			let content = await this.postPreviewComponent.postContent();
+			const gPreviewComponent = await GutenbergPreviewComponent.Expect( driver );
+			let content = await gPreviewComponent.postContent();
 			assert.strictEqual(
 				content.indexOf( blogPostQuote ) > -1,
 				true,
@@ -184,7 +140,8 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Can see the post category in preview', async function() {
-			let categoryDisplayed = await this.postPreviewComponent.categoryDisplayed();
+			const gPreviewComponent = await GutenbergPreviewComponent.Expect( driver );
+			let categoryDisplayed = await gPreviewComponent.categoryDisplayed();
 			assert.strictEqual(
 				categoryDisplayed.toUpperCase(),
 				newCategoryName.toUpperCase(),
@@ -192,87 +149,21 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			);
 		} );
 
-		step( 'Can see the post tag in preview', async function() {
-			let tagDisplayed = await this.postPreviewComponent.tagDisplayed();
-			assert.strictEqual(
-				tagDisplayed.toUpperCase(),
-				newTagName.toUpperCase(),
-				'The tag: ' + newTagName + ' is not being displayed on the post'
-			);
-		} );
-
 		step( 'Can see the image in preview', async function() {
-			let imageDisplayed = await this.postPreviewComponent.imageDisplayed( fileDetails );
+			const gPreviewComponent = await GutenbergPreviewComponent.Expect( driver );
+			let imageDisplayed = await gPreviewComponent.imageDisplayed( fileDetails );
 			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the web preview' );
 		} );
 
-		step( 'Can close post preview', async function() {
-			await this.postPreviewComponent.close();
-		} );
-
 		step( 'Can publish and view content', async function() {
-			const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
-			await postEditorToolbarComponent.publishThePost( { useConfirmStep: true } );
-		} );
-
-		step( 'Can see correct post title in preview', async function() {
-			this.postPreviewComponent = await PostPreviewComponent.Expect( driver );
-			let postTitle = await this.postPreviewComponent.postTitle();
-			assert.strictEqual(
-				postTitle.toLowerCase(),
-				blogPostTitle.toLowerCase(),
-				'The blog post preview title is not correct'
-			);
-		} );
-
-		step( 'Can see correct post content in preview', async function() {
-			let content = await this.postPreviewComponent.postContent();
-			assert.strictEqual(
-				content.indexOf( blogPostQuote ) > -1,
-				true,
-				'The post preview content (' +
-					content +
-					') does not include the expected content (' +
-					blogPostQuote +
-					')'
-			);
-		} );
-
-		step( 'Can see the post category in preview', async function() {
-			let categoryDisplayed = await this.postPreviewComponent.categoryDisplayed();
-			assert.strictEqual(
-				categoryDisplayed.toUpperCase(),
-				newCategoryName.toUpperCase(),
-				'The category: ' + newCategoryName + ' is not being displayed on the post'
-			);
-		} );
-
-		step( 'Can see the post tag in preview', async function() {
-			let tagDisplayed = await this.postPreviewComponent.tagDisplayed();
-			assert.strictEqual(
-				tagDisplayed.toUpperCase(),
-				newTagName.toUpperCase(),
-				'The tag: ' + newTagName + ' is not being displayed on the post'
-			);
-		} );
-
-		step( 'Can see the image in preview', async function() {
-			let imageDisplayed = await this.postPreviewComponent.imageDisplayed( fileDetails );
-			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the web preview' );
-		} );
-
-		step( 'Can close post preview', async function() {
-			return await this.postPreviewComponent.edit();
-		} );
-
-		step( 'Can publish and view content', async function() {
-			const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
-			await postEditorToolbarComponent.viewPublishedPostOrPage();
+			await GutenbergEditorComponent.switchToEditor( driver );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.publish( { visit: true } );
 		} );
 
 		step( 'Can see correct post title', async function() {
-			this.viewPostPage = await ViewPostPage.Expect( driver );
-			let postTitle = await this.viewPostPage.postTitle();
+			const viewPostPage = await ViewPostPage.Expect( driver );
+			let postTitle = await viewPostPage.postTitle();
 			assert.strictEqual(
 				postTitle.toLowerCase(),
 				blogPostTitle.toLowerCase(),
@@ -281,7 +172,8 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Can see correct post content', async function() {
-			let content = await this.viewPostPage.postContent();
+			const viewPostPage = await ViewPostPage.Expect( driver );
+			let content = await viewPostPage.postContent();
 			assert.strictEqual(
 				content.indexOf( blogPostQuote ) > -1,
 				true,
@@ -294,7 +186,8 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Can see correct post category', async function() {
-			let categoryDisplayed = await this.viewPostPage.categoryDisplayed();
+			const viewPostPage = await ViewPostPage.Expect( driver );
+			let categoryDisplayed = await viewPostPage.categoryDisplayed();
 			assert.strictEqual(
 				categoryDisplayed.toUpperCase(),
 				newCategoryName.toUpperCase(),
@@ -303,7 +196,8 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Can see correct post tag', async function() {
-			let tagDisplayed = await this.viewPostPage.tagDisplayed();
+			const viewPostPage = await ViewPostPage.Expect( driver );
+			let tagDisplayed = await viewPostPage.tagDisplayed();
 			assert.strictEqual(
 				tagDisplayed.toUpperCase(),
 				newTagName.toUpperCase(),
@@ -312,23 +206,16 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Can see the image published', async function() {
-			let imageDisplayed = await this.viewPostPage.imageDisplayed( fileDetails );
+			const viewPostPage = await ViewPostPage.Expect( driver );
+			let imageDisplayed = await viewPostPage.imageDisplayed( fileDetails );
 			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the published post' );
 		} );
-
-		if ( host !== 'CI' && host !== 'JN' ) {
-			describe( 'Can see post publicized on twitter', function() {
-				step( 'Can see post message', async function() {
-					let twitterFeedPage = await TwitterFeedPage.Visit( driver );
-					return await twitterFeedPage.checkLatestTweetsContain( publicizeMessage );
-				} );
-			} );
-		}
 
 		after( async function() {
 			if ( fileDetails ) {
 				await mediaHelper.deleteFile( fileDetails );
 			}
+			await driverHelper.dismissAlertIfPresent();
 		} );
 	} );
 

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -48,7 +48,7 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		let fileDetails;
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =
-			'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
+			'The foolish man seeketh happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
 		const newCategoryName = 'Category ' + new Date().getTime().toString();
 		const newTagName = 'Tag ' + new Date().getTime().toString();
 		const publicizeMessage = dataHelper.randomPhrase();

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -20,7 +20,7 @@ import PostPreviewComponent from '../lib/components/post-preview-component.js';
 import PostEditorSidebarComponent from '../lib/components/post-editor-sidebar-component.js';
 import PostEditorToolbarComponent from '../lib/components/post-editor-toolbar-component';
 import EditorConfirmationSidebarComponent from '../lib/components/editor-confirmation-sidebar-component';
-import GutenbergEditorHeaderComponent from '../lib/gutenberg/gutenberg-editor-header-component';
+import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import WPAdminPostsPage from '../lib/pages/wp-admin/wp-admin-posts-page';
 
 import * as driverManager from '../lib/driver-manager';
@@ -344,12 +344,12 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			step( 'Can enter post title and text content', async function() {
-				const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
-				await gHeaderComponent.removeNUXNotice();
-				await gHeaderComponent.enterTitle( blogPostTitle );
-				await gHeaderComponent.enterText( blogPostQuote );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				await gEditorComponent.removeNUXNotice();
+				await gEditorComponent.enterTitle( blogPostTitle );
+				await gEditorComponent.enterText( blogPostQuote );
 
-				const errorShown = await gHeaderComponent.errorDisplayed();
+				const errorShown = await gEditorComponent.errorDisplayed();
 				return assert.strictEqual(
 					errorShown,
 					false,
@@ -358,8 +358,8 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			step( 'Can publish and view content', async function() {
-				const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
-				await gHeaderComponent.publish( { visit: true } );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				await gEditorComponent.publish( { visit: true } );
 			} );
 
 			step( 'Can see correct post title', async function() {
@@ -385,18 +385,18 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 
 		step( 'Can enter post title and content', async function() {
-			const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
-			await gHeaderComponent.removeNUXNotice();
-			await gHeaderComponent.enterTitle( blogPostTitle );
-			await gHeaderComponent.enterText( blogPostQuote );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.removeNUXNotice();
+			await gEditorComponent.enterTitle( blogPostTitle );
+			await gEditorComponent.enterText( blogPostQuote );
 
-			let errorShown = await gHeaderComponent.errorDisplayed();
+			let errorShown = await gEditorComponent.errorDisplayed();
 			return assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
 		} );
 
 		step( 'Can publish and view content', async function() {
-			const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
-			await gHeaderComponent.publish( { visit: true } );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.publish( { visit: true } );
 		} );
 
 		step( 'Can see the post in the Activity log', async function() {
@@ -1041,10 +1041,10 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			step( 'Can enter post title and content', async function() {
-				const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
-				await gHeaderComponent.removeNUXNotice();
-				await gHeaderComponent.enterTitle( blogPostTitle );
-				return await gHeaderComponent.enterText( blogPostQuote );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				await gEditorComponent.removeNUXNotice();
+				await gEditorComponent.enterTitle( blogPostTitle );
+				return await gEditorComponent.enterText( blogPostQuote );
 			} );
 
 			step( 'Can trash the new post', async function() {
@@ -1078,11 +1078,11 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			step( 'Can enter post title and content', async function() {
-				const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
-				await gHeaderComponent.removeNUXNotice();
-				await gHeaderComponent.enterTitle( originalBlogPostTitle );
-				await gHeaderComponent.enterText( blogPostQuote );
-				let errorShown = await gHeaderComponent.errorDisplayed();
+				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				await gEditorComponent.removeNUXNotice();
+				await gEditorComponent.enterTitle( originalBlogPostTitle );
+				await gEditorComponent.enterText( blogPostQuote );
+				let errorShown = await gEditorComponent.errorDisplayed();
 				return assert.strictEqual(
 					errorShown,
 					false,
@@ -1091,8 +1091,8 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			} );
 
 			step( 'Can publish the post', async function() {
-				const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
-				await gHeaderComponent.publish( { visit: true } );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				await gEditorComponent.publish( { visit: true } );
 			} );
 
 			describe( 'Edit the post via posts', function() {
@@ -1119,12 +1119,12 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 						`The blog post titled '${ originalBlogPostTitle }' is not displayed in the list of posts`
 					);
 					await postsPage.editPostWithTitle( originalBlogPostTitle );
-					return await GutenbergEditorHeaderComponent.Expect( driver );
+					return await GutenbergEditorComponent.Expect( driver );
 				} );
 
 				step( 'Can see the post title', async function() {
-					const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
-					let titleShown = await gHeaderComponent.titleShown();
+					const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+					let titleShown = await gEditorComponent.titleShown();
 					assert.strictEqual(
 						titleShown,
 						originalBlogPostTitle,
@@ -1135,12 +1135,12 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 				step(
 					'Can set the new title and update it, and link to the updated post',
 					async function() {
-						const gHeaderComponent = await GutenbergEditorHeaderComponent.Expect( driver );
+						const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 
-						await gHeaderComponent.enterTitle( updatedBlogPostTitle );
-						let errorShown = await gHeaderComponent.errorDisplayed();
+						await gEditorComponent.enterTitle( updatedBlogPostTitle );
+						let errorShown = await gEditorComponent.errorDisplayed();
 						assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
-						return await gHeaderComponent.update( { visit: true } );
+						return await gEditorComponent.update( { visit: true } );
 					}
 				);
 

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -113,6 +113,8 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.ensureSaved();
 			await gEditorComponent.launchPreview();
+			await driverHelper.waitForNumberOfWindows( driver, 2 );
+			await driverHelper.switchToWindowByIndex( driver, 1 );
 		} );
 
 		step( 'Can see correct post title in preview', async function() {
@@ -155,8 +157,12 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the web preview' );
 		} );
 
+		step( 'Can close preview', async function() {
+			await driverHelper.closeCurrentWindow( driver );
+			return await driverHelper.switchToWindowByIndex( driver, 0 );
+		} );
+
 		step( 'Can publish and view content', async function() {
-			await GutenbergEditorComponent.switchToEditor( driver );
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.publish( { visit: true } );
 		} );
@@ -195,15 +201,15 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			);
 		} );
 
-		// step( 'Can see correct post tag', async function() {
-		// 	const viewPostPage = await ViewPostPage.Expect( driver );
-		// 	let tagDisplayed = await viewPostPage.tagDisplayed();
-		// 	assert.strictEqual(
-		// 		tagDisplayed.toUpperCase(),
-		// 		newTagName.toUpperCase(),
-		// 		'The tag: ' + newTagName + ' is not being displayed on the post'
-		// 	);
-		// } );
+		step( 'Can see correct post tag', async function() {
+			const viewPostPage = await ViewPostPage.Expect( driver );
+			let tagDisplayed = await viewPostPage.tagDisplayed();
+			assert.strictEqual(
+				tagDisplayed.toUpperCase(),
+				newTagName.toUpperCase(),
+				'The tag: ' + newTagName + ' is not being displayed on the post'
+			);
+		} );
 
 		step( 'Can see the image published', async function() {
 			const viewPostPage = await ViewPostPage.Expect( driver );


### PR DESCRIPTION
There's a lot of steps in this test and I wanted to get some eyes on this as I'm about midway. There are a few things I did so far and a few that may cause conflicts.  @Stojdza @alisterscott @bsessions85  

* Renamed `GutenbergEditorHeaderComponent` to `GutenbergEditorComponent - did this because we were doing things with the editor in general and not just the header and thought the name was a little misleading
* Created components for Sidebar and Preview 
* Removed the Sharing step in the original step as that's no longer in the sidebar for the Gutenberg editor(actually not sure how a user would replicate this functionality from the original editor)
* Category and tags now have there own section in the sidebar so separated the method for expanding and collapsing. 
* Categories and tags no longer appear on the sidebar as they did after their saved so couldn't verify it in the same way we did originally
* No longer seeing tags when previewing(not sure if I'm just missing it)
* Chrome level notification about leaving page stops test from progressing to next test even though it's saved before launching the preview. 

Part of #1620 

Original PR and conversation: https://github.com/Automattic/wp-e2e-tests/pull/1627