### PR TITLE
Remove and address sleep statement in `close-account-page.js`

### DIFF
--- a/lib/pages/account/close-account-page.js
+++ b/lib/pages/account/close-account-page.js
@@ -5,6 +5,9 @@ import { By as by } from 'selenium-webdriver';
 import * as driverHelper from '../../driver-helper.js';
 
 import AsyncBaseContainer from '../../async-base-container';
+import config from 'config';
+
+const explicitWaitMS = config.get( 'explicitWaitMS' );
 
 export default class CloseAccountPage extends AsyncBaseContainer {
 	constructor( driver ) {
@@ -12,11 +15,22 @@ export default class CloseAccountPage extends AsyncBaseContainer {
 	}
 
 	async chooseCloseAccount() {
-		await this.driver.sleep( 1000 ); // Button doesn't register clicks immediately
-		return driverHelper.clickWhenClickable(
-			this.driver,
-			by.css( '.account-close button.is-scary' )
-		);
+		const buttonSelector = by.css( '.account-close button.is-scary' );
+		const confirmDialogSelector = by.css( '.account-close__confirm-dialog-confirm-input' );
+		const pauseBetweenClickAttemptsMS = 100;
+
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, buttonSelector );
+
+		// Click doesn't always fire even if the button is already displayed.
+		// We can safely attempt to click the button until the confirmation dialog pop-up window is present.
+		for ( let i = 0; i < explicitWaitMS / pauseBetweenClickAttemptsMS; i++ ) {
+			await driverHelper.clickWhenClickable( this.driver, buttonSelector );
+			if ( await driverHelper.isElementPresent( this.driver, confirmDialogSelector ) ) {
+				return true;
+			}
+			await this.driver.sleep( pauseBetweenClickAttemptsMS );
+		}
+		return false;
 	}
 
 	async enterAccountNameAndClose( accountName ) {


### PR DESCRIPTION
Removed the `sleep` statement as it was not deterministic. Click doesn't always fire even if the button is already displayed. 

In the loop that I implemented, we can safely attempt to click the button until the confirmation dialog pop-up window is present which indicates the end of the loop. The test can move on to the next step. 