### PR TITLE
Fix uploading images and adding alt text

### DIFF
--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -3,7 +3,6 @@ import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper';
 import * as driverManager from '../driver-manager.js';
 import AsyncBaseContainer from '../async-base-container';
-import webdriver from 'selenium-webdriver';
 
 export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	constructor( driver ) {
@@ -124,38 +123,19 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return await element.getAttribute( 'value' );
 	}
 
-	async sendFile( name, path ) {
-		const fileNameInputSelector = webdriver.By.css(
-			'.components-form-file-upload input[type="file"]'
-		);
-		const driver = this.driver;
-
+	async uploadImage( fileDetails ) {
 		await driverHelper.waitTillPresentAndDisplayed(
-			driver,
+			this.driver,
 			By.css( '.components-form-file-upload ' )
 		);
-		let filePathInput = await driver.findElement( fileNameInputSelector );
-		await filePathInput.sendKeys( path );
-
-		await this.openSidebar();
-
-		await driverHelper.clickWhenClickable(
-			driver,
-			By.css( '.components-textarea-control__input' )
+		const filePathInput = await this.driver.findElement(
+			By.css( '.components-form-file-upload input[type="file"]' )
 		);
-		let altTextInput = await driver.findElement( By.css( '.components-textarea-control__input' ) );
-		await altTextInput.click();
-		// There's a little time here where the image block seems to refresh, if the alt text is entered before the refresh it will be cleared before saving
-		await this.driver.sleep( 2000 );
-		await altTextInput.sendKeys( name );
-		return await this.closeSidebar();
-	}
-
-	async enterImage( fileDetails ) {
-		const newImageName = fileDetails.imageName;
-		const newFile = fileDetails.file;
-
-		await this.sendFile( newImageName, newFile );
+		await filePathInput.sendKeys( fileDetails.file );
+		return await driverHelper.waitTillNotPresent(
+			this.driver,
+			By.css( '.wp-block-image .components-spinner' )
+		); // Wait for upload spinner to complete
 	}
 
 	async toggleSidebar( open = true ) {

--- a/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -229,4 +229,14 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, trashSelector );
 		return await driverHelper.clickWhenClickable( this.driver, trashSelector );
 	}
+
+	async enterImageAltText( fileDetails ) {
+		const altTextInputSelector = By.css( '.components-textarea-control__input' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, altTextInputSelector );
+		return await driverHelper.setWhenSettable(
+			this.driver,
+			altTextInputSelector,
+			fileDetails.imageName
+		);
+	}
 }

--- a/specs/wp-gutenberg-page-editor-spec.js
+++ b/specs/wp-gutenberg-page-editor-spec.js
@@ -60,7 +60,11 @@ describe( `[${ host }] Gutenberg Editor: Pages (${ screenSize })`, function() {
 			await gEditorComponent.enterText( pageQuote );
 			await gEditorComponent.addBlock( 'Image' );
 
-			await gEditorComponent.enterImage( fileDetails );
+			await gEditorComponent.uploadImage( fileDetails );
+			await gEditorComponent.openSidebar();
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			await gEditorSidebarComponent.enterImageAltText( fileDetails );
+			await gEditorComponent.closeSidebar();
 
 			let errorShown = await gEditorComponent.errorDisplayed();
 			return assert.strictEqual(
@@ -104,10 +108,10 @@ describe( `[${ host }] Gutenberg Editor: Pages (${ screenSize })`, function() {
 				content.indexOf( pageQuote ) > -1,
 				true,
 				'The page preview content (' +
-				content +
-				') does not include the expected content (' +
-				pageQuote +
-				')'
+					content +
+					') does not include the expected content (' +
+					pageQuote +
+					')'
 			);
 		} );
 
@@ -211,12 +215,12 @@ describe( `[${ host }] Gutenberg Editor: Pages (${ screenSize })`, function() {
 			return await gEditorComponent.waitForSuccessViewPostNotice();
 		} );
 
-		step( 'Can view content', async function () {
+		step( 'Can view content', async function() {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.viewPublishedPostOrPage();
 		} );
 
-		step( 'Can view page title as logged in user', async function () {
+		step( 'Can view page title as logged in user', async function() {
 			const viewPagePage = await ViewPagePage.Expect( driver );
 			const actualPageTitle = await viewPagePage.pageTitle();
 			assert.strictEqual(
@@ -226,21 +230,21 @@ describe( `[${ host }] Gutenberg Editor: Pages (${ screenSize })`, function() {
 			);
 		} );
 
-		step( 'Can view page content as logged in user', async function () {
+		step( 'Can view page content as logged in user', async function() {
 			const viewPagePage = await ViewPagePage.Expect( driver );
 			const content = await viewPagePage.pageContent();
 			assert.strictEqual(
 				content.indexOf( pageQuote ) > -1,
 				true,
 				'The page content (' +
-				content +
-				') does not include the expected content (' +
-				pageQuote +
-				')'
+					content +
+					') does not include the expected content (' +
+					pageQuote +
+					')'
 			);
 		} );
 
-		step( "Can't view page title or content as non-logged in user", async function () {
+		step( "Can't view page title or content as non-logged in user", async function() {
 			await driver.manage().deleteAllCookies();
 			await driver.navigate().refresh();
 

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -68,7 +68,11 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			await gEditorComponent.enterText( blogPostQuote );
 			await gEditorComponent.addBlock( 'Image' );
 
-			await gEditorComponent.enterImage( fileDetails );
+			await gEditorComponent.uploadImage( fileDetails );
+			await gEditorComponent.openSidebar();
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			await gEditorSidebarComponent.enterImageAltText( fileDetails );
+			await gEditorComponent.closeSidebar();
 
 			let errorShown = await gEditorComponent.errorDisplayed();
 			return assert.strictEqual(


### PR DESCRIPTION
This no longer requires a sleep as it waits for the image to be uploaded first

See https://github.com/WordPress/gutenberg/issues/12202