### PR TITLE
Update sidebar in Gutenberg to select by text instead of index

### DIFF
--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -445,6 +445,13 @@ export async function verifyTextPresent( driver, selector, text ) {
 	return await this.isElementPresent( driver, element );
 }
 
+export async function getElementByText( driver, selector, text ) {
+	return async () => {
+		let allElements = await driver.findElements( selector );
+		return await webdriver.promise.filter( allElements, async e => ( await e.getText() ) === text );
+	};
+}
+
 export async function clearTextArea( driver, selector ) {
 	const textArea = await driver.findElement( selector );
 	const textValue = await textArea.getText();

--- a/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -79,7 +79,11 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 	}
 
 	async _expandOrCollapseSectionByText( text, expand = true ) {
-		const sectionSelector = By.xpath( `//button[text()="${ text }"]` );
+		const sectionSelector = await driverHelper.getElementByText(
+			this.driver,
+			By.css( '.components-panel__body-toggle' ),
+			text
+		);
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, sectionSelector );
 		const sectionButton = await this.driver.findElement( sectionSelector );
 		let c = await sectionButton.getAttribute( 'aria-expanded' );

--- a/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -7,23 +7,15 @@ import * as driverManager from '../driver-manager';
 
 export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.block-editor.gutenberg' ) );
+		super( driver, By.css( '.edit-post-header' ) );
 		this.cogSelector = By.css( '[aria-label="Settings"]:not([disabled])' );
 		this.closeSelector = By.css( '[aria-label="Close settings"]:not([disabled])' );
-	}
-
-	async sidebarSections() {
-		await driverHelper.waitTillPresentAndDisplayed(
-			this.driver,
-			By.css( '.components-panel__body-toggle' )
-		);
-		return await this.driver.findElements( By.css( '.components-panel__body-toggle' ) );
 	}
 
 	async selectTab( name ) {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( `.edit-post-sidebar__panel-tab[data-label='${ name }'` )
+			By.css( `.edit-post-sidebar__panel-tab[aria-label^=${ name }]` )
 		);
 	}
 	async selectDocumentTab() {
@@ -31,67 +23,65 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 	}
 
 	async expandStatusAndVisibility() {
-		return this._expandOrCollapseSection( 0, true );
+		return await this._expandOrCollapseSectionByText( 'Status & Visibility', true );
 	}
 
 	async expandPermalink() {
-		return this._expandOrCollapseSection( 1, true );
+		return this._expandOrCollapseSectionByText( 'Permalink', true );
 	}
 
 	async expandCategories() {
-		return this._expandOrCollapseSection( 2, true );
+		return await this._expandOrCollapseSectionByText( 'Categories', true );
 	}
 
 	async expandTags() {
-		return this._expandOrCollapseSection( 3, true );
+		return this._expandOrCollapseSectionByText( 'Tags', true );
 	}
 
 	async expandFeaturedImage() {
-		return this._expandOrCollapseSection( 4, true );
+		return this._expandOrCollapseSectionByText( 'Featured Image', true );
 	}
 
 	async expandExcerpt() {
-		return this._expandOrCollapseSection( 5, true );
+		return this._expandOrCollapseSectionByText( 'Excerpt', true );
 	}
 
 	async expandDiscussion() {
-		return this._expandOrCollapseSection( 6, true );
+		return this._expandOrCollapseSectionByText( 'Discussion', true );
 	}
 
 	async collapseStatusAndVisibility() {
-		return this._expandOrCollapseSection( 0, false );
+		return this._expandOrCollapseSectionByText( 'Status & Visibility', false );
 	}
 
 	async collapsePermalink() {
-		return this._expandOrCollapseSection( 1, false );
+		return this._expandOrCollapseSectionByText( 'Permalink', false );
 	}
 
 	async collapseCategories() {
-		return this._expandOrCollapseSection( 2, false );
+		return this._expandOrCollapseSectionByText( 'Categories', false );
 	}
 
 	async collapseTags() {
-		return this._expandOrCollapseSection( 3, false );
+		return this._expandOrCollapseSectionByText( 'Tags', false );
 	}
 
 	async collapseFeaturedImage() {
-		return this._expandOrCollapseSection( 4, false );
+		return this._expandOrCollapseSectionByText( 'Featured Image', false );
 	}
 
 	async collapseExcerpt() {
-		return this._expandOrCollapseSection( 5, false );
+		return this._expandOrCollapseSectionByText( 'Excerpt', false );
 	}
 
 	async collapseDiscussion() {
-		return this._expandOrCollapseSection( 6, false );
+		return this._expandOrCollapseSectionByText( 'Discussion', false );
 	}
 
-	async _expandOrCollapseSection( sectionNumber, expand = true ) {
-		// Without the pause it doesn't wait to find all the sections, only picking up the last 3
-		await this.driver.sleep( 2000 );
-		const sidebarButtons = await this.sidebarSections();
-		const sectionButton = sidebarButtons[ sectionNumber ];
-
+	async _expandOrCollapseSectionByText( text, expand = true ) {
+		const sectionSelector = By.xpath( `//button[text()="${ text }"]` );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, sectionSelector );
+		const sectionButton = await this.driver.findElement( sectionSelector );
 		let c = await sectionButton.getAttribute( 'aria-expanded' );
 		if ( expand && c === 'false' ) {
 			// TODO: Scroll into view


### PR DESCRIPTION
The editor sidebar in Gutenberg currently uses an index based approach, the issue is the indexes change between state, eg. a saved draft has a different sidebar to an unsaved draft.

Also, wpcalypso.wordpress.com/gutenberg has a different sidebar order :(

<img width="293" alt="screen shot 2018-11-21 at 5 08 22 pm" src="https://user-images.githubusercontent.com/128826/48824449-1361be80-edb0-11e8-86d8-34feb6040cb2.png">

This PR updates the sidebar to select by text - not ideal but no other choice at present AFAIK