### PR TITLE
Add tests for the onboarding signup flow

### DIFF
--- a/lib/override-abtest.js
+++ b/lib/override-abtest.js
@@ -1,0 +1,46 @@
+/** @format */
+
+import config from 'config';
+import { findIndex } from 'lodash';
+
+function getABTestEraser( name ) {
+	return () => {
+		const overrideABTests = config.get( 'overrideABTests' );
+		const index = findIndex( overrideABTests, item => item[ 0 ] === name );
+
+		if ( index !== -1 ) {
+			overrideABTests.splice( index, 1 );
+		}
+	};
+}
+
+function getABTestUpdater( name, variation ) {
+	return () => {
+		const overrideABTests = config.get( 'overrideABTests' );
+		const index = findIndex( overrideABTests, item => item[ 0 ] === name );
+
+		if ( index !== -1 ) {
+			overrideABTests[ index ][ 1 ] = variation;
+		}
+	};
+}
+
+/**
+ * Overrides an A/B Test.
+ * @param {String} name A/B test name
+ * @param {String} variation the variation you want to set
+ * @return {Function} undo the changes.
+ */
+export default function overrideABTest( name, variation ) {
+	const overrideABTests = config.get( 'overrideABTests' );
+	const index = findIndex( overrideABTests, item => item[ 0 ] === name );
+
+	if ( index !== -1 ) {
+		const originalVariation = overrideABTests[ index ][ 1 ];
+		overrideABTests[ index ][ 1 ] = variation;
+		return getABTestUpdater( name, originalVariation );
+	}
+
+	overrideABTests.push( [ name, variation ] );
+	return getABTestEraser( name );
+}

--- a/lib/pages/signup/site-info-page.js
+++ b/lib/pages/signup/site-info-page.js
@@ -1,0 +1,23 @@
+/** @format */
+
+import { By } from 'selenium-webdriver';
+import * as driverHelper from '../../driver-helper.js';
+
+import AsyncBaseContainer from '../../async-base-container';
+
+export default class SiteInfoPage extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.site-information__wrapper' ) );
+	}
+
+	async enterSiteTitle( siteTitle ) {
+		return await driverHelper.setWhenSettable( this.driver, By.css( '#name' ), siteTitle );
+	}
+
+	async submitForm() {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.site-information__submit-wrapper button.is-primary' )
+		);
+	}
+}

--- a/lib/pages/signup/site-topic-page.js
+++ b/lib/pages/signup/site-topic-page.js
@@ -1,0 +1,28 @@
+/** @format */
+
+import { By } from 'selenium-webdriver';
+import * as driverHelper from '../../driver-helper.js';
+
+import AsyncBaseContainer from '../../async-base-container';
+
+export default class SiteTopicPage extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.site-topic__content' ) );
+	}
+
+	async enterSiteTopic( siteTopic ) {
+		await driverHelper.setWhenSettable( this.driver, By.css( '#siteTopic' ), siteTopic );
+		// click info popover icon to close the suggestion overlay
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.site-topic__info-popover' )
+		);
+	}
+
+	async submitForm() {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.site-topic__submit-wrapper button.is-primary' )
+		);
+	}
+}

--- a/lib/pages/signup/site-type-page.js
+++ b/lib/pages/signup/site-type-page.js
@@ -1,0 +1,28 @@
+/** @format */
+
+import { By } from 'selenium-webdriver';
+import * as driverHelper from '../../driver-helper.js';
+
+import AsyncBaseContainer from '../../async-base-container';
+
+export default class SiteTypePage extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.site-type__wrapper' ) );
+	}
+
+	async _selectType( type ) {
+		await driverHelper.setCheckbox( this.driver, By.css( `input.form-radio[value='${ type }']` ) );
+		return await this.driver.sleep( 1000 );
+	}
+
+	async selectBlogType() {
+		return await this._selectType( 'blog' );
+	}
+
+	async submitForm() {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.site-type__submit-wrapper button.is-primary' )
+		);
+	}
+}

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -21,6 +21,9 @@ import CreateYourAccountPage from '../lib/pages/signup/create-your-account-page.
 import CheckOutPage from '../lib/pages/signup/checkout-page';
 import CheckOutThankyouPage from '../lib/pages/signup/checkout-thankyou-page.js';
 import ImportFromURLPage from '../lib/pages/signup/import-from-url-page';
