### PR TITLE
Disable Gutenberg Editor: Public Posts

### DIFF
--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -42,7 +42,7 @@ before( async function() {
 describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
-	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
+	xdescribe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
 		let fileDetails;
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =


### PR DESCRIPTION
Temporary disable `Gutenberg Editor: Public Posts`