### PR TITLE
Disable tag checking in post preview

### DIFF
--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -146,14 +146,15 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			);
 		} );
 
-		step( 'Can see the post tag in preview', async function() {
-			let tagDisplayed = await this.postPreviewComponent.tagDisplayed();
-			assert.strictEqual(
-				tagDisplayed.toUpperCase(),
-				newTagName.toUpperCase(),
-				'The tag: ' + newTagName + ' is not being displayed on the post'
-			);
-		} );
+		// Disable this step until https://github.com/Automattic/wp-calypso/issues/28974 is solved
+		// step( 'Can see the post tag in preview', async function() {
+		// 	let tagDisplayed = await this.postPreviewComponent.tagDisplayed();
+		// 	assert.strictEqual(
+		// 		tagDisplayed.toUpperCase(),
+		// 		newTagName.toUpperCase(),
+		// 		'The tag: ' + newTagName + ' is not being displayed on the post'
+		// 	);
+		// } );
 
 		step( 'Can see the image in preview', async function() {
 			let imageDisplayed = await this.postPreviewComponent.imageDisplayed( fileDetails );


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/issues/28974 is still open, and tag checking in post preview [started with failing](https://circleci.com/gh/Automattic/wp-e2e-tests/25115#tests/containers/0) on master branch after https://github.com/Automattic/wp-e2e-tests/pull/1710 is merged. Disabling it for now. 