### PR TITLE
Secure-payment-component: css class is being updated

### DIFF
--- a/lib/components/secure-payment-component.js
+++ b/lib/components/secure-payment-component.js
@@ -8,7 +8,7 @@ import { currentScreenSize } from '../driver-manager';
 
 export default class SecurePaymentComponent extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.secure-payment-form' ) );
+		super( driver, By.css( '.checkout__secure-payment-form' ) );
 		this.paymentButtonSelector = By.css(
 			'.credit-card-payment-box button.is-primary:not([disabled])'
 		);


### PR DESCRIPTION
This is to match the change from https://github.com/Automattic/wp-calypso/pull/28884
Not sure what's the proper order to commit this or the other one.
Also, do we need to update 