### PR TITLE
Remove and address sleep statements in `wp-jetpack-plans-spec.js`

### DIFF
--- a/lib/pages/jetpack-plans-sales-page.js
+++ b/lib/pages/jetpack-plans-sales-page.js
@@ -12,6 +12,7 @@ export default class JetpackPlansSalesPage extends AsyncBaseContainer {
 
 	async clickPurchaseButton() {
 		const selector = By.css( '.cta-install #btn-mast-getstarted' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 }

--- a/lib/pages/wp-admin/wp-admin-jetpack-page.js
+++ b/lib/pages/wp-admin/wp-admin-jetpack-page.js
@@ -33,6 +33,7 @@ export default class WPAdminJetpackPage extends AsyncBaseContainer {
 
 	async clickUpgradeNudge() {
 		const selector = By.css( '.dops-notice a[href*="upgrade"]' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 

--- a/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -65,13 +65,11 @@ describe( `[${ host }] Jetpack Plans: (${ screenSize }) @jetpack`, function() {
 		step( 'Can find and click Upgrade nudge button', async function() {
 			await driverHelper.refreshIfJNError( driver );
 			const jetpackDashboard = await WPAdminJetpackPage.Expect( driver );
-			await driver.sleep( 3000 ); // The nudge buttons are loaded after the page, and there's no good loaded status indicator to key off of
 			return await jetpackDashboard.clickUpgradeNudge();
 		} );
 
 		step( 'Can click the Proceed button', async function() {
 			const jetpackPlanSalesPage = await JetpackPlanSalesPage.Expect( driver );
-			await driver.sleep( 3000 ); // The upgrade buttons are loaded after the page, and there's no good loaded status indicator to key off of
 			return await jetpackPlanSalesPage.clickPurchaseButton();
 		} );
 


### PR DESCRIPTION
Removed 2 `sleep` statements and addressed it by using `waitTillPresentAndDislplayed` in respective functions:

- updated `clickUpgradeNudge()` in `wp-admin-jetpack-page.js`
- updated `clickPurchaseButton()` in `jetpack-plans-sales-page.js`

`waitTillPresentAndDislplayed` adds the necessary check to make sure that both buttons are displayed and ready to be clicked on. 

**To test:**

The change affects `wp-jetpack-plans-spec.js`. 