### PR TITLE
Contact Form on wpcalypso 

### DIFF
--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -78,12 +78,21 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return await shortcodeTextarea.sendKeys( shortcode );
 	}
 
-	async insertContactForm() {
-		await this.addBlock( 'Shortcode' );
-		const shortcodeSelector = By.css( 'textarea.editor-plain-text' );
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, shortcodeSelector );
-		const shortcodeTextarea = await this.driver.findElement( shortcodeSelector );
-		return await shortcodeTextarea.sendKeys( '[contact-form][/contact-form]' );
+	async insertContactForm( email, subject ) {
+		await this.addBlock( 'Form' );
+		const emailSelector = By.css( '#inspector-text-control-0' );
+		const subjectSelector = By.css( '#inspector-text-control-1' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, emailSelector );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, subjectSelector );
+
+		const emailTextfield = await this.driver.findElement( emailSelector );
+		const subjectTextfiled = await this.driver.findElement( subjectSelector );
+		await emailTextfield.sendKeys( email );
+		await subjectTextfiled.sendKeys( subject );
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.jetpack-contact-form__create .components-button' )
+		);
 	}
 
 	async errorDisplayed() {

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -70,6 +70,14 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return await this.driver.findElement( textSelector ).sendKeys( text );
 	}
 
+	async insertShortcode( shortcode ) {
+		await this.addBlock( 'Shortcode' );
+		const shortcodeSelector = By.css( 'textarea.editor-plain-text' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, shortcodeSelector );
+		const shortcodeTextarea = await this.driver.findElement( shortcodeSelector );
+		return await shortcodeTextarea.sendKeys( shortcode );
+	}
+
 	async insertContactForm() {
 		await this.addBlock( 'Shortcode' );
 		const shortcodeSelector = By.css( 'textarea.editor-plain-text' );

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -924,7 +924,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			step( 'Can insert the contact form', async function() {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( originalBlogPostTitle );
-				await gEditorComponent.insertContactForm();
+				await gEditorComponent.insertShortcode( '[contact-form][/contact-form]' );
 
 				let errorShown = await gEditorComponent.errorDisplayed();
 				return assert.strictEqual(

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -912,9 +912,11 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe( 'Insert a contact form: @parallel', function() {
+	describe.only( 'Insert a contact form: @parallel', function() {
 		describe( 'Publish a New Post with a Contact Form', function() {
 			const originalBlogPostTitle = 'Contact Us: ' + dataHelper.randomPhrase();
+			const contactEmail = 'testing@automattic.com';
+			const subject = "Let's work together";
 
 			step( 'Can log in', async function() {
 				const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
@@ -924,7 +926,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			step( 'Can insert the contact form', async function() {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( originalBlogPostTitle );
-				await gEditorComponent.insertShortcode( '[contact-form][/contact-form]' );
+				await gEditorComponent.insertContactForm( contactEmail, subject );
 
 				let errorShown = await gEditorComponent.errorDisplayed();
 				return assert.strictEqual(

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -912,7 +912,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe.only( 'Insert a contact form: @parallel', function() {
+	describe( 'Insert a contact form: @parallel', function() {
 		describe( 'Publish a New Post with a Contact Form', function() {
 			const originalBlogPostTitle = 'Contact Us: ' + dataHelper.randomPhrase();
 			const contactEmail = 'testing@automattic.com';

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -912,7 +912,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	xdescribe( 'Insert a contact form: @parallel', function() {
+	describe( 'Insert a contact form: @parallel', function() {
 		describe( 'Publish a New Post with a Contact Form', function() {
 			const originalBlogPostTitle = 'Contact Us: ' + dataHelper.randomPhrase();
 

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -914,7 +914,7 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			step( 'Can insert the contact form', async function() {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( originalBlogPostTitle );
-				await gEditorComponent.insertContactForm();
+				await gEditorComponent.insertShortcode( '[contact-form][/contact-form]' );
 
 				let errorShown = await gEditorComponent.errorDisplayed();
 				return assert.strictEqual(


### PR DESCRIPTION
Included contact form test on wpcalypso 

Related: #1640 

Part of #1620 

This test is currently failing since the after the contact form is added via the editor it doesn't show in Preview/Publish. Once this is ready in wpcalypso the test should pass and we can merge.