### PR TITLE
Gutenberg: Updating selector used to publish

### DIFF
--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -262,7 +262,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		);
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.editor-post-publish-panel__header-publish-button button:not([disabled])' )
+			By.css( '.editor-post-publish-panel__header-publish-button button[aria-disabled=false]' )
 		);
 		await driverHelper.waitTillNotPresent(
 			this.driver,

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -25,7 +25,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		);
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.editor-post-publish-panel__header-publish-button button:not([disabled])' )
+			By.css( '.editor-post-publish-panel__header-publish-button button[aria-disabled=false]' )
 		);
 		await driverHelper.waitTillNotPresent(
 			this.driver,


### PR DESCRIPTION
Publish step fails locally sometimes in the Gutenberg Editor tests, changing out the selector to use the `aria-disabled` attribute resolves this locally. 

Related: https://github.com/Automattic/wp-e2e-tests/pull/1652#issuecomment-441074836