### PR TITLE
Clean up sidebar menu item selection

### DIFF
--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -1,6 +1,6 @@
 /** @format */
 
-import { By, until } from 'selenium-webdriver';
+import { By } from 'selenium-webdriver';
 
 import AsyncBaseContainer from '../async-base-container';
 import DisconnectSurveyPage from '../pages/disconnect-survey-page.js';
@@ -10,53 +10,117 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.sidebar' ) );
 		this.storeSelector = By.css( '.menu-link-text[data-e2e-sidebar="Store"]' );
-		this.settingsSelector = By.css( '.menu-link-text[data-e2e-sidebar="Settings"]' );
-		this.importSelector = By.css( '.menu-link-text[data-e2e-sidebar="Import"]' );
 	}
 
 	async selectDomains() {
-		const selector = By.css( '.menu-link-text[data-e2e-sidebar="Domains"]' );
-		return await driverHelper.clickWhenClickable( this.driver, selector );
+		return await this._scrollToAndClickMenuItem( 'domains' );
 	}
 
 	async selectPeople() {
-		const selector = By.css( '.menu-link-text[data-e2e-sidebar="People"]' );
-		await driverHelper.scrollIntoView( this.driver, selector );
-		return await driverHelper.clickWhenClickable( this.driver, selector );
+		return await this._scrollToAndClickMenuItem( 'people' );
 	}
 
 	async selectAddPerson() {
-		const selector = By.css( '.sites-navigation [data-tip-target="people"] a.sidebar__button' );
-		await driverHelper.scrollIntoView( this.driver, selector );
-		return await driverHelper.clickWhenClickable( this.driver, selector );
+		return await this._scrollToAndClickMenuItem( 'people', { clickButton: true } );
 	}
 
 	async selectManagePlugins() {
-		const selector = By.css(
-			'.sites-navigation [data-tip-target="side-menu-plugins"] a.sidebar__button'
-		);
-		return await driverHelper.clickWhenClickable( this.driver, selector );
+		return await this._scrollToAndClickMenuItem( 'side-menu-plugins', { clickButton: true } );
 	}
 
 	async selectThemes() {
-		const selector = By.css( '.sites-navigation [data-tip-target="themes"] a[href*=themes]' );
+		return await this._scrollToAndClickMenuItem( 'themes', { clickButton: true } );
+	}
+
+	async customizeTheme() {
+		return await this._scrollToAndClickMenuItem( 'themes' );
+	}
+
+	async selectPlan() {
+		return await this._scrollToAndClickMenuItem( 'plan' );
+	}
+
+	async selectAddNewPage() {
+		return await this._scrollToAndClickMenuItem( 'side-menu-page', { clickButton: true } );
+	}
+
+	async selectStats() {
+		return await this._scrollToAndClickMenuItem( 'menus' );
+	}
+
+	async selectActivity() {
+		return await this._scrollToAndClickMenuItem( 'activity' );
+	}
+
+	async selectViewThisSite() {
+		return await this._scrollToAndClickMenuItem( 'sitePreview' );
+	}
+
+	async selectPlugins() {
+		return await this._scrollToAndClickMenuItem( 'side-menu-plugins' );
+	}
+
+	async selectSettings() {
+		return await this._scrollToAndClickMenuItem( 'settings' );
+	}
+
+	async selectImport() {
+		return await this._scrollToAndClickMenuItem( 'side-menu-import' );
+	}
+
+	async selectPages() {
+		return await this._scrollToAndClickMenuItem( 'side-menu-page' );
+	}
+
+	async selectPosts() {
+		return await this._scrollToAndClickMenuItem( 'side-menu-post' );
+	}
+
+	async selectComments() {
+		return await this._scrollToAndClickMenuItem( 'side-menu-comments' );
+	}
+
+	async selectStoreOption() {
+		return await driverHelper.clickWhenClickable( this.driver, this.storeSelector );
+	}
+
+	async storeOptionDisplayed() {
+		return await driverHelper.isEventuallyPresentAndDisplayed( this.driver, this.storeSelector );
+	}
+
+	async settingsOptionExists() {
+		return await driverHelper.isElementPresent(
+			this.driver,
+			SidebarComponent._getSidebarSelector( 'settings' )
+		);
+	}
+
+	async numberOfMenuItems() {
+		let elements = await this.driver.findElements( By.css( '.sidebar .sidebar__menu li' ) );
+		return elements.length;
+	}
+
+	async _scrollToAndClickMenuItem( target, { clickButton = false } = {} ) {
+		const selector = SidebarComponent._getSidebarSelector( target, { clickButton: clickButton } );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.site__notices' ) );
 		await driverHelper.scrollIntoView( this.driver, selector );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 
-	async customizeTheme() {
-		const selector = By.css( '.sites-navigation [data-tip-target="themes"] a[href*=customize]' );
-		return await driverHelper.clickWhenClickable( this.driver, selector );
+	static _getSidebarSelector( target, { getButton = false } = {} ) {
+		const linkSelector = getButton ? 'a.sidebar__button' : 'a:not(.sidebar__button)';
+		return By.css( `.sidebar li[data-tip-target="${ target }"] ${ linkSelector }` );
 	}
 
-	async selectPlan() {
-		const selector = By.css( '.menu-link-text[data-e2e-sidebar="Plan"]' );
-		return await driverHelper.clickWhenClickable( this.driver, selector );
-	}
+	async ensureSidebarMenuVisible() {
+		const allSitesSelector = By.css( '.current-section a' );
+		const sidebarSelector = By.css( '.sidebar' );
+		const sidebarVisible = await this.driver.findElement( sidebarSelector ).isDisplayed();
 
-	async selectAddNewPage() {
-		const selector = By.css( '.sites-navigation [data-post-type="page"] a.sidebar__button' );
-		return await driverHelper.clickWhenClickable( this.driver, selector );
+		if ( ! sidebarVisible ) {
+			await driverHelper.clickWhenClickable( this.driver, allSitesSelector );
+		}
+		return await driverHelper.waitTillPresentAndDisplayed( this.driver, sidebarSelector );
 	}
 
 	async selectSiteSwitcher() {
@@ -71,27 +135,6 @@ export default class SidebarComponent extends AsyncBaseContainer {
 			return await driverHelper.clickWhenClickable( this.driver, siteSwitcherSelector );
 		}
 		return false;
-	}
-
-	async selectStats() {
-		const selector = By.css( '.sites-navigation .stats a' );
-		return await driverHelper.clickWhenClickable( this.driver, selector );
-	}
-
-	async selectActivity() {
-		const selector = By.css( '.menu-link-text[data-e2e-sidebar="Activity"]' );
-		return await driverHelper.clickWhenClickable( this.driver, selector );
-	}
-
-	async ensureSidebarMenuVisible() {
-		const allSitesSelector = By.css( '.current-section a' );
-		const sidebarSelector = By.css( '.sidebar' );
-		const sidebarVisible = await this.driver.findElement( sidebarSelector ).isDisplayed();
-
-		if ( ! sidebarVisible ) {
-			await driverHelper.clickWhenClickable( this.driver, allSitesSelector );
-		}
-		return await driverHelper.waitTillPresentAndDisplayed( this.driver, sidebarSelector );
 	}
 
 	async searchForSite( searchString ) {
@@ -109,82 +152,6 @@ export default class SidebarComponent extends AsyncBaseContainer {
 
 	async selectAllSites() {
 		return await driverHelper.clickWhenClickable( this.driver, By.css( '.all-sites a' ) );
-	}
-
-	async selectViewThisSite() {
-		const selector = By.css( '.menu-link-text[data-e2e-sidebar="View Site"]' );
-		return await driverHelper.clickWhenClickable( this.driver, selector );
-	}
-
-	async selectPlugins() {
-		const selector = By.css( '.menu-link-text[data-e2e-sidebar="Plugins"]' );
-		const dismissNoticeSelector = By.css( '.notice.is-dismissable .notice__dismiss' );
-		const driver = this.driver;
-
-		return await driverHelper
-			.clickWhenClickable( driver, selector )
-			.then(
-				() => {}, // success
-				async () => {
-					// fail
-					// Dismiss any visible notice (i.e upgrade nudge) and try again
-					await driverHelper.clickIfPresent( driver, dismissNoticeSelector );
-					return await driverHelper.clickWhenClickable( driver, selector );
-				}
-			)
-			.then( async () => {
-				return await driver.wait( until.elementLocated( By.css( '.plugins-browser-list' ) ) );
-			} );
-	}
-
-	async selectSettings() {
-		const dismissNoticeSelector = By.css( '.notice.is-dismissable .notice__dismiss' );
-		const driver = this.driver;
-
-		if ( await driverHelper.isElementPresent( driver, dismissNoticeSelector ) ) {
-			await driverHelper.clickIfPresent( driver, dismissNoticeSelector );
-		}
-		return await driverHelper.clickWhenClickable( driver, this.settingsSelector );
-	}
-
-	async settingsOptionExists() {
-		return await driverHelper.isElementPresent( this.driver, this.settingsSelector );
-	}
-
-	async importOptionExists() {
-		return await driverHelper.isElementPresent( this.driver, this.importSelector );
-	}
-
-	async selectImport() {
-		return await driverHelper.clickWhenClickable( this.driver, this.importSelector );
-	}
-
-	async selectPages() {
-		const selector = By.css( '.sites-navigation [data-post-type="page"] a:not(.sidebar__button)' );
-		return await driverHelper.clickWhenClickable( this.driver, selector );
-	}
-
-	async selectPosts() {
-		const selector = By.css( '.menu-link-text[data-e2e-sidebar="Blog Posts"]' );
-		return await driverHelper.clickWhenClickable( this.driver, selector );
-	}
-
-	async selectComments() {
-		const selector = By.css( '.menu-link-text[data-e2e-sidebar="Comments"]' );
-		return await driverHelper.clickWhenClickable( this.driver, selector );
-	}
-
-	async storeOptionDisplayed() {
-		return await driverHelper.isEventuallyPresentAndDisplayed( this.driver, this.storeSelector );
-	}
-
-	async selectStoreOption() {
-		return await driverHelper.clickWhenClickable( this.driver, this.storeSelector );
-	}
-
-	async numberOfMenuItems() {
-		let elements = await this.driver.findElements( By.css( '.sidebar .sidebar__menu li' ) );
-		return elements.length;
 	}
 
 	async addNewSite() {

--- a/lib/components/sidebar-component.js
+++ b/lib/components/sidebar-component.js
@@ -101,7 +101,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async _scrollToAndClickMenuItem( target, { clickButton = false } = {} ) {
-		const selector = SidebarComponent._getSidebarSelector( target, { clickButton: clickButton } );
+		const selector = SidebarComponent._getSidebarSelector( target, { getButton: clickButton } );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.site__notices' ) );
 		await driverHelper.scrollIntoView( this.driver, selector );
 		return await driverHelper.clickWhenClickable( this.driver, selector );


### PR DESCRIPTION
The sidebar component had lots of duplication in how to click menu items

This simplifies it.


**Before**

```
async selectPeople() {
  const selector = By.css( '.menu-link-text[data-e2e-sidebar="People"]' );
  await driverHelper.scrollIntoView( this.driver, selector );
  return await driverHelper.clickWhenClickable( this.driver, selector );
}

async selectAddPerson() {
  const selector = By.css( '.sites-navigation [data-tip-target="people"] a.sidebar__button' );
  await driverHelper.scrollIntoView( this.driver, selector );
  return await driverHelper.clickWhenClickable( this.driver, selector );
}
```

**After**

```
async selectPeople() {
  return await this._scrollToAndClickMenuItem( 'people' );
}

async selectAddPerson() {
  return await this._scrollToAndClickMenuItem( 'people', { clickButton: true } );
}
```

