### PR TITLE
Add test for Simple Payments button

### DIFF
--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -343,44 +343,40 @@ export function waitForInfiniteListLoad( driver, elementSelector, { numElements 
 	} );
 }
 
-export function switchToWindowByIndex( driver, index ) {
-	return driver.getAllWindowHandles().then( handles => {
-		return driver.switchTo().window( handles[ index ] );
-	} );
-}
-export function numberOfOpenWindows( driver ) {
-	return driver.getAllWindowHandles().then( handles => {
-		return handles.length;
-	} );
+export async function switchToWindowByIndex( driver, index ) {
+	let handles = await driver.getAllWindowHandles();
+	return await driver.switchTo().window( handles[ index ] );
 }
 
-export function waitForNumberOfWindows( driver, numberWindows, waitOverride ) {
+export async function numberOfOpenWindows( driver ) {
+	let handles = await driver.getAllWindowHandles();
+	return handles.length;
+}
+
+export async function waitForNumberOfWindows( driver, numberWindows, waitOverride ) {
 	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
 
-	return driver.wait(
-		function() {
-			return driver.getAllWindowHandles().then( handles => {
-				return handles.length === numberWindows;
-			} );
+	return await driver.wait(
+		async function() {
+			let handles = await driver.getAllWindowHandles();
+			return handles.length === numberWindows;
 		},
 		timeoutWait,
 		`Timed out waiting for ${ numberWindows } browser windows`
 	);
 }
 
-export function closeCurrentWindow( driver ) {
-	return driver.close();
+export async function closeCurrentWindow( driver ) {
+	return await driver.close();
 }
 
-export function ensurePopupsClosed( driver ) {
-	numberOfOpenWindows( driver ).then( numWindows => {
-		let windowIndex;
-		for ( windowIndex = 1; windowIndex < numWindows; windowIndex++ ) {
-			switchToWindowByIndex( driver, windowIndex ).then( () => {
-				closeCurrentWindow( driver );
-			} );
-		}
-	} );
+export async function ensurePopupsClosed( driver ) {
+	let numWindows = await numberOfOpenWindows( driver );
+	let windowIndex;
+	for ( windowIndex = 1; windowIndex < numWindows; windowIndex++ ) {
+		await switchToWindowByIndex( driver, windowIndex );
+		await closeCurrentWindow( driver );
+	}
 	return switchToWindowByIndex( driver, 0 );
 }
 

--- a/lib/gutenberg/blocks/payment-block-component.js
+++ b/lib/gutenberg/blocks/payment-block-component.js
@@ -1,0 +1,63 @@
+/** @format */
+import { By } from 'selenium-webdriver';
+import * as driverHelper from '../../driver-helper';
+import GutenbergBlockComponent from './gutenberg-block-component';
+
+export default class SimplePaymentsBlockComponent extends GutenbergBlockComponent {
+	constructor( driver, blockID ) {
+		super( driver, blockID );
+	}
+
+	async insertPaymentButtonDetails( {
+		title = 'Button',
+		description = 'Description',
+		price = '1.00',
+		currency = 'AUD',
+		allowQuantity = true,
+		email = 'test@wordpress.com',
+	} = {} ) {
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.wp-block-jetpack-simple-payments' )
+		);
+		await driverHelper.setWhenSettable(
+			this.driver,
+			By.css( '.simple-payments__field-title .components-text-control__input' ),
+			title
+		);
+		await driverHelper.setWhenSettable(
+			this.driver,
+			By.css( '.simple-payments__field-content .components-textarea-control__input' ),
+			description
+		);
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css(
+				`.simple-payments__field-currency .components-select-control__input option[value="${ currency }"]`
+			)
+		);
+		await driverHelper.setWhenSettable(
+			this.driver,
+			By.css( '.simple-payments__field-price .components-text-control__input' ),
+			price
+		);
+		if ( allowQuantity === true ) {
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( '.simple-payments__field-multiple .components-form-toggle__input' )
+			);
+		}
+		return await driverHelper.setWhenSettable(
+			this.driver,
+			By.css( '.simple-payments__field-email .components-text-control__input' ),
+			email
+		);
+	}
+
+	async ensurePaymentButtonDisplayedInEditor() {
+		return await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.jetpack-simple-payments-button' )
+		);
+	}
+}

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -256,7 +256,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		allowQuantity = true,
 		email = 'test@wordpress.com',
 	} = {} ) {
-		await driverHelper.isElementPresent(
+		await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,
 			By.css( '.wp-block-jetpack-simple-payments' )
 		);

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -284,7 +284,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		if ( allowQuantity === true ) {
 			await driverHelper.clickWhenClickable(
 				this.driver,
-				By.css( '.components-form-toggle__input' )
+				By.css( '.simple-payments__field-multiple .components-form-toggle__input' )
 			);
 		}
 		return await driverHelper.setWhenSettable(

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -248,6 +248,59 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.clickWhenClickable( this.driver, By.css( '.dashicons-no-alt' ) );
 	}
 
+	async insertPaymentButtonDetails( {
+		title = 'Button',
+		description = 'Description',
+		price = '1.00',
+		currency = 'AUD',
+		allowQuantity = true,
+		email = 'test@wordpress.com',
+	} = {} ) {
+		await driverHelper.isElementPresent(
+			this.driver,
+			By.css( '.wp-block-jetpack-simple-payments' )
+		);
+		await driverHelper.setWhenSettable(
+			this.driver,
+			By.css( '.simple-payments__field-title .components-text-control__input' ),
+			title
+		);
+		await driverHelper.setWhenSettable(
+			this.driver,
+			By.css( '.simple-payments__field-content .components-textarea-control__input' ),
+			description
+		);
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css(
+				`.simple-payments__field-currency .components-select-control__input option[value="${ currency }"]`
+			)
+		);
+		await driverHelper.setWhenSettable(
+			this.driver,
+			By.css( '.simple-payments__field-price .components-text-control__input' ),
+			price
+		);
+		if ( allowQuantity === true ) {
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( '.components-form-toggle__input' )
+			);
+		}
+		return await driverHelper.setWhenSettable(
+			this.driver,
+			By.css( '.simple-payments__field-email .components-text-control__input' ),
+			email
+		);
+	}
+
+	async ensurePaymentButtonDisplayedInEditor() {
+		return await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.jetpack-simple-payments-button' )
+		);
+	}
+
 	static getCalypsoGutenbergEditorPageURL( { type = 'post', site = null } ) {
 		if ( ! site ) {
 			site = '';

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -248,59 +248,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.clickWhenClickable( this.driver, By.css( '.dashicons-no-alt' ) );
 	}
 
-	async insertPaymentButtonDetails( {
-		title = 'Button',
-		description = 'Description',
-		price = '1.00',
-		currency = 'AUD',
-		allowQuantity = true,
-		email = 'test@wordpress.com',
-	} = {} ) {
-		await driverHelper.waitTillPresentAndDisplayed(
-			this.driver,
-			By.css( '.wp-block-jetpack-simple-payments' )
-		);
-		await driverHelper.setWhenSettable(
-			this.driver,
-			By.css( '.simple-payments__field-title .components-text-control__input' ),
-			title
-		);
-		await driverHelper.setWhenSettable(
-			this.driver,
-			By.css( '.simple-payments__field-content .components-textarea-control__input' ),
-			description
-		);
-		await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css(
-				`.simple-payments__field-currency .components-select-control__input option[value="${ currency }"]`
-			)
-		);
-		await driverHelper.setWhenSettable(
-			this.driver,
-			By.css( '.simple-payments__field-price .components-text-control__input' ),
-			price
-		);
-		if ( allowQuantity === true ) {
-			await driverHelper.clickWhenClickable(
-				this.driver,
-				By.css( '.simple-payments__field-multiple .components-form-toggle__input' )
-			);
-		}
-		return await driverHelper.setWhenSettable(
-			this.driver,
-			By.css( '.simple-payments__field-email .components-text-control__input' ),
-			email
-		);
-	}
-
-	async ensurePaymentButtonDisplayedInEditor() {
-		return await driverHelper.waitTillPresentAndDisplayed(
-			this.driver,
-			By.css( '.jetpack-simple-payments-button' )
-		);
-	}
-
 	static getCalypsoGutenbergEditorPageURL( { type = 'post', site = null } ) {
 		if ( ! site ) {
 			site = '';

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -17,6 +17,7 @@ import NavBarComponent from '../lib/components/nav-bar-component.js';
 import GutenbergPostPreviewComponent from '../lib/gutenberg/gutenberg-post-preview-component';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
+import SimplePaymentsBlockComponent from '../lib/gutenberg/blocks/payment-block-component';
 
 import * as driverManager from '../lib/driver-manager';
 import * as driverHelper from '../lib/driver-helper';
@@ -971,15 +972,16 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		step( 'Can insert the payment button', async function() {
 			const blogPostTitle = 'Payment Button: ' + dataHelper.randomPhrase();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			const blockId = await gEditorComponent.addBlock( 'Simple Payments button' );
 
-			await gEditorComponent.addBlock( 'Simple Payments button' );
-			await gEditorComponent.insertPaymentButtonDetails( paymentButtonDetails );
+			const gPaymentComponent = await SimplePaymentsBlockComponent.Expect( driver, blockId );
+			await gPaymentComponent.insertPaymentButtonDetails( paymentButtonDetails );
 
 			let errorShown = await gEditorComponent.errorDisplayed();
 			assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
 
 			await gEditorComponent.enterTitle( blogPostTitle );
-			return await gEditorComponent.ensurePaymentButtonDisplayedInEditor();
+			return await gPaymentComponent.ensurePaymentButtonDisplayedInEditor();
 		} );
 
 		step( 'Can publish and view content', async function() {

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -5,7 +5,6 @@ import config from 'config';
 
 import LoginFlow from '../lib/flows/login-flow.js';
 
-import EditorPage from '../lib/pages/editor-page.js';
 import ViewPostPage from '../lib/pages/view-post-page.js';
 import NotFoundPage from '../lib/pages/not-found-page.js';
 import PostsPage from '../lib/pages/posts-page.js';
@@ -16,7 +15,6 @@ import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
 import SidebarComponent from '../lib/components/sidebar-component.js';
 import NavBarComponent from '../lib/components/nav-bar-component.js';
 import GutenbergPostPreviewComponent from '../lib/gutenberg/gutenberg-post-preview-component';
-import PostEditorToolbarComponent from '../lib/components/post-editor-toolbar-component';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
 
@@ -952,7 +950,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	xdescribe( 'Insert a payment button: @parallel', function() {
+	describe( 'Insert a payment button: @parallel', function() {
 		const paymentButtonDetails = {
 			title: 'Button',
 			description: 'Description',
@@ -964,39 +962,35 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		};
 
 		step( 'Can log in', async function() {
-			if ( host === 'WPCOM' ) {
-				return await new LoginFlow( driver, 'gutenbergSimpleSiteUser' ).loginAndStartNewPost();
-			}
-			const jetpackUrl = `jetpackpro${ host.toLowerCase() }.mystagingwebsite.com`;
-			await new LoginFlow( driver, 'jetpackUserPREMIUM' ).loginAndStartNewPost( jetpackUrl );
+			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+			return await this.loginFlow.loginAndStartNewPost( null, true, {
+				forceCalypsoGutenberg: true,
+			} );
 		} );
 
 		step( 'Can insert the payment button', async function() {
 			const blogPostTitle = 'Payment Button: ' + dataHelper.randomPhrase();
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 
-			const editorPage = await EditorPage.Expect( driver );
-			await editorPage.enterTitle( blogPostTitle );
-			await editorPage.insertPaymentButton( paymentButtonDetails );
+			await gEditorComponent.addBlock( 'Simple Payments button' );
+			await gEditorComponent.insertPaymentButtonDetails( paymentButtonDetails );
 
-			let errorShown = await editorPage.errorDisplayed();
-			return assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
-		} );
+			let errorShown = await gEditorComponent.errorDisplayed();
+			assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
 
-		step( 'Can see the payment button inserted into the visual editor', async function() {
-			const editorPage = await EditorPage.Expect( driver );
-			return await editorPage.ensurePaymentButtonDisplayedInPost();
+			await gEditorComponent.enterTitle( blogPostTitle );
+			return await gEditorComponent.ensurePaymentButtonDisplayedInEditor();
 		} );
 
 		step( 'Can publish and view content', async function() {
-			const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
-			await postEditorToolbarComponent.ensureSaved();
-			await postEditorToolbarComponent.publishAndViewContent( { useConfirmStep: true } );
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			return await gEditorComponent.publish( { visit: true } );
 		} );
 
 		step( 'Can see the payment button in our published post', async function() {
 			const viewPostPage = await ViewPostPage.Expect( driver );
 			let displayed = await viewPostPage.paymentButtonDisplayed();
-			assert.strictEqual(
+			return assert.strictEqual(
 				displayed,
 				true,
 				'The published post does not contain the payment button'


### PR DESCRIPTION
Simple Payment button test. It works against `wpcalypso.wordpress.com/gutenberg/post/`. 

To test: Make sure that test `Insert a payment button: @parallel` is passing, both desktop and mobile. `UnhandledPromiseRejectionWarning` should not appear.

Part of #1620