### PR TITLE
Put back classic editor comment test

### DIFF
--- a/specs/wp-comments-spec.js
+++ b/specs/wp-comments-spec.js
@@ -72,7 +72,7 @@ describe( `[${ host }] Comments: (${ screenSize })`, function() {
 			);
 		} );
 	} );
-  
+
 	describe( 'Commenting and replying to newly created post in Gutenberg Editor: @parallel', function() {
 		step( 'Can login and create a new post', async function() {
 			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );

--- a/specs/wp-comments-spec.js
+++ b/specs/wp-comments-spec.js
@@ -6,6 +6,8 @@ import * as driverManager from '../lib/driver-manager';
 import * as dataHelper from '../lib/data-helper';
 import * as mediaHelper from '../lib/media-helper';
 import LoginFlow from '../lib/flows/login-flow';
+import EditorPage from '../lib/pages/editor-page';
+import PostEditorToolbarComponent from '../lib/components/post-editor-toolbar-component';
 import CommentsAreaComponent from '../lib/pages/frontend/comments-area-component';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 
@@ -34,7 +36,44 @@ describe( `[${ host }] Comments: (${ screenSize })`, function() {
 		return fileDetails;
 	} );
 
-	describe( 'Commenting and replying to newly created post in Gutenberg Editor: @parallel @jetpack', function() {
+	describe( 'Commenting and replying to newly created post: @parallel @jetpack', function() {
+		step( 'Can login and create a new post', async function() {
+			await new LoginFlow( driver ).loginAndStartNewPost();
+			const editorPage = await EditorPage.Expect( driver );
+			await editorPage.enterTitle( blogPostTitle );
+			await editorPage.enterContent( blogPostQuote + '\n' );
+		} );
+
+		step( 'Can publish and visit site', async function() {
+			const postEditorToolbar = await PostEditorToolbarComponent.Expect( driver );
+			await postEditorToolbar.ensureSaved();
+			await postEditorToolbar.publishAndViewContent( { useConfirmStep: true } );
+		} );
+
+		step( 'Can post a comment', async function() {
+			const commentArea = await CommentsAreaComponent.Expect( driver );
+			return await commentArea._postComment( {
+				comment: dataHelper.randomPhrase(),
+				name: 'e2eTestName',
+				email: 'e2eTestName@test.com',
+			} );
+		} );
+
+		step( 'Can post a reply', async function() {
+			await driver.sleep( 10000 ); // Wait to not to post too quickly
+			const commentArea = await CommentsAreaComponent.Expect( driver );
+			await commentArea.reply(
+				{
+					comment: dataHelper.randomPhrase(),
+					name: 'e2eTestName',
+					email: 'e2eTestName@test.com',
+				},
+				2
+			);
+		} );
+	} );
+
+	describe( 'Commenting and replying to newly created post in Gutenberg Editor: @parallel', function() {
 		step( 'Can login and create a new post', async function() {
 			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
 			await this.loginFlow.loginAndStartNewPost( null, true );


### PR DESCRIPTION
Changes in https://github.com/Automattic/wp-e2e-tests/pull/1729 caused that comments test is not passing for jetpack sites. I've removed `@jetpack` tag from `Commenting and replying to newly created post in Gutenberg Editor:` and put back test `Commenting and replying to newly created post:`.

To test: 
Make sure that `wp-comments-spec.js` is passing against jetpack sites. 