### PR TITLE
Update calypso gutenberg specs to use page preview

### DIFF
--- a/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -11,7 +11,7 @@ import NotFoundPage from '../lib/pages/not-found-page.js';
 import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
-import GutenbergPagePreviewComponent from '../lib/gutenberg/gutenberg-page-preview-component';
+import PagePreviewComponent from '../lib/components/page-preview-component';
 import SimplePaymentsBlockComponent from '../lib/gutenberg/blocks/payment-block-component';
 
 import * as driverManager from '../lib/driver-manager.js';
@@ -86,13 +86,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.ensureSaved();
 			await gEditorComponent.launchPreview();
-			await driverHelper.waitForNumberOfWindows( driver, 2 );
-			await driverHelper.switchToWindowByIndex( driver, 1 );
 		} );
 
 		step( 'Can see correct page title in preview', async function() {
-			const gPreviewComponent = await GutenbergPagePreviewComponent.Expect( driver );
-			let actualPageTitle = await gPreviewComponent.pageTitle();
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			await pagePreviewComponent.displayed();
+			let actualPageTitle = await pagePreviewComponent.pageTitle();
 			assert.strictEqual(
 				actualPageTitle.toUpperCase(),
 				pageTitle.toUpperCase(),
@@ -101,8 +100,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct page content in preview', async function() {
-			const gPagePreviewComponent = await GutenbergPagePreviewComponent.Expect( driver );
-			let content = await gPagePreviewComponent.pageContent();
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			let content = await pagePreviewComponent.pageContent();
 			assert.strictEqual(
 				content.indexOf( pageQuote ) > -1,
 				true,
@@ -115,14 +114,18 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see the image uploaded in the preview', async function() {
-			const gPagePreviewComponent = await GutenbergPagePreviewComponent.Expect( driver );
-			let imageDisplayed = await gPagePreviewComponent.imageDisplayed( fileDetails );
-			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the web preview' );
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			const imageDisplayed = await pagePreviewComponent.imageDisplayed( fileDetails );
+			return assert.strictEqual(
+				imageDisplayed,
+				true,
+				'Could not see the image in the web preview'
+			);
 		} );
 
 		step( 'Can close page preview', async function() {
-			await driverHelper.closeCurrentWindow( driver );
-			return await driverHelper.switchToWindowByIndex( driver, 0 );
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			await pagePreviewComponent.close();
 		} );
 
 		step( 'Can publish and preview published content', async function() {

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -14,7 +14,7 @@ import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
 
 import SidebarComponent from '../lib/components/sidebar-component.js';
 import NavBarComponent from '../lib/components/nav-bar-component.js';
-import GutenbergPostPreviewComponent from '../lib/gutenberg/gutenberg-post-preview-component';
+import PostPreviewComponent from '../lib/components/post-preview-component';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
 import SimplePaymentsBlockComponent from '../lib/gutenberg/blocks/payment-block-component';
@@ -121,13 +121,11 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.ensureSaved();
 			await gEditorComponent.launchPreview();
-			await driverHelper.waitForNumberOfWindows( driver, 2 );
-			await driverHelper.switchToWindowByIndex( driver, 1 );
 		} );
 
 		step( 'Can see correct post title in preview', async function() {
-			const gPreviewComponent = await GutenbergPostPreviewComponent.Expect( driver );
-			let postTitle = await gPreviewComponent.postTitle();
+			this.postPreviewComponent = await PostPreviewComponent.Expect( driver );
+			let postTitle = await this.postPreviewComponent.postTitle();
 			assert.strictEqual(
 				postTitle.toLowerCase(),
 				blogPostTitle.toLowerCase(),
@@ -136,8 +134,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct post content in preview', async function() {
-			const gPreviewComponent = await GutenbergPostPreviewComponent.Expect( driver );
-			let content = await gPreviewComponent.postContent();
+			let content = await this.postPreviewComponent.postContent();
 			assert.strictEqual(
 				content.indexOf( blogPostQuote ) > -1,
 				true,
@@ -149,36 +146,22 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			);
 		} );
 
-		step( 'Can see the post category in preview', async function() {
-			const gPreviewComponent = await GutenbergPostPreviewComponent.Expect( driver );
-			let categoryDisplayed = await gPreviewComponent.categoryDisplayed();
+		step( 'Can see the post tag in preview', async function() {
+			let tagDisplayed = await this.postPreviewComponent.tagDisplayed();
 			assert.strictEqual(
-				categoryDisplayed.toUpperCase(),
-				newCategoryName.toUpperCase(),
-				'The category: ' + newCategoryName + ' is not being displayed on the post'
+				tagDisplayed.toUpperCase(),
+				newTagName.toUpperCase(),
+				'The tag: ' + newTagName + ' is not being displayed on the post'
 			);
 		} );
 
-		// Disable this step until https://github.com/Automattic/wp-calypso/issues/28974 is solved
-		// step( 'Can see the post tag in preview', async function() {
-		// 	const gPreviewComponent = await GutenbergPostPreviewComponent.Expect( driver );
-		// 	let tagDisplayed = await gPreviewComponent.tagDisplayed();
-		// 	assert.strictEqual(
-		// 		tagDisplayed.toUpperCase(),
-		// 		newTagName.toUpperCase(),
-		// 		'The tag: ' + newTagName + ' is not being displayed on the post'
-		// 	);
-		// } );
-
 		step( 'Can see the image in preview', async function() {
-			const gPreviewComponent = await GutenbergPostPreviewComponent.Expect( driver );
-			let imageDisplayed = await gPreviewComponent.imageDisplayed( fileDetails );
+			let imageDisplayed = await this.postPreviewComponent.imageDisplayed( fileDetails );
 			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the web preview' );
 		} );
 
-		step( 'Can close preview', async function() {
-			await driverHelper.closeCurrentWindow( driver );
-			return await driverHelper.switchToWindowByIndex( driver, 0 );
+		step( 'Can close post preview', async function() {
+			await this.postPreviewComponent.close();
 		} );
 
 		step( 'Can publish and view content', async function() {

--- a/specs/wp-gutenberg-page-editor-spec.js
+++ b/specs/wp-gutenberg-page-editor-spec.js
@@ -22,6 +22,7 @@ const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
+const baseURL = dataHelper.configGet( 'calypsoBaseURL' );
 
 let driver;
 
@@ -32,6 +33,13 @@ before( async function() {
 
 describe( `[${ host }] Gutenberg Editor (wp-admin): Pages (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
+
+	beforeEach( async function() {
+		if ( baseURL !== 'https://wordpress.com' ) {
+			// these wp-admin tests only work on Production
+			return this.skip();
+		}
+	} );
 
 	describe( 'Public Pages: @parallel', function() {
 		let fileDetails;

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -31,6 +31,7 @@ const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
+const baseURL = dataHelper.configGet( 'calypsoBaseURL' );
 
 let driver;
 
@@ -41,6 +42,13 @@ before( async function() {
 
 describe( `[${ host }] Gutenberg Editor (wp-admin): Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
+
+	beforeEach( async function() {
+		if ( baseURL !== 'https://wordpress.com' ) {
+			// these wp-admin tests only work on Production
+			return this.skip();
+		}
+	} );
 
 	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
 		let fileDetails;


### PR DESCRIPTION
This PR is for changes in https://github.com/Automattic/wp-calypso/pull/29321

For Gutenberg Calypso the e2e tests now use the preview component

For wp-admin Gutenberg - these specs now run only on WordPress.com production since these are out of sync with dev environments