### PR TITLE
Wait for radio button to show

### DIFF
--- a/lib/pages/signup/checkout-page.js
+++ b/lib/pages/signup/checkout-page.js
@@ -53,6 +53,7 @@ export default class CheckOutPage extends AsyncBaseContainer {
 	async selectAddPrivacyProtectionCheckbox() {
 		// The radio button _should_ be selected by default, but let's click it anyway :)
 		const selector = By.css( 'input#registrantType[value="private"]' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
 		return await driverHelper.setCheckbox( this.driver, selector );
 	}
 


### PR DESCRIPTION
Tests were [failing](https://circleci.com/gh/Automattic/wp-e2e-tests/24805) today at this [line](https://github.com/Automattic/wp-e2e-tests/blob/master/specs/wp-signup-spec.js#L849) due to slower loading of Checkout page.
This fix ensures that test is waiting for the radio button and in case of failing we will see better error message. 