### PR TITLE
Enable more Gutenberg in Calypso Posts

### DIFF
--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -248,7 +248,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.clickWhenClickable( this.driver, By.css( '.dashicons-no-alt' ) );
 	}
 
-	static getCalypsoGutenbergEditorPageURL( { type = 'post', site = '' } ) {
+	static getCalypsoGutenbergEditorPageURL( { type = 'post', site = null } ) {
+		if ( ! site ) {
+			site = '';
+		}
 		return dataHelper.getCalypsoURL( `gutenberg/${ type }/${ site }`, [], {
 			forceWpCalypso: true,
 		} );

--- a/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -175,7 +175,7 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 	async chooseDocumentSetttings() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '[data-label="Document"]' )
+			By.css( '[aria-label^="Document settings"]' )
 		);
 	}
 

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1037,7 +1037,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	xdescribe( 'Revert a post to draft: @parallel', function() {
+	describe( 'Revert a post to draft: @parallel', function() {
 		describe( 'Publish a new post', function() {
 			const originalBlogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -277,14 +277,14 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	xdescribe( 'Check Activity Log for Public Post @parallel', function() {
+	describe( 'Check Activity Log for Public Post @parallel', function() {
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =
 			'“We are what we pretend to be, so we must be careful about what we pretend to be.”\n- Kurt Vonnegut';
 
 		step( 'Can log in', async function() {
 			let loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-			return await loginFlow.loginAndStartNewPost( null, true );
+			return await loginFlow.loginAndStartNewPost( null, true, { forceCalypsoGutenberg: true } );
 		} );
 
 		step( 'Can enter post title and content', async function() {

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -375,7 +375,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	xdescribe( 'Private Posts: @parallel', function() {
+	describe( 'Private Posts: @parallel', function() {
 		describe( 'Publish a Private Post', function() {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =
@@ -393,7 +393,9 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can log in', async function() {
 				this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await this.loginFlow.loginAndStartNewPost( null, true );
+				return await this.loginFlow.loginAndStartNewPost( null, true, {
+					forceCalypsoGutenberg: true,
+				} );
 			} );
 
 			step( 'Can enter post title and content', async function() {
@@ -406,7 +408,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can disable sharing buttons', async function() {
 				return await SlackNotifier.warn(
-					'Sharing buttons not currently available for Gutenberg in wp-admin'
+					'Sharing buttons not currently available for Gutenberg in Calypso'
 				);
 				//let postEditorSidebarComponent = await PostEditorSidebarComponent.Expect( driver );
 				//await postEditorSidebarComponent.expandSharingSection();
@@ -522,7 +524,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can log in', async function() {
 				let loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				await loginFlow.loginAndStartNewPost( null, true );
+				await loginFlow.loginAndStartNewPost( null, true, { forceCalypsoGutenberg: true } );
 			} );
 
 			step( 'Can enter post title and content and set to password protected', async function() {
@@ -782,7 +784,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can log in', async function() {
 				const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await loginFlow.loginAndStartNewPost( null, true );
+				return await loginFlow.loginAndStartNewPost( null, true, { forceCalypsoGutenberg: true } );
 			} );
 
 			step( 'Can enter post title and content', async function() {
@@ -818,7 +820,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can log in', async function() {
 				const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await loginFlow.loginAndStartNewPost( null, true );
+				return await loginFlow.loginAndStartNewPost( null, true, { forceCalypsoGutenberg: true } );
 			} );
 
 			step( 'Can enter post title and content', async function() {
@@ -912,7 +914,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can log in', async function() {
 				const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await loginFlow.loginAndStartNewPost( null, true );
+				return await loginFlow.loginAndStartNewPost( null, true, { forceCalypsoGutenberg: true } );
 			} );
 
 			step( 'Can insert the contact form', async function() {
@@ -1038,7 +1040,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can log in', async function() {
 				const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await loginFlow.loginAndStartNewPost( null, true );
+				return await loginFlow.loginAndStartNewPost( null, true, { forceCalypsoGutenberg: true } );
 			} );
 
 			step( 'Can enter post title and content', async function() {

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -816,7 +816,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	xdescribe( 'Edit a Post: @parallel', function() {
+	describe( 'Edit a Post: @parallel', function() {
 		describe( 'Publish a New Post', function() {
 			const originalBlogPostTitle = dataHelper.randomPhrase();
 			const updatedBlogPostTitle = dataHelper.randomPhrase();

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -42,7 +42,7 @@ before( async function() {
 describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
-	xdescribe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
+	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
 		let fileDetails;
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =
@@ -58,7 +58,9 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 		step( 'Can log in', async function() {
 			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-			return await this.loginFlow.loginAndStartNewPost( null, true );
+			return await this.loginFlow.loginAndStartNewPost( null, true, {
+				forceCalypsoGutenberg: true,
+			} );
 		} );
 
 		step( 'Can enter post title, content and image', async function() {
@@ -67,7 +69,11 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			await gEditorComponent.enterText( blogPostQuote );
 			await gEditorComponent.addBlock( 'Image' );
 
-			await gEditorComponent.enterImage( fileDetails );
+			await gEditorComponent.uploadImage( fileDetails );
+			await gEditorComponent.openSidebar();
+			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+			await gEditorSidebarComponent.enterImageAltText( fileDetails );
+			await gEditorComponent.closeSidebar();
 
 			let errorShown = await gEditorComponent.errorDisplayed();
 			return assert.strictEqual(

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -18,7 +18,6 @@ import NavBarComponent from '../lib/components/nav-bar-component.js';
 import GutenbergPostPreviewComponent from '../lib/gutenberg/gutenberg-post-preview-component';
 import PostEditorToolbarComponent from '../lib/components/post-editor-toolbar-component';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
-import WPAdminPostsPage from '../lib/pages/wp-admin/wp-admin-posts-page';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
 
 import * as driverManager from '../lib/driver-manager';
@@ -322,14 +321,16 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	xdescribe( 'Schedule Basic Public Post @parallel', function() {
+	describe( 'Schedule Basic Public Post @parallel', function() {
 		describe( 'Schedule (and remove) a New Post', function() {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote = '“Worries shared are worries halved.”\n- Unknown';
 
 			step( 'Can log in', async function() {
 				this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await this.loginFlow.loginAndStartNewPost( null, true );
+				return await this.loginFlow.loginAndStartNewPost( null, true, {
+					forceCalypsoGutenberg: true,
+				} );
 			} );
 
 			step( 'Can enter post title and content', async function() {
@@ -363,15 +364,18 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				await gEditorComponent.closeScheduledPanel();
 				let gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 				await gSidebarComponent.trashPost();
-
-				const wpAdminPostsPage = await WPAdminPostsPage.Expect( driver );
-				const displayed = await wpAdminPostsPage.trashedSuccessNoticeDisplayed();
-				return assert.strictEqual(
-					displayed,
-					true,
-					'The Posts page success notice for deleting the post is not displayed'
-				);
 			} );
+
+			// Not working https://github.com/Automattic/wp-calypso/issues/28813
+			// step( 'Can then see the Posts page with a confirmation message', async function() {
+			// 	const postsPage = await PostsPage.Expect( driver );
+			// 	const displayed = await postsPage.successNoticeDisplayed();
+			// 	return assert.strictEqual(
+			// 		displayed,
+			// 		true,
+			// 		'The Posts page success notice for deleting the post is not displayed'
+			// 	);
+			// } );
 		} );
 	} );
 
@@ -776,7 +780,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	xdescribe( 'Trash Post: @parallel', function() {
+	describe( 'Trash Post: @parallel', function() {
 		describe( 'Trash a New Post', function() {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =
@@ -799,15 +803,16 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				return await gSidebarComponent.trashPost();
 			} );
 
-			step( 'Can then see the Posts page with a confirmation message', async function() {
-				const wpAdminPostsPage = await WPAdminPostsPage.Expect( driver );
-				const displayed = await wpAdminPostsPage.trashedSuccessNoticeDisplayed();
-				return assert.strictEqual(
-					displayed,
-					true,
-					'The Posts page success notice for deleting the post is not displayed'
-				);
-			} );
+			// Not working https://github.com/Automattic/wp-calypso/issues/28813
+			// step( 'Can then see the Posts page with a confirmation message', async function() {
+			// 	const postsPage = await PostsPage.Expect( driver );
+			// 	const displayed = await postsPage.successNoticeDisplayed();
+			// 	return assert.strictEqual(
+			// 		displayed,
+			// 		true,
+			// 		'The Posts page success notice for deleting the post is not displayed'
+			// 	);
+			// } );
 		} );
 	} );
 

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -505,7 +505,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	xdescribe( 'Password Protected Posts: @parallel', function() {
+	describe( 'Password Protected Posts: @parallel', function() {
 		describe( 'Publish a Password Protected Post', function() {
 			let blogPostTitle = dataHelper.randomPhrase();
 			let blogPostQuote =


### PR DESCRIPTION
This enables most of the specs against the Gutenberg editor running in Calypso (not wp-admin)

The Trash Post specs aren't fully working due to this bug: https://github.com/Automattic/wp-calypso/issues/28813

I haven't created the Contact Form and Payment Button tests even though these blocks are available - this is a bigger job and should be done in a separate PR