### PR TITLE
Gutenlypso: Check category in post preview

### DIFF
--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -146,6 +146,15 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			);
 		} );
 
+		step( 'Can see the post category in preview', async function() {
+			let categoryDisplayed = await this.postPreviewComponent.categoryDisplayed();
+			assert.strictEqual(
+				categoryDisplayed.toUpperCase(),
+				newCategoryName.toUpperCase(),
+				'The tag: ' + newCategoryName + ' is not being displayed on the post'
+			);
+		} );
+
 		// Disable this step until https://github.com/Automattic/wp-calypso/issues/28974 is solved
 		// step( 'Can see the post tag in preview', async function() {
 		// 	let tagDisplayed = await this.postPreviewComponent.tagDisplayed();


### PR DESCRIPTION
Put back category check in the post preview, discussed [here](https://github.com/Automattic/wp-e2e-tests/pull/1710#issuecomment-446849469).

To test: 
Make sure that test `Public Posts: Preview and Publish a Public Post @parallel` is passing, mobile and desktop. 