### PR TITLE
Update manage domains tests to run more reliably

### DIFF
--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -94,7 +94,7 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 	}
 
 	async declineGoogleApps() {
-		this.driver.sleep(2000);
+		this.driver.sleep( 2000 );
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			this.declineGoogleAppsLinkSelector,

--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -94,12 +94,26 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 	}
 
 	async declineGoogleApps() {
-		this.driver.sleep( 2000 );
-		return await driverHelper.clickWhenClickable(
+		await driverHelper.clickWhenClickable(
 			this.driver,
 			this.declineGoogleAppsLinkSelector,
 			this.explicitWaitMS
 		);
+		try {
+			await driverHelper.waitTillNotPresent(
+				this.driver,
+				this.declineGoogleAppsLinkSelector
+			);
+		} catch ( err ) {
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				this.declineGoogleAppsLinkSelector
+			);
+			await driverHelper.waitTillNotPresent(
+				this.driver,
+				this.declineGoogleAppsLinkSelector
+			);
+		}
 	}
 
 	selectAddEmailForGoogleApps() {

--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -105,11 +105,8 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 				this.declineGoogleAppsLinkSelector
 			);
 		} catch ( err ) {
+			//Sometimes the first click doesn't work. Clicking again
 			await driverHelper.clickWhenClickable(
-				this.driver,
-				this.declineGoogleAppsLinkSelector
-			);
-			await driverHelper.waitTillNotPresent(
 				this.driver,
 				this.declineGoogleAppsLinkSelector
 			);

--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -94,14 +94,14 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 	}
 
 	async declineGoogleApps() {
-		await driverHelper.clickWhenClickable(
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			this.declineGoogleAppsLinkSelector
+		);
+		return await driverHelper.clickWhenClickable(
 			this.driver,
 			this.declineGoogleAppsLinkSelector,
 			this.explicitWaitMS
-		);
-		return await driverHelper.waitTillNotPresent(
-			this.driver,
-			this.declineGoogleAppsLinkSelector
 		);
 	}
 

--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -98,6 +98,10 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 			this.driver,
 			this.declineGoogleAppsLinkSelector
 		);
+		await driverHelper.scrollIntoView(
+			this.driver,
+			this.declineGoogleAppsLinkSelector
+		);
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			this.declineGoogleAppsLinkSelector,

--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -94,6 +94,7 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 	}
 
 	async declineGoogleApps() {
+		this.driver.sleep(2000);
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			this.declineGoogleAppsLinkSelector,

--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -10,7 +10,7 @@ import * as driverHelper from '../driver-helper.js';
 export default class FindADomainComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.register-domain-step' ) );
-		this.declineGoogleAppsLinkSelector = By.css( 'button.google-apps-dialog__checkout-button' );
+		this.declineGoogleAppsLinkSelector = By.className( 'google-apps-dialog__checkout-button' );
 	}
 
 	async waitForResults() {

--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -103,7 +103,6 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 			this.driver,
 			this.declineGoogleAppsLinkSelector
 		);
-
 	}
 
 	selectAddEmailForGoogleApps() {

--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -94,11 +94,16 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 	}
 
 	async declineGoogleApps() {
-		return await driverHelper.clickWhenClickable(
+		await driverHelper.clickWhenClickable(
 			this.driver,
 			this.declineGoogleAppsLinkSelector,
 			this.explicitWaitMS
 		);
+		return await driverHelper.waitTillNotPresent(
+			this.driver,
+			this.declineGoogleAppsLinkSelector
+		);
+
 	}
 
 	selectAddEmailForGoogleApps() {

--- a/lib/components/find-a-domain-component.js
+++ b/lib/components/find-a-domain-component.js
@@ -10,7 +10,7 @@ import * as driverHelper from '../driver-helper.js';
 export default class FindADomainComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.register-domain-step' ) );
-		this.declineGoogleAppsLinkSelector = By.className( 'google-apps-dialog__checkout-button' );
+		this.declineGoogleAppsLinkSelector = By.css( 'button.google-apps-dialog__checkout-button' );
 	}
 
 	async waitForResults() {
@@ -94,14 +94,6 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 	}
 
 	async declineGoogleApps() {
-		await driverHelper.waitTillPresentAndDisplayed(
-			this.driver,
-			this.declineGoogleAppsLinkSelector
-		);
-		await driverHelper.scrollIntoView(
-			this.driver,
-			this.declineGoogleAppsLinkSelector
-		);
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			this.declineGoogleAppsLinkSelector,

--- a/lib/pages/domain-my-own-page.js
+++ b/lib/pages/domain-my-own-page.js
@@ -16,10 +16,6 @@ export default class MyOwnDomainPage extends AsyncBaseContainer {
 			this.driver,
 			buyMappingSelector
 		);
-		await driverHelper.scrollIntoView(
-			this.driver,
-			buyMappingSelector
-		);
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			buyMappingSelector

--- a/lib/pages/domain-my-own-page.js
+++ b/lib/pages/domain-my-own-page.js
@@ -11,9 +11,14 @@ export default class MyOwnDomainPage extends AsyncBaseContainer {
 	}
 
 	async selectBuyDomainMapping() {
+		const buyMappingSelector = By.css( '.use-your-domain-step__option-button:not(.is-primary)' );
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			buyMappingSelector
+		);
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.use-your-domain-step__option-button:not(.is-primary)' )
+			buyMappingSelector
 		);
 	}
 

