### PR TITLE
Run tests against calypso.live if match exists in wp-calypso

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ See the information on [how to run tests](docs/running-tests.md) where you'll fi
 
 ## Other information
 
-See the [other information](docs/miscellaneous.md) documentation for other details that may be of interest.
+See the [other information](docs/miscellaneous.md) documentation for other details that may be of interessdfgsdfgt.

--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ See the information on [how to run tests](docs/running-tests.md) where you'll fi
 
 ## Other information
 
-See the [other information](docs/miscellaneous.md) documentation for other details that may be of interessdfgsdfgt.
+See the [other information](docs/miscellaneous.md) documentation for other details that may be of interest.

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -45,7 +45,6 @@ if [ "$MATCH_SHA" != null ]; then
     TESTARGS+=" -S $MATCH_SHA"
     echo "Found matching branch in wp-calypso. Running against calypso.live"
 fi
-echo $TESTARGS
 
 # If on CI and the -x flag is not yet set, set it
 #if [ "$CI" == "true" ] && [[ "$TESTARGS" != *"-x"* ]]; then

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -38,12 +38,14 @@ elif [ "$CIRCLE_BRANCH" == "master" ]; then
 fi
 
 #Check if matching branch exists in wp-calypso
-sudo apt-get install jq > /dev/null &&
-MATCH_SHA=$(curl -s -X GET https://api.github.com/repos/Automattic/wp-calypso/branches/${CIRCLE_BRANCH} | jq -r '.commit.sha')
+if [ "$CIRCLE_BRANCH" != "master" ]; then
+    sudo apt-get install jq > /dev/null &&
+    MATCH_SHA=$(curl -s -X GET https://api.github.com/repos/Automattic/wp-calypso/branches/${CIRCLE_BRANCH} | jq -r '.commit.sha')
 
-if [ "$MATCH_SHA" != null ]; then
-    TESTARGS+=" -S $MATCH_SHA"
-    echo "Found matching branch in wp-calypso. Running against calypso.live"
+    if [ "$MATCH_SHA" != null ]; then
+        TESTARGS+=" -S $MATCH_SHA"
+        echo "Found matching branch in wp-calypso. Running against calypso.live"
+    fi
 fi
 
 # If on CI and the -x flag is not yet set, set it

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -19,33 +19,31 @@ fi
 #disable selenium promise manager
 export SELENIUM_PROMISE_MANAGER=0
 export TEST_VIDEO="true"
+export TESTARGS=""
 
 #Check if matching branch exists in wp-calypso
-sudo apt-get install jq
-MATCH_SHA=$(curl -s -X GET https://api.github.com/repos/Automattic/wp-calypso/branches/${CIRCLE_BRANCH} | jq '.commit.sha')
+sudo apt-get install jq > /dev/null &&
+MATCH_SHA=$(curl -s -X GET https://api.github.com/repos/Automattic/wp-calypso/branches/${CIRCLE_BRANCH} | jq -r '.commit.sha')
 
 if [ "$MATCH_SHA" != null ]; then
-    export LIVEBRANCHES="true"
-    NODE_CONFIG_ARGS+=("\"liveBranch\":\"true\",\"calypsoBaseURL\":\"https://hash-$MATCH_SHA.calypso.live\",\"branchName\":\"$CIRCLE_BRANCH\"")
-    echo "Running tests against https://hash-$MATCH_SHA.calypso.live"
+    TESTARGS="-S $MATCH_SHA "
+    echo "Found matching branch in wp-calypso. Running against calypso.live"
 fi
 
-export TESTARGS="-R -p"
-
 if [ "$RUN_SPECIFIED" == "true" ]; then
-  TESTARGS=$RUN_ARGS
+  TESTARGS+=$RUN_ARGS
 elif [[ "$CIRCLE_BRANCH" =~ .*[Jj]etpack.*|.*[Jj][Pp].* ]]; then
   export JETPACKHOST=PRESSABLE
   export TARGET=JETPACK
-  TESTARGS="-R -j" # Execute Jetpack tests
+  TESTARGS+="-R -j" # Execute Jetpack tests
 elif [[ "$CIRCLE_BRANCH" =~ .*[Ww][Oo][Oo].* ]]; then
   export TARGET=WOO
-  TESTARGS="-R -W" # Execute WooCommerce tests
+  TESTARGS+="-R -W" # Execute WooCommerce tests
 elif [[ "$CIRCLE_BRANCH" =~ .*[Ii][Ee][1][1].* ]]; then
   export TARGET=IE11
-  TESTARGS="-R -w" # Execute IE11 tests
+  TESTARGS+="-R -w" # Execute IE11 tests
 elif [ "$CIRCLE_BRANCH" == "master" ]; then
-  TESTARGS="-R -p" # Parallel execution, implies -g -s mobile,desktop
+  TESTARGS+="-R -p" # Parallel execution, implies -g -s mobile,desktop
 fi
 
 # If on CI and the -x flag is not yet set, set it

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -19,33 +19,32 @@ fi
 #disable selenium promise manager
 export SELENIUM_PROMISE_MANAGER=0
 export TEST_VIDEO="true"
-export TESTARGS=""
+export TESTARGS="-R -p"
+
+if [ "$RUN_SPECIFIED" == "true" ]; then
+  TESTARGS=$RUN_ARGS
+elif [[ "$CIRCLE_BRANCH" =~ .*[Jj]etpack.*|.*[Jj][Pp].* ]]; then
+  export JETPACKHOST=PRESSABLE
+  export TARGET=JETPACK
+  TESTARGS="-R -j" # Execute Jetpack tests
+elif [[ "$CIRCLE_BRANCH" =~ .*[Ww][Oo][Oo].* ]]; then
+  export TARGET=WOO
+  TESTARGS="-R -W" # Execute WooCommerce tests
+elif [[ "$CIRCLE_BRANCH" =~ .*[Ii][Ee][1][1].* ]]; then
+  export TARGET=IE11
+  TESTARGS="-R -w" # Execute IE11 tests
+elif [ "$CIRCLE_BRANCH" == "master" ]; then
+  TESTARGS="-R -p" # Parallel execution, implies -g -s mobile,desktop
+fi
 
 #Check if matching branch exists in wp-calypso
 sudo apt-get install jq > /dev/null &&
 MATCH_SHA=$(curl -s -X GET https://api.github.com/repos/Automattic/wp-calypso/branches/${CIRCLE_BRANCH} | jq -r '.commit.sha')
 
 if [ "$MATCH_SHA" != null ]; then
-    TESTARGS="-S $MATCH_SHA "
+    TESTARGS+=" -S $MATCH_SHA"
     echo "Found matching branch in wp-calypso. Running against calypso.live"
 fi
-
-if [ "$RUN_SPECIFIED" == "true" ]; then
-  TESTARGS+=$RUN_ARGS
-elif [[ "$CIRCLE_BRANCH" =~ .*[Jj]etpack.*|.*[Jj][Pp].* ]]; then
-  export JETPACKHOST=PRESSABLE
-  export TARGET=JETPACK
-  TESTARGS+="-R -j" # Execute Jetpack tests
-elif [[ "$CIRCLE_BRANCH" =~ .*[Ww][Oo][Oo].* ]]; then
-  export TARGET=WOO
-  TESTARGS+="-R -W" # Execute WooCommerce tests
-elif [[ "$CIRCLE_BRANCH" =~ .*[Ii][Ee][1][1].* ]]; then
-  export TARGET=IE11
-  TESTARGS+="-R -w" # Execute IE11 tests
-elif [ "$CIRCLE_BRANCH" == "master" ]; then
-  TESTARGS+="-R -p" # Parallel execution, implies -g -s mobile,desktop
-fi
-
 echo $TESTARGS
 
 # If on CI and the -x flag is not yet set, set it

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -27,6 +27,7 @@ MATCH_SHA=$(curl -s -X GET https://api.github.com/repos/Automattic/wp-calypso/br
 if [ "$MATCH_SHA" != null ]; then
     export LIVEBRANCHES="true"
     NODE_CONFIG_ARGS+=("\"liveBranch\":\"true\",\"calypsoBaseURL\":\"https://hash-$MATCH_SHA.calypso.live\",\"branchName\":\"$CIRCLE_BRANCH\"")
+    echo "Running tests against https://hash-$MATCH_SHA.calypso.live"
 fi
 
 export TESTARGS="-R -p"

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -20,6 +20,15 @@ fi
 export SELENIUM_PROMISE_MANAGER=0
 export TEST_VIDEO="true"
 
+#Check if matching branch exists in wp-calypso
+sudo apt-get install jq
+MATCH_SHA=$(curl -s -X GET https://api.github.com/repos/Automattic/wp-calypso/branches/${CIRCLE_BRANCH} | jq '.commit.sha')
+
+if [ "$MATCH_SHA" != null ]; then
+    export LIVEBRANCHES="true"
+    NODE_CONFIG_ARGS+=("\"liveBranch\":\"true\",\"calypsoBaseURL\":\"https://hash-$MATCH_SHA.calypso.live\",\"branchName\":\"$CIRCLE_BRANCH\"")
+fi
+
 export TESTARGS="-R -p"
 
 if [ "$RUN_SPECIFIED" == "true" ]; then

--- a/scripts/run-wrapper.sh
+++ b/scripts/run-wrapper.sh
@@ -46,6 +46,8 @@ elif [ "$CIRCLE_BRANCH" == "master" ]; then
   TESTARGS+="-R -p" # Parallel execution, implies -g -s mobile,desktop
 fi
 
+echo $TESTARGS
+
 # If on CI and the -x flag is not yet set, set it
 #if [ "$CI" == "true" ] && [[ "$TESTARGS" != *"-x"* ]]; then
 #  TESTARGS+=" -x"


### PR DESCRIPTION
This PR does a check to see if the branch running has a branch with the same name in wp-calypso. If so, it takes the sha and runs it against that hash on calypso.live. This check is not done if running on master.

part of #1549 