### PR TITLE
Gutenberg: Insert a contact form: @parallel

### DIFF
--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -73,6 +73,14 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return await this.driver.findElement( textSelector ).sendKeys( text );
 	}
 
+	async insertContactForm() {
+		await this.addBlock( 'Shortcode' );
+		const shortcodeSelector = By.css( 'textarea.editor-plain-text' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, shortcodeSelector );
+		const shortcodeTextarea = this.driver.findElement( shortcodeSelector );
+		shortcodeTextarea.sendKeys( '[contact-form][/contact-form]' );
+	}
+
 	async errorDisplayed() {
 		await this.driver.sleep( 1000 );
 		return await driverHelper.isElementPresent( this.driver, By.css( '.editor-error-boundary' ) );

--- a/lib/gutenberg/gutenberg-preview-component.js
+++ b/lib/gutenberg/gutenberg-preview-component.js
@@ -27,4 +27,9 @@ export default class GutenbergPreviewComponent extends AsyncBaseContainer {
 		const viewPagePage = await ViewPostPage.Expect( this.driver );
 		return await viewPagePage.imageDisplayed( fileDetails );
 	}
+
+	async ensureContactFormDisplayedInPost() {
+		const viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await viewPostPage.contactFormDisplayed();
+	}
 }

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -1061,37 +1061,32 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 	} );
 
-	xdescribe( 'Insert a contact form: @parallel', function() {
+	describe( 'Insert a contact form: @parallel', function() {
 		describe( 'Publish a New Post with a Contact Form', function() {
 			const originalBlogPostTitle = 'Contact Us: ' + dataHelper.randomPhrase();
 
 			step( 'Can log in', async function() {
-				this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await this.loginFlow.loginAndStartNewPost();
+				const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+				return await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			step( 'Can insert the contact form', async function() {
-				this.editorPage = await EditorPage.Expect( driver );
-				await this.editorPage.enterTitle( originalBlogPostTitle );
-				await this.editorPage.insertContactForm();
+				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				await gEditorComponent.removeNUXNotice();
+				await gEditorComponent.enterTitle( originalBlogPostTitle );
+				await gEditorComponent.insertContactForm();
 
-				let errorShown = await this.editorPage.errorDisplayed();
+				let errorShown = await gEditorComponent.errorDisplayed();
 				return assert.strictEqual(
 					errorShown,
 					false,
-					'There is an error shown on the editor page!'
+					'There is an error shown on the Gutenberg editor page!'
 				);
 			} );
 
-			step( 'Can see the contact form inserted into the visual editor', async function() {
-				this.editorPage = await EditorPage.Expect( driver );
-				return await this.editorPage.ensureContactFormDisplayedInPost();
-			} );
-
 			step( 'Can publish and view content', async function() {
-				const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
-				await postEditorToolbarComponent.ensureSaved();
-				await postEditorToolbarComponent.publishAndViewContent( { useConfirmStep: true } );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				await gEditorComponent.publish( { visit: true } );
 			} );
 
 			step( 'Can see the contact form in our published post', async function() {


### PR DESCRIPTION
There's no contact form block but I used a shortcode to simulate similar functionality. The shortcode doesn't render in the preview so there's no way to check in that step. Think this could be a suitable substitute until we have an official contact form block. 