### PR TITLE
Move Image, Shortcode and Contact form code into their own blocks

### DIFF
--- a/lib/gutenberg/blocks/contact-form-block-component.js
+++ b/lib/gutenberg/blocks/contact-form-block-component.js
@@ -1,0 +1,33 @@
+/** @format */
+import { By } from 'selenium-webdriver';
+import * as driverHelper from '../../driver-helper';
+import GutenbergBlockComponent from './gutenberg-block-component';
+
+export class ContactFormBlockComponent extends GutenbergBlockComponent {
+	constructor( driver, blockID ) {
+		super( driver, blockID );
+	}
+
+	async insertEmail( email ) {
+		const emailSelector = By.css( '#inspector-text-control-0' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, emailSelector );
+
+		const emailTextfield = await this.driver.findElement( emailSelector );
+		return await emailTextfield.sendKeys( email );
+	}
+
+	async insertSubject( subject ) {
+		const subjectSelector = By.css( '#inspector-text-control-1' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, subjectSelector );
+
+		const subjectTextfiled = await this.driver.findElement( subjectSelector );
+		return await subjectTextfiled.sendKeys( subject );
+	}
+
+	async submitForm() {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.jetpack-contact-form__create .components-button' )
+		);
+	}
+}

--- a/lib/gutenberg/blocks/image-block-component.js
+++ b/lib/gutenberg/blocks/image-block-component.js
@@ -1,0 +1,25 @@
+/** @format */
+import { By } from 'selenium-webdriver';
+import * as driverHelper from '../../driver-helper';
+import GutenbergBlockComponent from './gutenberg-block-component';
+
+export class ImageBlockComponent extends GutenbergBlockComponent {
+	constructor( driver, blockID ) {
+		super( driver, blockID );
+	}
+
+	async uploadImage( fileDetails ) {
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.components-form-file-upload ' )
+		);
+		const filePathInput = await this.driver.findElement(
+			By.css( '.components-form-file-upload input[type="file"]' )
+		);
+		await filePathInput.sendKeys( fileDetails.file );
+		return await driverHelper.waitTillNotPresent(
+			this.driver,
+			By.css( '.wp-block-image .components-spinner' )
+		); // Wait for upload spinner to complete
+	}
+}

--- a/lib/gutenberg/blocks/shortcode-block-component.js
+++ b/lib/gutenberg/blocks/shortcode-block-component.js
@@ -1,0 +1,17 @@
+/** @format */
+import { By } from 'selenium-webdriver';
+import * as driverHelper from '../../driver-helper';
+import GutenbergBlockComponent from './gutenberg-block-component';
+
+export class ShortcodeBlockComponent extends GutenbergBlockComponent {
+	constructor( driver, blockID ) {
+		super( driver, blockID );
+	}
+
+	async enterShortcode( shortcode ) {
+		const shortcodeSelector = By.css( 'textarea.editor-plain-text' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, shortcodeSelector );
+		const shortcodeTextarea = await this.driver.findElement( shortcodeSelector );
+		return await shortcodeTextarea.sendKeys( shortcode );
+	}
+}

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -78,12 +78,21 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return await shortcodeTextarea.sendKeys( shortcode );
 	}
 
