### PR TITLE
Skip test if domains tests are disabled

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1358,6 +1358,16 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const expectedDomainName = `${ blogName }.art.blog`;
 
 		before( async function() {
+			if ( process.env.SKIP_DOMAIN_TESTS === 'true' ) {
+				await SlackNotifier.warn(
+					'Domains tests are currently disabled as SKIP_DOMAIN_TESTS is set to true',
+					{ suppressDuplicateMessages: true }
+				);
+				return this.skip();
+			}
+		} );
+
+		before( async function() {
 			await driverManager.ensureNotLoggedIn( driver );
 		} );
 


### PR DESCRIPTION
Test `Sign up for free subdomain site` wasn't affected when SKIP_DOMAIN_TESTS is true. As a result, only this test was constantly [failing](https://circleci.com/gh/Automattic/wp-e2e-tests/24445#tests/containers/0) when domain registration was unavailable. 