### PR TITLE
Remove and address sleep statement in `about-page.js`

### DIFF
--- a/lib/pages/signup/about-page.js
+++ b/lib/pages/signup/about-page.js
@@ -11,11 +11,9 @@ export default class AboutPage extends AsyncBaseContainer {
 	}
 
 	async submitForm() {
-		await this.driver.sleep( 5000 ); // This is necessary to allow continue button to be enabled on mobile
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.about__submit-wrapper button.is-primary' )
-		);
+		const submitSelector = By.css( '.about__submit-wrapper button.is-primary' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, submitSelector );
+		return await driverHelper.clickWhenClickable( this.driver, submitSelector );
 	}
 
 	async enterSiteDetails(


### PR DESCRIPTION
Removed `sleep` statement and addressed it by using `waitTillPresentAndDisplayed` instead. Previously, there was no check on the page whether the button was present and displayed. `waitTillPresentAndDisplayed` provides that check.

Note that the `sleep` was there for 5 seconds necessary to allow `continue` button to be enabled on mobile. I tested my change extensively on mobile - tests were always passing with `waitTillPresentAndDisplayed`. 

**To test:**

The change affects `wp-signup-spec.js` and `wp-manage-domains-spec.js`. The `sleep` was added to address the issue that was present on mobile. Please make sure tests are passing on mobile. 