-	async insertContactForm() {
-		await this.addBlock( 'Shortcode' );
-		const shortcodeSelector = By.css( 'textarea.editor-plain-text' );
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, shortcodeSelector );
-		const shortcodeTextarea = await this.driver.findElement( shortcodeSelector );
-		return await shortcodeTextarea.sendKeys( '[contact-form][/contact-form]' );
+	async insertContactForm( email, subject ) {
+		await this.addBlock( 'Form' );
+		const emailSelector = By.css( '#inspector-text-control-0' );
+		const subjectSelector = By.css( '#inspector-text-control-1' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, emailSelector );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, subjectSelector );
+
+		const emailTextfield = await this.driver.findElement( emailSelector );
+		const subjectTextfiled = await this.driver.findElement( subjectSelector );
+		await emailTextfield.sendKeys( email );
+		await subjectTextfiled.sendKeys( subject );
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.jetpack-contact-form__create .components-button' )
+		);
 	}
 
 	async errorDisplayed() {

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -6,6 +6,7 @@ import * as dataHelper from '../data-helper';
 import AsyncBaseContainer from '../async-base-container';
 import { ContactFormBlockComponent } from './blocks/contact-form-block-component';
 import { ShortcodeBlockComponent } from './blocks/shortcode-block-component';
+import { ImageBlockComponent } from './blocks/image-block-component';
 
 export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	constructor( driver, url ) {
@@ -76,14 +77,13 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		const blockID = await this.addBlock( 'Shortcode' );
 
 		const shortcodeBlock = await ShortcodeBlockComponent.Expect( this.driver, blockID );
-
 		return await shortcodeBlock.enterShortcode( shortcode );
 	}
 
 	async insertContactForm( email, subject ) {
 		const blockID = await this.addBlock( 'Form' );
-		const contactFormBlock = await ContactFormBlockComponent.Expect( this.driver, blockID );
 
+		const contactFormBlock = await ContactFormBlockComponent.Expect( this.driver, blockID );
 		await contactFormBlock.insertEmail( email );
 		await contactFormBlock.insertSubject( subject );
 		return await contactFormBlock.submitForm();
@@ -131,19 +131,11 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return await element.getAttribute( 'value' );
 	}
 
-	async uploadImage( fileDetails ) {
-		await driverHelper.waitTillPresentAndDisplayed(
-			this.driver,
-			By.css( '.components-form-file-upload ' )
-		);
-		const filePathInput = await this.driver.findElement(
-			By.css( '.components-form-file-upload input[type="file"]' )
-		);
-		await filePathInput.sendKeys( fileDetails.file );
-		return await driverHelper.waitTillNotPresent(
-			this.driver,
-			By.css( '.wp-block-image .components-spinner' )
-		); // Wait for upload spinner to complete
+	async addImage( fileDetails ) {
+		const blockID = await this.addBlock( 'Image' );
+
+		const imageBlock = await ImageBlockComponent.Expect( this.driver, blockID );
+		return await imageBlock.uploadImage( fileDetails );
 	}
 
 	async toggleSidebar( open = true ) {

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -4,6 +4,8 @@ import * as driverHelper from '../driver-helper';
 import * as driverManager from '../driver-manager.js';
 import * as dataHelper from '../data-helper';
 import AsyncBaseContainer from '../async-base-container';
+import { ContactFormBlockComponent } from './blocks/contact-form-block-component';
+import { ShortcodeBlockComponent } from './blocks/shortcode-block-component';
 
 export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	constructor( driver, url ) {
@@ -71,28 +73,20 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async insertShortcode( shortcode ) {
-		await this.addBlock( 'Shortcode' );
-		const shortcodeSelector = By.css( 'textarea.editor-plain-text' );
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, shortcodeSelector );
-		const shortcodeTextarea = await this.driver.findElement( shortcodeSelector );
-		return await shortcodeTextarea.sendKeys( shortcode );
+		const blockID = await this.addBlock( 'Shortcode' );
+
+		const shortcodeBlock = await ShortcodeBlockComponent.Expect( this.driver, blockID );
+
+		return await shortcodeBlock.enterShortcode( shortcode );
 	}
 
 	async insertContactForm( email, subject ) {
-		await this.addBlock( 'Form' );
-		const emailSelector = By.css( '#inspector-text-control-0' );
-		const subjectSelector = By.css( '#inspector-text-control-1' );
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, emailSelector );
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, subjectSelector );
+		const blockID = await this.addBlock( 'Form' );
+		const contactFormBlock = await ContactFormBlockComponent.Expect( this.driver, blockID );
 
-		const emailTextfield = await this.driver.findElement( emailSelector );
-		const subjectTextfiled = await this.driver.findElement( subjectSelector );
-		await emailTextfield.sendKeys( email );
-		await subjectTextfiled.sendKeys( subject );
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.jetpack-contact-form__create .components-button' )
-		);
+		await contactFormBlock.insertEmail( email );
+		await contactFormBlock.insertSubject( subject );
+		return await contactFormBlock.submitForm();
 	}
 
 	async errorDisplayed() {

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -70,6 +70,14 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return await this.driver.findElement( textSelector ).sendKeys( text );
 	}
 
