### PR TITLE
Check embedded content in published post 

### DIFF
--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1081,28 +1081,28 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.enterTitle( 'Embeds: ' + blogPostTitle );
 
-			this.youtubeSelector = '.wp-block-embed-youtube';
+			this.youtubeEditorSelector = '.wp-block-embed-youtube';
 			const blockIdYouTube = await gEditorComponent.addBlock( 'YouTube' );
 			const gEmbedsComponentYouTube = await EmbedsBlockComponent.Expect( driver, blockIdYouTube );
 			await gEmbedsComponentYouTube.embedUrl( 'https://www.youtube.com/watch?v=xifhQyopjZM' );
-			// await gEmbedsComponentYouTube.isEmbeddedInEditor( this.youtubeSelector ); TODO: check is it shown in the Editor
+			// await gEmbedsComponentYouTube.isEmbeddedInEditor( this.youtubeEditorSelector ); TODO: check is it shown in the Editor
 
-			this.instagramSelector = '.wp-block-embed-instagram';
+			this.instagramEditorSelector = '.wp-block-embed-instagram';
 			const blockIdInstagram = await gEditorComponent.addBlock( 'Instagram' );
 			const gEmbedsComponentInstagram = await EmbedsBlockComponent.Expect(
 				driver,
 				blockIdInstagram
 			);
 			await gEmbedsComponentInstagram.embedUrl( 'https://www.instagram.com/p/BlDOZMil933/' );
-			// await gEmbedsComponentInstagram.isEmbeddedInEditor( this.instagramSelector ); TODO: check is it shown in the Editor
+			// await gEmbedsComponentInstagram.isEmbeddedInEditor( this.instagramEditorSelector ); TODO: check is it shown in the Editor
 
-			this.twitterSelector = '.wp-block-embed-twitter';
+			this.twitterEditorSelector = '.wp-block-embed-twitter';
 			const blockIdTwitter = await gEditorComponent.addBlock( 'Twitter' );
 			const gEmbedsComponentTwitter = await EmbedsBlockComponent.Expect( driver, blockIdTwitter );
 			await gEmbedsComponentTwitter.embedUrl(
 				'https://twitter.com/automattic/status/1067120832676327424'
 			);
-			await gEmbedsComponentTwitter.isEmbeddedInEditor( this.twitterSelector );
+			await gEmbedsComponentTwitter.isEmbeddedInEditor( this.twitterEditorSelector );
 
 			let errorShown = await gEditorComponent.errorDisplayed();
 			return assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
@@ -1115,9 +1115,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 		step( 'Can see embedded content in our published post', async function() {
 			const viewPostPage = await ViewPostPage.Expect( driver );
-			await viewPostPage.embedContentDisplayed( this.youtubeSelector ); // check YouTube content
-			await viewPostPage.embedContentDisplayed( this.instagramSelector ); // check Instagram content
-			return await viewPostPage.embedContentDisplayed( this.twitterSelector ); // check Twitter content
+			this.youtubePostSelector = '.youtube-player';
+			await viewPostPage.embedContentDisplayed( this.youtubePostSelector ); // check YouTube content
+			this.instagramPostSelector = '.instagram-media-rendered';
+			await viewPostPage.embedContentDisplayed( this.instagramPostSelector ); // check Instagram content
+			this.instagramPostSelector = '.twitter-tweet-rendered';
+			return await viewPostPage.embedContentDisplayed( this.instagramPostSelector ); // check Twitter content
 		} );
 	} );
 } );

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -1085,28 +1085,28 @@ describe( `[${ host }] Gutenberg Editor (wp-admin): Posts (${ screenSize })`, fu
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.enterTitle( 'Embeds: ' + blogPostTitle );
 
-			this.youtubeSelector = '.wp-block-embed-youtube';
+			this.youtubeEditorSelector = '.wp-block-embed-youtube';
 			const blockIdYouTube = await gEditorComponent.addBlock( 'YouTube' );
 			const gEmbedsComponentYouTube = await EmbedsBlockComponent.Expect( driver, blockIdYouTube );
 			await gEmbedsComponentYouTube.embedUrl( 'https://www.youtube.com/watch?v=xifhQyopjZM' );
-			await gEmbedsComponentYouTube.isEmbeddedInEditor( this.youtubeSelector ); // TODO: check is it shown in the Editor
+			await gEmbedsComponentYouTube.isEmbeddedInEditor( this.youtubeEditorSelector ); // TODO: check is it shown in the Editor
 
-			this.instagramSelector = '.wp-block-embed-instagram';
+			this.instagramEditorSelector = '.wp-block-embed-instagram';
 			const blockIdInstagram = await gEditorComponent.addBlock( 'Instagram' );
 			const gEmbedsComponentInstagram = await EmbedsBlockComponent.Expect(
 				driver,
 				blockIdInstagram
 			);
 			await gEmbedsComponentInstagram.embedUrl( 'https://www.instagram.com/p/BlDOZMil933/' );
-			// await gEmbedsComponentInstagram.isEmbeddedInEditor( this.instagramSelector ); TODO: check is it shown in the Editor
+			// await gEmbedsComponentInstagram.isEmbeddedInEditor( this.instagramEditorSelector ); TODO: check is it shown in the Editor
 
-			this.twitterSelector = '.wp-block-embed-twitter';
+			this.twitterEditorSelector = '.wp-block-embed-twitter';
 			const blockIdTwitter = await gEditorComponent.addBlock( 'Twitter' );
 			const gEmbedsComponentTwitter = await EmbedsBlockComponent.Expect( driver, blockIdTwitter );
 			await gEmbedsComponentTwitter.embedUrl(
 				'https://twitter.com/automattic/status/1067120832676327424'
 			);
-			await gEmbedsComponentTwitter.isEmbeddedInEditor( this.twitterSelector );
+			await gEmbedsComponentTwitter.isEmbeddedInEditor( this.twitterEditorSelector );
 
 			let errorShown = await gEditorComponent.errorDisplayed();
 			return assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
@@ -1119,9 +1119,12 @@ describe( `[${ host }] Gutenberg Editor (wp-admin): Posts (${ screenSize })`, fu
 
 		step( 'Can see embedded content in our published post', async function() {
 			const viewPostPage = await ViewPostPage.Expect( driver );
-			await viewPostPage.embedContentDisplayed( this.youtubeSelector ); // check YouTube content
-			await viewPostPage.embedContentDisplayed( this.instagramSelector ); // check Instagram content
-			return await viewPostPage.embedContentDisplayed( this.twitterSelector ); // check Twitter content
+			this.youtubePostSelector = '.youtube-player';
+			await viewPostPage.embedContentDisplayed( this.youtubePostSelector ); // check YouTube content
+			this.instagramPostSelector = '.instagram-media-rendered';
+			await viewPostPage.embedContentDisplayed( this.instagramPostSelector ); // check Instagram content
+			this.instagramPostSelector = '.twitter-tweet-rendered';
+			return await viewPostPage.embedContentDisplayed( this.instagramPostSelector ); // check Twitter content
 		} );
 	} );
 } );


### PR DESCRIPTION
For embedded URLs, we had the same selector for embed in the Block editor and for a published post. I added more specific selectors for a published post as an additional check is content embedded. 