### PR TITLE
Remove visiting gutenberg page in wp-calypso

### DIFF
--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -252,13 +252,9 @@ export function getTestDomainRegistarDetails( emailAddress ) {
 	};
 }
 
-export function getCalypsoURL( route = '', queryStrings = [], { forceWpCalypso = false } = {} ) {
+export function getCalypsoURL( route = '', queryStrings = [] ) {
 	let queryString = '';
-	let baseURL = this.configGet( 'calypsoBaseURL' );
-	if ( forceWpCalypso && baseURL === 'https://wordpress.com' ) {
-		baseURL = 'https://wpcalypso.wordpress.com';
-	}
-	let url = baseURL + '/' + route;
+	let url = this.configGet( 'calypsoBaseURL' ) + '/' + route;
 
 	for ( let qs of queryStrings ) {
 		queryString = this._appendQueryString( queryString, qs );

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -12,12 +12,13 @@ import NavBarComponent from '../components/nav-bar-component.js';
 
 import * as dataHelper from '../data-helper';
 import * as driverManager from '../driver-manager';
-import GutenbergEditorComponent from '../gutenberg/gutenberg-editor-component';
 const host = dataHelper.getJetpackHost();
 
 export default class LoginFlow {
 	constructor( driver, accountOrFeatures ) {
 		this.driver = driver;
+		this.PROD_URL = 'https://wordpress.com';
+		this.WPCALYPSO_URL = 'https://wpcalypso.wordpress.com';
 		if ( host !== 'WPCOM' && ! accountOrFeatures ) {
 			accountOrFeatures = 'jetpackUser' + host;
 		}
@@ -100,10 +101,11 @@ export default class LoginFlow {
 		await NavBarComponent.Expect( this.driver );
 
 		if ( forceCalypsoGutenberg ) {
-			return await GutenbergEditorComponent.Visit(
-				this.driver,
-				GutenbergEditorComponent.getCalypsoGutenbergEditorPageURL( { type: 'post', site: siteURL } )
-			);
+			let url = await this.driver.getCurrentUrl();
+			if ( url.indexOf( this.PROD_URL ) === 0 ) {
+				url = url.replace( this.PROD_URL, this.WPCALYPSO_URL );
+				await this.driver.get( url );
+			}
 		}
 		const navbarComponent = await NavBarComponent.Expect( this.driver );
 		await navbarComponent.clickCreateNewPost( { siteURL: siteURL } );
@@ -124,10 +126,11 @@ export default class LoginFlow {
 		await this.loginAndSelectMySite( site );
 
 		if ( forceCalypsoGutenberg ) {
-			return await GutenbergEditorComponent.Visit(
-				this.driver,
-				GutenbergEditorComponent.getCalypsoGutenbergEditorPageURL( { type: 'page', site: site } )
-			);
+			let url = await this.driver.getCurrentUrl();
+			if ( url.indexOf( this.PROD_URL ) === 0 ) {
+				url = url.replace( this.PROD_URL, this.WPCALYPSO_URL );
+				await this.driver.get( url );
+			}
 		}
 
 		const sidebarComponent = await SidebarComponent.Expect( this.driver );

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -2,7 +2,6 @@
 import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper';
 import * as driverManager from '../driver-manager.js';
-import * as dataHelper from '../data-helper';
 import AsyncBaseContainer from '../async-base-container';
 import { ContactFormBlockComponent } from './blocks/contact-form-block-component';
 import { ShortcodeBlockComponent } from './blocks/shortcode-block-component';
@@ -250,14 +249,5 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async closeScheduledPanel() {
 		await driverHelper.clickWhenClickable( this.driver, By.css( '.dashicons-no-alt' ) );
-	}
-
-	static getCalypsoGutenbergEditorPageURL( { type = 'post', site = null } ) {
-		if ( ! site ) {
-			site = '';
-		}
-		return dataHelper.getCalypsoURL( `block-editor/${ type }/${ site }`, [], {
-			forceWpCalypso: true,
-		} );
 	}
 }


### PR DESCRIPTION
Since this is enabled in wpcalypso now this switches the URL and then uses regular nav