### PR TITLE
Try using fewer workers for Jetpack tests

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -146,6 +146,7 @@ while getopts ":a:RpS:B:s:gjWCJH:wzyl:cm:fiIUvxu:h:F" opt; do
       exit $?
       ;;
     j)
+      WORKERS=3
       SCREENSIZES="desktop,mobile"
       MAGELLAN_CONFIG="magellan-jetpack.json"
       ;;


### PR DESCRIPTION
The magellan config file for Jetpack says 3 workers, but we were overriding it in run.sh. Most tests run fine with 8, but Jetpack needs fewer