--- a/lib/pages/domain-my-own-page.js
+++ b/lib/pages/domain-my-own-page.js
@@ -16,6 +16,10 @@ export default class MyOwnDomainPage extends AsyncBaseContainer {
 			this.driver,
 			buyMappingSelector
 		);
+		await driverHelper.scrollIntoView(
+			this.driver,
+			buyMappingSelector
+		);
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			buyMappingSelector

--- a/lib/pages/domain-my-own-page.js
+++ b/lib/pages/domain-my-own-page.js
@@ -11,14 +11,9 @@ export default class MyOwnDomainPage extends AsyncBaseContainer {
 	}
 
 	async selectBuyDomainMapping() {
-		const buyMappingSelector = By.css( '.use-your-domain-step__option-button:not(.is-primary)' );
-		await driverHelper.waitTillPresentAndDisplayed(
-			this.driver,
-			buyMappingSelector
-		);
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			buyMappingSelector
+			By.css( '.use-your-domain-step__option-button:not(.is-primary)' )
 		);
 	}
 

--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -59,7 +59,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function(
 		} );
 
 		step( 'Log In and Select Domains', async function() {
-			return await new LoginFlow( driver ).loginAndSelectDomains();
+			return await new LoginFlow( driver, 'gutenbergSimpleSiteUser' ).loginAndSelectDomains();
 		} );
 
 		step( 'Can see the Domains page and choose add a domain', async function() {

--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -132,7 +132,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function(
 		} );
 
 		step( 'Log In and Select Domains', async function() {
-			return await new LoginFlow( driver ).loginAndSelectDomains();
+			return await new LoginFlow( driver, 'gutenbergSimpleSiteUser' ).loginAndSelectDomains();
 		} );
 
 		step( 'Can see the Domains page and choose add a domain', async function() {

--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -268,7 +268,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize })`, function() {
 		} );
 
 		step( 'Can see the transfer precheck page', async function() {
-			return await TransferDomainPrecheckPage.Expect( driver,  );
+			return await TransferDomainPrecheckPage.Expect( driver );
 		} );
 	} );
 } );

--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -39,10 +39,10 @@ before( async function() {
 	driver = await driverManager.startBrowser();
 } );
 
-describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function() {
+describe( `[${ host }] Managing Domains: (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
-	describe( 'Adding a domain to an existing site ', function() {
+	describe( 'Adding a domain to an existing site @parallel', function() {
 		const blogName = dataHelper.getNewBlogName();
 		const domainEmailAddress = dataHelper.getEmailAddress( blogName, domainsInboxId );
 		const expectedDomainName = blogName + '.com';
@@ -132,7 +132,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function(
 		} );
 
 		step( 'Log In and Select Domains', async function() {
-			return await new LoginFlow( driver, 'gutenbergSimpleSiteUser' ).loginAndSelectDomains();
+			return await new LoginFlow( driver ).loginAndSelectDomains();
 		} );
 
 		step( 'Can see the Domains page and choose add a domain', async function() {

--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -132,7 +132,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize })`, function() {
 		} );
 
 		step( 'Log In and Select Domains', async function() {
-			return await new LoginFlow( driver ).loginAndSelectDomains();
+			return await new LoginFlow( driver, 'gutenbergSimpleSiteUser' ).loginAndSelectDomains();
 		} );
 
 		step( 'Can see the Domains page and choose add a domain', async function() {
@@ -268,7 +268,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize })`, function() {
 		} );
 
 		step( 'Can see the transfer precheck page', async function() {
-			return await TransferDomainPrecheckPage.Expect( driver );
+			return await TransferDomainPrecheckPage.Expect( driver,  );
 		} );
 	} );
 } );

--- a/specs/wp-manage-domains-spec.js
+++ b/specs/wp-manage-domains-spec.js
@@ -59,7 +59,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function(
 		} );
 
 		step( 'Log In and Select Domains', async function() {
-			return await new LoginFlow( driver, 'gutenbergSimpleSiteUser' ).loginAndSelectDomains();
+			return await new LoginFlow( driver ).loginAndSelectDomains();
 		} );
 
 		step( 'Can see the Domains page and choose add a domain', async function() {


### PR DESCRIPTION
This one took some time to get figured out, but it came down to 3 different issues:

1. The first and second tests would occasionally conflict with each other when running in parallel. The clearing of the cart in one test would clear the cart in the other test and mess up the flow. I used a different test user in one of the tests to clear that up.

2. Sometimes clicking on the button to decline Google Apps would not do anything. I added a catch to retry it if things didn't progress.

3. The parallel tag was on the whole suite in addition to two of the three tests. This caused some funkiness in results and conflicting tests since the suite would run all three tests and the other two tests would also run. 