### PR TITLE
Remove and address sleep statement in `wizard-navigation-component.js`

### DIFF
--- a/lib/components/wizard-navigation-component.js
+++ b/lib/components/wizard-navigation-component.js
@@ -9,7 +9,14 @@ import * as driverHelper from '../driver-helper.js';
 export default class WizardNavigationComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.wizard__navigation-links' ) );
-		driver.sleep( 1000 );
+	}
+
+	async _postInit() {
+		return await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( 'a.wizard__navigation-link' ),
+			this.explicitWaitMS
+		);
 	}
 
 	async goBack() {


### PR DESCRIPTION
Removed `sleep` statement and addressed it by using `_postInit()` function which adds an extra check to make sure that `.wizard__navigation-links` are displayed. 

**To test:**

The change affects `wp-jetpack-onboarding-spec.js` and `wp-jetpack-plugins-spec.js`.