### PR TITLE
Gutenberg integration on WP.com

### DIFF
--- a/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -48,9 +48,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 
 		step( 'Can log in', async function() {
 			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-			return await this.loginFlow.loginAndStartNewPage( null, true, {
-				forceCalypsoGutenberg: true,
-			} );
+			return await this.loginFlow.loginAndStartNewPage( null, true );
 		} );
 
 		step( 'Can enter page title, content and image', async function() {
@@ -188,9 +186,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 
 		step( 'Can log in', async function() {
 			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-			return await this.loginFlow.loginAndStartNewPage( null, true, {
-				forceCalypsoGutenberg: true,
-			} );
+			return await this.loginFlow.loginAndStartNewPage( null, true );
 		} );
 
 		step( 'Can enter page title and content', async function() {
@@ -262,9 +258,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		describe( 'Publish a Password Protected Page', function() {
 			step( 'Can log in', async function() {
 				this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await this.loginFlow.loginAndStartNewPage( null, true, {
-					forceCalypsoGutenberg: true,
-				} );
+				return await this.loginFlow.loginAndStartNewPage( null, true );
 			} );
 
 			step( 'Can enter page title and content and set to password protected', async function() {
@@ -530,9 +524,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 
 		step( 'Can log in', async function() {
 			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-			return await this.loginFlow.loginAndStartNewPage( null, true, {
-				forceCalypsoGutenberg: true,
-			} );
+			return await this.loginFlow.loginAndStartNewPage( null, true );
 		} );
 
 		step( 'Can insert the payment button', async function() {

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -57,9 +57,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 		step( 'Can log in', async function() {
 			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-			return await this.loginFlow.loginAndStartNewPost( null, true, {
-				forceCalypsoGutenberg: true,
-			} );
+			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		step( 'Can enter post title, content and image', async function() {
@@ -246,9 +244,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can log in', async function() {
 				this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await this.loginFlow.loginAndStartNewPost( null, true, {
-					forceCalypsoGutenberg: true,
-				} );
+				return await this.loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			step( 'Can enter post title and text content', async function() {
@@ -288,7 +284,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 		step( 'Can log in', async function() {
 			let loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-			return await loginFlow.loginAndStartNewPost( null, true, { forceCalypsoGutenberg: true } );
+			return await loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		step( 'Can enter post title and content', async function() {
@@ -333,9 +329,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can log in', async function() {
 				this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await this.loginFlow.loginAndStartNewPost( null, true, {
-					forceCalypsoGutenberg: true,
-				} );
+				return await this.loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			step( 'Can enter post title and content', async function() {
@@ -392,9 +386,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can log in', async function() {
 				this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await this.loginFlow.loginAndStartNewPost( null, true, {
-					forceCalypsoGutenberg: true,
-				} );
+				return await this.loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			step( 'Can enter post title and content', async function() {
@@ -514,7 +506,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can log in', async function() {
 				let loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				await loginFlow.loginAndStartNewPost( null, true, { forceCalypsoGutenberg: true } );
+				await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			step( 'Can enter post title and content and set to password protected', async function() {
@@ -774,7 +766,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can log in', async function() {
 				const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await loginFlow.loginAndStartNewPost( null, true, { forceCalypsoGutenberg: true } );
+				return await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			step( 'Can enter post title and content', async function() {
@@ -811,7 +803,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can log in', async function() {
 				const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await loginFlow.loginAndStartNewPost( null, true, { forceCalypsoGutenberg: true } );
+				return await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			step( 'Can enter post title and content', async function() {
@@ -907,7 +899,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can log in', async function() {
 				const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await loginFlow.loginAndStartNewPost( null, true, { forceCalypsoGutenberg: true } );
+				return await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			step( 'Can insert the contact form', async function() {
@@ -957,9 +949,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 		step( 'Can log in', async function() {
 			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-			return await this.loginFlow.loginAndStartNewPost( null, true, {
-				forceCalypsoGutenberg: true,
-			} );
+			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		step( 'Can insert the payment button', async function() {
@@ -1035,7 +1025,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can log in', async function() {
 				const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-				return await loginFlow.loginAndStartNewPost( null, true, { forceCalypsoGutenberg: true } );
+				return await loginFlow.loginAndStartNewPost( null, true );
 			} );
 
 			step( 'Can enter post title and content', async function() {
@@ -1071,9 +1061,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 	describe( 'Insert embeds: @parallel', function() {
 		step( 'Can log in', async function() {
 			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-			return await this.loginFlow.loginAndStartNewPost( null, true, {
-				forceCalypsoGutenberg: true,
-			} );
+			return await this.loginFlow.loginAndStartNewPost( null, true );
 		} );
 
 		step( 'Can insert Embeds block', async function() {

--- a/specs/wp-gutenberg-page-editor-spec.js
+++ b/specs/wp-gutenberg-page-editor-spec.js
@@ -31,7 +31,7 @@ before( async function() {
 	driver = await driverManager.startBrowser();
 } );
 
-describe( `[${ host }] Gutenberg Editor (wp-admin): Pages (${ screenSize })`, function() {
+xdescribe( `[${ host }] Gutenberg Editor (wp-admin): Pages (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
 	beforeEach( async function() {

--- a/specs/wp-gutenberg-post-editor-spec.js
+++ b/specs/wp-gutenberg-post-editor-spec.js
@@ -40,7 +40,7 @@ before( async function() {
 	driver = await driverManager.startBrowser();
 } );
 
-describe( `[${ host }] Gutenberg Editor (wp-admin): Posts (${ screenSize })`, function() {
+xdescribe( `[${ host }] Gutenberg Editor (wp-admin): Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
 	beforeEach( async function() {


### PR DESCRIPTION
Gutenberg integration is live. This PR disables wp-admin Gutenberg tests and removes `forceCalypsoGutenberg` from _wp-calypso-gutenberg-*_ tests

To test:
Make sure that `wp-calypso-gutenberg-page-editor-spec.js` and `wp-calypso-gutenberg-post-editor-spec.js` are passing.