### PR TITLE
Remove and address sleep statement in `business-address-page.js`

### DIFF
--- a/lib/pages/jetpack-onboarding/business-address-page.js
+++ b/lib/pages/jetpack-onboarding/business-address-page.js
@@ -11,11 +11,9 @@ export default class BusinessAddressPage extends AsyncBaseContainer {
 	}
 
 	async selectAddBusinessAddress() {
-		await this.driver.sleep( 1000 );
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.card[data-e2e-type="business-address"] button' )
-		);
+		const businessAddressSelector = By.css( '.card[data-e2e-type="business-address"] button' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, businessAddressSelector );
+		return await driverHelper.clickWhenClickable( this.driver, businessAddressSelector );
 	}
 
 	async selectContinue() {


### PR DESCRIPTION
Removed `sleep` statement and addressed it by using `waitTillPresentAndDisplayed` instead. Previously, there was no check on the page whether the `Add a business address` button was present and displayed. `waitTillPresentAndDisplayed` provides that check.

**To test:**

The change affects `wp-jetpack-onboarding-spec.js`. Make sure that the set of tests with description `'Onboard business site with posts homepage: @parallel @jetpack'` is passing. 