### PR TITLE
Remove and address sleep statement with new `waitTillSelected` method in `site-type-page.js`

### DIFF
--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -131,6 +131,32 @@ export function waitTillPresentAndDisplayed( driver, selector, waitOverride ) {
 	);
 }
 
+export function waitTillSelected( driver, selector, waitOverride ) {
+	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
+
+	return driver.wait(
+		function() {
+			return driver.findElement( selector ).then(
+				function( element ) {
+					return element.isSelected().then(
+						function() {
+							return true;
+						},
+						function() {
+							return false;
+						}
+					);
+				},
+				function() {
+					return false;
+				}
+			);
+		},
+		timeoutWait,
+		`Timed out waiting for element with ${ selector.using } of '${ selector.value }' to be selected`
+	);
+}
+
 export function isEventuallyPresentAndDisplayed( driver, selector, waitOverride ) {
 	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
 

--- a/lib/pages/signup/site-type-page.js
+++ b/lib/pages/signup/site-type-page.js
@@ -11,8 +11,9 @@ export default class SiteTypePage extends AsyncBaseContainer {
 	}
 
 	async _selectType( type ) {
-		await driverHelper.setCheckbox( this.driver, By.css( `input.form-radio[value='${ type }']` ) );
-		return await this.driver.sleep( 1000 );
+		const radioButtonSelector = By.css( `input.form-radio[value='${ type }']` );
+		await driverHelper.setCheckbox( this.driver, radioButtonSelector );
+		return await driverHelper.waitTillSelected( this.driver, radioButtonSelector );
 	}
 
 	async selectBlogType() {


### PR DESCRIPTION
Removed `sleep` statement and addressed it by using a new `waitTillSelected` driverHelper method. 

`waitTillSelected` waits until the element had been selected which works great for radio buttons. 

I tested the original code without a `sleep` statement - the test was failing (waiting for the button to be clickable which is a part of the `setCheckbox` method). `sleep` adds the necessary wait time. Replacing `sleep` with `waitTillSelected` works great. 

**To test:**

The change affects `wp-signup-spec.js`.