### PR TITLE
Fix: Wait for tag to load

### DIFF
--- a/lib/pages/view-post-page.js
+++ b/lib/pages/view-post-page.js
@@ -34,7 +34,6 @@ export default class ViewPostPage extends AsyncBaseContainer {
 	}
 
 	async tagDisplayed() {
-		// await this.driver.wait( until.elementLocated( By.css( 'a[rel=tag]' ) ), this.explicitWaitMS, 'Could not locate tag' );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( 'a[rel=tag]' ) );
 		return await this.driver.findElement( By.css( 'a[rel=tag]' ) ).getText();
 	}

--- a/lib/pages/view-post-page.js
+++ b/lib/pages/view-post-page.js
@@ -34,6 +34,8 @@ export default class ViewPostPage extends AsyncBaseContainer {
 	}
 
 	async tagDisplayed() {
+		// await this.driver.wait( until.elementLocated( By.css( 'a[rel=tag]' ) ), this.explicitWaitMS, 'Could not locate tag' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( 'a[rel=tag]' ) );
 		return await this.driver.findElement( By.css( 'a[rel=tag]' ) ).getText();
 	}
 

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -40,7 +40,7 @@ before( async function() {
 describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
-	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
+	describe.only( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
 		let fileDetails;
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -40,7 +40,7 @@ before( async function() {
 describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
-	describe.only( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
+	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
 		let fileDetails;
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =


### PR DESCRIPTION
Today tests were failing on master branch with this [error](https://circleci.com/gh/Automattic/wp-e2e-tests/24680#tests/containers/1). This fix ensures that locator for tag is displayed before `getText()`