+import SiteTypePage from '../lib/pages/signup/site-type-page';
+import SiteTopicPage from '../lib/pages/signup/site-topic-page';
+import SiteInfoPage from '../lib/pages/signup/site-info-page';
 import LoginPage from '../lib/pages/login-page';
 import MagicLoginPage from '../lib/pages/magic-login-page';
 import ReaderPage from '../lib/pages/reader-page';
@@ -52,6 +55,7 @@ import DeleteAccountFlow from '../lib/flows/delete-account-flow';
 import DeletePlanFlow from '../lib/flows/delete-plan-flow';
 import ThemeDialogComponent from '../lib/components/theme-dialog-component';
 import SignUpStep from '../lib/flows/sign-up-step';
+import overrideABTest from '../lib/override-abtest';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -1703,6 +1707,100 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can delete our newly created account', async function() {
 			return await new DeleteAccountFlow( driver ).deleteAccount( userName );
+		} );
+	} );
+
+	describe( 'Sign up for a free WordPress.com site via the new onboarding flow', () => {
+		const userName = dataHelper.getNewBlogName();
+		const blogName = dataHelper.getNewBlogName();
+		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
+		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
+		let undo = null;
+
+		before( async function() {
+			undo = overrideABTest( 'improvedOnboarding_20181023', 'onboarding' );
+			return await driverManager.ensureNotLoggedIn( driver );
+		} );
+
+		step( 'Can visit the start page', async function() {
+			return await StartPage.Visit( driver, StartPage.getStartURL( { culture: locale } ) );
+		} );
+
+		step( 'Can see the account page and enter account details', async function() {
+			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			return await createYourAccountPage.enterAccountDetailsAndSubmit(
+				emailAddress,
+				userName,
+				passwordForTestAccounts
+			);
+		} );
+
+		step( 'Can see the "Site Type" page, and enter some site information', async function() {
+			const siteTypePage = await SiteTypePage.Expect( driver );
+			await siteTypePage.selectBlogType();
+			return await siteTypePage.submitForm();
+		} );
+
+		step( 'Can see the "Site Topic" page, and enter the site topic', async function() {
+			const siteTopicPage = await SiteTopicPage.Expect( driver );
+			await siteTopicPage.enterSiteTopic( 'Tech Blog' );
+			return await siteTopicPage.submitForm();
+		} );
+
+		step( 'Can see the "Site Information" page, and enter the site title', async function() {
+			const siteInfoPage = await SiteInfoPage.Expect( driver );
+			await siteInfoPage.enterSiteTitle( blogName );
+			return await siteInfoPage.submitForm();
+		} );
+
+		step(
+			'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
+			async function() {
+				const findADomainComponent = await FindADomainComponent.Expect( driver );
+				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
+				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
+					expectedBlogAddresses,
+					blogName
+				);
+				let actualAddress = await findADomainComponent.freeBlogAddress();
+				assert(
+					expectedBlogAddresses.indexOf( actualAddress ) > -1,
+					`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
+				);
+				return await findADomainComponent.selectFreeAddress();
+			}
+		);
+
+		step( 'Can see the plans page and pick the free plan', async function() {
+			const pickAPlanPage = await PickAPlanPage.Expect( driver );
+			return await pickAPlanPage.selectFreePlan();
+		} );
+
+		step(
+			'Can then see the sign up processing page which will finish automatically move along',
+			async function() {
+				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+			}
+		);
+
+		step( 'Can then see the onboarding checklist', async function() {
+			const checklistPage = await ChecklistPage.Expect( driver );
+			const header = await checklistPage.headerExists();
+			const subheader = await checklistPage.subheaderExists();
+
+			assert( header, 'The checklist header does not exist.' );
+
+			return assert( subheader, 'The checklist subheader does not exist.' );
+		} );
+
+		step( 'Can delete our newly created account', async function() {
+			return await new DeleteAccountFlow( driver ).deleteAccount( userName );
+		} );
+
+		after( async function() {
+			if ( typeof undo === 'function' ) {
+				undo();
+			}
 		} );
 	} );
 } );


### PR DESCRIPTION
Even though new `onboarding` signup flow is still in A/B testing, it is a critical piece of WordPress.com and many current/future works are based on the new flow. Therefore, it would make sense to add some e2e tests to have additional layers of safety.

@Automattic/flowpatrol I'd appreciate if you take a look at this since I'm not 100% sure about the approach I used here to turn on the `onboarding` flow. 