### PR TITLE
Update selector for closing editor

### DIFF
--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -278,7 +278,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async closeEditor() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.edit-post-fullscreen-mode-close__toolbar' )
+			By.css( '.edit-post-fullscreen-mode-close__toolbar, .edit-post-header-toolbar__back' )
 		);
 	}
 }


### PR DESCRIPTION
The close button for both versions of Gutenberg are different. This updates to account for both.

To Test:
Run `Inviting New User as an Contributor, then change them to Author` against wordpress.com and against wpcalypso.wordpress.com