### PR TITLE
Remove and address sleep statement in `woo-wizard-jetpack-page.js`

### DIFF
--- a/lib/pages/woocommerce/woo-wizard-jetpack-page.js
+++ b/lib/pages/woocommerce/woo-wizard-jetpack-page.js
@@ -12,7 +12,7 @@ export default class WooWizardJetpackPage extends AsyncBaseContainer {
 
 	async selectContinueWithJetpack() {
 		const buttonSelector = By.css( 'button.button-primary' );
-		await this.driver.sleep( 2000 );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, buttonSelector );
 		await driverHelper.clickWhenClickable( this.driver, buttonSelector );
 		return await driverHelper.waitTillNotPresent(
 			this.driver,


### PR DESCRIPTION
Removed sleep statement and addressed it by using `waitTillPresentAndDisplayed` instead. Previously, there was no check on the page whether the button was present and displayed. `waitTillPresentAndDisplayed` provides that check. 