+	async insertShortcode( shortcode ) {
+		await this.addBlock( 'Shortcode' );
+		const shortcodeSelector = By.css( 'textarea.editor-plain-text' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, shortcodeSelector );
+		const shortcodeTextarea = await this.driver.findElement( shortcodeSelector );
+		return await shortcodeTextarea.sendKeys( shortcode );
+	}
+
 	async insertContactForm() {
 		await this.addBlock( 'Shortcode' );
 		const shortcodeSelector = By.css( 'textarea.editor-plain-text' );

--- a/specs-blocks/gutenberg-markdown-block-spec.js
+++ b/specs-blocks/gutenberg-markdown-block-spec.js
@@ -71,8 +71,8 @@ if ( screenSize !== 'mobile' ) {
 			} );
 
 			step( 'Can insert a markdown block', async function() {
-				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
-				this.markdownBlockID = await gHeaderComponent.addBlock( 'Markdown' );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				this.markdownBlockID = await gEditorComponent.addBlock( 'Markdown' );
 			} );
 
 			step( 'Can fill markdown block with content', async function() {
@@ -90,8 +90,8 @@ if ( screenSize !== 'mobile' ) {
 			} );
 
 			step( 'Can publish the post and see its content', async function() {
-				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
-				await gHeaderComponent.publish( { visit: true } );
+				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				await gEditorComponent.publish( { visit: true } );
 				const postFrontend = await PostAreaComponent.Expect( driver );
 				const html = await postFrontend.getPostHTML();
 				assert( html.includes( expectedHTML ) );

--- a/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -59,9 +59,8 @@ describe( `[${ host }] Editor: Pages (${ screenSize })`, function() {
 			await gEditorComponent.removeNUXNotice();
 			await gEditorComponent.enterTitle( pageTitle );
 			await gEditorComponent.enterText( pageQuote );
-			await gEditorComponent.addBlock( 'Image' );
+			await gEditorComponent.addImage( fileDetails );
 
-			await gEditorComponent.uploadImage( fileDetails );
 			await gEditorComponent.openSidebar();
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.enterImageAltText( fileDetails );

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -912,7 +912,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe( 'Insert a contact form: @parallel', function() {
+	describe.only( 'Insert a contact form: @parallel', function() {
 		describe( 'Publish a New Post with a Contact Form', function() {
 			const originalBlogPostTitle = 'Contact Us: ' + dataHelper.randomPhrase();
 			const contactEmail = 'testing@automattic.com';

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -911,7 +911,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe( 'Insert a contact form: @parallel', function() {
+	xdescribe( 'Insert a contact form: @parallel', function() {
 		describe( 'Publish a New Post with a Contact Form', function() {
 			const originalBlogPostTitle = 'Contact Us: ' + dataHelper.randomPhrase();
 			const contactEmail = 'testing@automattic.com';

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -924,7 +924,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			step( 'Can insert the contact form', async function() {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( originalBlogPostTitle );
-				await gEditorComponent.insertContactForm();
+				await gEditorComponent.insertShortcode( '[contact-form][/contact-form]' );
 
 				let errorShown = await gEditorComponent.errorDisplayed();
 				return assert.strictEqual(

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -65,9 +65,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.enterTitle( blogPostTitle );
 			await gEditorComponent.enterText( blogPostQuote );
-			await gEditorComponent.addBlock( 'Image' );
+			await gEditorComponent.addImage( fileDetails );
 
-			await gEditorComponent.uploadImage( fileDetails );
 			await gEditorComponent.openSidebar();
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.enterImageAltText( fileDetails );
@@ -912,7 +911,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe.only( 'Insert a contact form: @parallel', function() {
+	describe( 'Insert a contact form: @parallel', function() {
 		describe( 'Publish a New Post with a Contact Form', function() {
 			const originalBlogPostTitle = 'Contact Us: ' + dataHelper.randomPhrase();
 			const contactEmail = 'testing@automattic.com';

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -912,9 +912,11 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe( 'Insert a contact form: @parallel', function() {
+	describe.only( 'Insert a contact form: @parallel', function() {
 		describe( 'Publish a New Post with a Contact Form', function() {
 			const originalBlogPostTitle = 'Contact Us: ' + dataHelper.randomPhrase();
+			const contactEmail = 'testing@automattic.com';
+			const subject = "Let's work together";
 
 			step( 'Can log in', async function() {
 				const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
@@ -924,7 +926,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			step( 'Can insert the contact form', async function() {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( originalBlogPostTitle );
-				await gEditorComponent.insertShortcode( '[contact-form][/contact-form]' );
+				await gEditorComponent.insertContactForm( contactEmail, subject );
 
 				let errorShown = await gEditorComponent.errorDisplayed();
 				return assert.strictEqual(

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -912,7 +912,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe.only( 'Insert a contact form: @parallel', function() {
+	describe( 'Insert a contact form: @parallel', function() {
 		describe( 'Publish a New Post with a Contact Form', function() {
 			const originalBlogPostTitle = 'Contact Us: ' + dataHelper.randomPhrase();
 			const contactEmail = 'testing@automattic.com';

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -912,7 +912,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	xdescribe( 'Insert a contact form: @parallel', function() {
+	describe( 'Insert a contact form: @parallel', function() {
 		describe( 'Publish a New Post with a Contact Form', function() {
 			const originalBlogPostTitle = 'Contact Us: ' + dataHelper.randomPhrase();
 

--- a/specs/wp-gutenberg-page-editor-spec.js
+++ b/specs/wp-gutenberg-page-editor-spec.js
@@ -58,9 +58,8 @@ describe( `[${ host }] Gutenberg Editor: Pages (${ screenSize })`, function() {
 			await gEditorComponent.removeNUXNotice();
 			await gEditorComponent.enterTitle( pageTitle );
 			await gEditorComponent.enterText( pageQuote );
-			await gEditorComponent.addBlock( 'Image' );
+			await gEditorComponent.addImage( fileDetails );
 
-			await gEditorComponent.uploadImage( fileDetails );
 			await gEditorComponent.openSidebar();
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.enterImageAltText( fileDetails );

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -65,9 +65,8 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.enterTitle( blogPostTitle );
 			await gEditorComponent.enterText( blogPostQuote );
-			await gEditorComponent.addBlock( 'Image' );
+			await gEditorComponent.addImage( fileDetails );
 
-			await gEditorComponent.uploadImage( fileDetails );
 			await gEditorComponent.openSidebar();
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.enterImageAltText( fileDetails );

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -914,7 +914,7 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 			step( 'Can insert the contact form', async function() {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( originalBlogPostTitle );
-				await gEditorComponent.insertContactForm();
+				await gEditorComponent.insertShortcode( '[contact-form][/contact-form]' );
 
 				let errorShown = await gEditorComponent.errorDisplayed();
 				return assert.strictEqual(


### PR DESCRIPTION
See conversation at https://github.com/Automattic/wp-e2e-tests/pull/1664

* Moved some of the work out of the EditorComponent into their own blocks for easier reuse. 
* Contact Form test disabled until ready 