### PR TITLE
Trying to get ie11 canary to pass more reliably.

### DIFF
--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -226,7 +226,8 @@ export async function setWhenSettable(
 					await element.sendKeys( value[ i ] );
 				}
 			}
-			const actualValue = await element.getAttribute( 'value' );
+			const newElement = await driver.findElement( selector );
+			const actualValue = await newElement.getAttribute( 'value' );
 			return actualValue === value;
 		},
 		explicitWaitMS,


### PR DESCRIPTION
This change seems to get the tests to run without the stale element error in IE. 