### PR TITLE
Remove product number assertion

### DIFF
--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -782,7 +782,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe( 'Trash Post: @parallel', function() {
+	xdescribe( 'Trash Post: @parallel', function() {
 		describe( 'Trash a New Post', function() {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -372,13 +372,13 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 				let gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 				await gSidebarComponent.trashPost();
 
-				const wpAdminPostsPage = await WPAdminPostsPage.Expect( driver );
-				const displayed = await wpAdminPostsPage.trashedSuccessNoticeDisplayed();
-				return assert.strictEqual(
-					displayed,
-					true,
-					'The Posts page success notice for deleting the post is not displayed'
-				);
+				// const wpAdminPostsPage = await WPAdminPostsPage.Expect( driver );
+				// const displayed = await wpAdminPostsPage.trashedSuccessNoticeDisplayed();
+				// return assert.strictEqual(
+				// 	displayed,
+				// 	true,
+				// 	'The Posts page success notice for deleting the post is not displayed'
+				// );
 			} );
 		} );
 	} );
@@ -772,7 +772,7 @@ describe( `[${ host }] Gutenberg Editor: Posts (${ screenSize })`, function() {
 		} );
 	} );
 
-	describe( 'Trash Post: @parallel', function() {
+	xdescribe( 'Trash Post: @parallel', function() {
 		describe( 'Trash a New Post', function() {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1082,12 +1082,13 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 					true,
 					"The cart doesn't contain the business plan product"
 				);
-				const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
-				return assert.strictEqual(
-					numberOfProductsInCart,
-					3,
-					"The cart doesn't contain the expected number of products"
-				);
+				// Removing product number assertion due to https://github.com/Automattic/wp-calypso/issues/24579
+				// const numberOfProductsInCart = await securePaymentComponent.numberOfProductsInCart();
+				// return assert.strictEqual(
+				// 	numberOfProductsInCart,
+				// 	3,
+				// 	"The cart doesn't contain the expected number of products"
+				// );
 			}
 		);
 


### PR DESCRIPTION
Due to this bug: https://github.com/Automattic/wp-calypso/issues/24579

Also temporarily disable the trashing specs for Gutenberg