### PR TITLE
Patch Gutenberg contact form: await promises from shortcode element

### DIFF
--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -77,8 +77,8 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await this.addBlock( 'Shortcode' );
 		const shortcodeSelector = By.css( 'textarea.editor-plain-text' );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, shortcodeSelector );
-		const shortcodeTextarea = this.driver.findElement( shortcodeSelector );
-		shortcodeTextarea.sendKeys( '[contact-form][/contact-form]' );
+		const shortcodeTextarea = await this.driver.findElement( shortcodeSelector );
+		return await shortcodeTextarea.sendKeys( '[contact-form][/contact-form]' );
 	}
 
 	async errorDisplayed() {


### PR DESCRIPTION
Merged PR without waiting on promises when looking for an element, 

Discussion: https://github.com/Automattic/wp-e2e-tests/pull/1639#discussion_r235104886

Thanks @Stojdza  for the catch! 