### PR TITLE
Gutenberg: Updating sections for permalink

### DIFF
--- a/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -34,48 +34,56 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 		return this._expandOrCollapseSection( 0, true );
 	}
 
-	async expandCategories() {
+	async expandPermalink() {
 		return this._expandOrCollapseSection( 1, true );
 	}
 
-	async expandTags() {
+	async expandCategories() {
 		return this._expandOrCollapseSection( 2, true );
 	}
 
-	async expandFeaturedImage() {
+	async expandTags() {
 		return this._expandOrCollapseSection( 3, true );
 	}
 
-	async expandExcerpt() {
+	async expandFeaturedImage() {
 		return this._expandOrCollapseSection( 4, true );
 	}
 
-	async expandDiscussion() {
+	async expandExcerpt() {
 		return this._expandOrCollapseSection( 5, true );
+	}
+
+	async expandDiscussion() {
+		return this._expandOrCollapseSection( 6, true );
 	}
 
 	async collapseStatusAndVisibility() {
 		return this._expandOrCollapseSection( 0, false );
 	}
 
-	async collapseCategories() {
+	async collapsePermalink() {
 		return this._expandOrCollapseSection( 1, false );
 	}
 
-	async collapseTags() {
+	async collapseCategories() {
 		return this._expandOrCollapseSection( 2, false );
 	}
 
-	async collapseFeaturedImage() {
+	async collapseTags() {
 		return this._expandOrCollapseSection( 3, false );
 	}
 
-	async collapseExcerpt() {
+	async collapseFeaturedImage() {
 		return this._expandOrCollapseSection( 4, false );
 	}
 
-	async collapseDiscussion() {
+	async collapseExcerpt() {
 		return this._expandOrCollapseSection( 5, false );
+	}
+
+	async collapseDiscussion() {
+		return this._expandOrCollapseSection( 6, false );
 	}
 
 	async _expandOrCollapseSection( sectionNumber, expand = true ) {

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -85,6 +85,7 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			await gEditorComponent.openSidebar();
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.selectDocumentTab();
+			await driver.sleep( 3000 );
 			await gEditorSidebarComponent.collapseStatusAndVisibility(); // Status and visibility starts opened
 			await gEditorSidebarComponent.expandCategories();
 			await gEditorSidebarComponent.expandTags();


### PR DESCRIPTION
The permalink section is new and it takes a couple seconds for it to show up.

Updated the tab index and added a sleep to wait for it.

Can't wait until we can add some better identifiers on these!