### PR TITLE
Update selectors for new onboarding flow

### DIFF
--- a/lib/pages/signup/site-topic-page.js
+++ b/lib/pages/signup/site-topic-page.js
@@ -15,14 +15,14 @@ export default class SiteTopicPage extends AsyncBaseContainer {
 		// click info popover icon to close the suggestion overlay
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.site-topic__info-popover' )
+			By.css( '.suggestions__item.has-highlight' )
 		);
 	}
 
 	async submitForm() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.site-topic__submit-wrapper button.is-primary' )
+			By.css( '.site-topic__content button.is-primary' )
 		);
 	}
 }


### PR DESCRIPTION
This was broken by https://github.com/Automattic/wp-calypso/pull/29421

Just updating some selectors so that `[WPCOM] Sign Up  (desktop, en) Sign up for an account only (no site) then add a site via new onboarding flow @parallel` will pass again 

