### PR TITLE
Remove and address `sleep` statement in `wp-admin-jetpack-page.js`

### DIFF
--- a/lib/pages/wp-admin/wp-admin-jetpack-page.js
+++ b/lib/pages/wp-admin/wp-admin-jetpack-page.js
@@ -16,11 +16,11 @@ export default class WPAdminJetpackPage extends AsyncBaseContainer {
 
 	async connectWordPressCom() {
 		const selector = By.css( 'a.jp-jetpack-connect__button' );
-		const pauseBetweenFocusAttempts = 200;
+		const pauseBetweenFocusAttemptsMS = 200;
 		const connectJetpackButtonFocus =
 			"document.getElementsByClassName( 'jp-jetpack-connect__button')[0].focus();";
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
-		for ( let i = 0; i < explicitWaitMS / pauseBetweenFocusAttempts; i++ ) {
+		for ( let i = 0; i < explicitWaitMS / pauseBetweenFocusAttemptsMS; i++ ) {
 			await this.driver.executeScript( connectJetpackButtonFocus );
 			let currentActiveElementId = await this.driver
 				.switchTo()
@@ -31,7 +31,7 @@ export default class WPAdminJetpackPage extends AsyncBaseContainer {
 			if ( connectJetpackButtonId === currentActiveElementId ) {
 				break;
 			}
-			await this.driver.sleep( pauseBetweenFocusAttempts );
+			await this.driver.sleep( pauseBetweenFocusAttemptsMS );
 		}
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}

--- a/lib/pages/wp-admin/wp-admin-jetpack-page.js
+++ b/lib/pages/wp-admin/wp-admin-jetpack-page.js
@@ -4,6 +4,9 @@ import { By } from 'selenium-webdriver';
 
 import * as driverHelper from '../../driver-helper';
 import AsyncBaseContainer from '../../async-base-container';
+import config from 'config';
+
+const explicitWaitMS = config.get( 'explicitWaitMS' );
 
 export default class WPAdminJetpackPage extends AsyncBaseContainer {
 	constructor( driver ) {
@@ -13,8 +16,23 @@ export default class WPAdminJetpackPage extends AsyncBaseContainer {
 
 	async connectWordPressCom() {
 		const selector = By.css( 'a.jp-jetpack-connect__button' );
+		const pauseBetweenFocusAttempts = 200;
+		const connectJetpackButtonFocus =
+			"document.getElementsByClassName( 'jp-jetpack-connect__button')[0].focus();";
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
-		await this.driver.sleep( 1000 );
+		for ( let i = 0; i < explicitWaitMS / pauseBetweenFocusAttempts; i++ ) {
+			await this.driver.executeScript( connectJetpackButtonFocus );
+			let currentActiveElementId = await this.driver
+				.switchTo()
+				.activeElement()
+				.getId();
+			let connectJetpackButtonId = await ( await this.driver.findElement( selector ) ).getId();
+
+			if ( connectJetpackButtonId === currentActiveElementId ) {
+				break;
+			}
+			await this.driver.sleep( pauseBetweenFocusAttempts );
+		}
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 


### PR DESCRIPTION
Removed and addressed `sleep` statement with a `for` loop that checks if the `Connect Jetpack` button ID matches with the currently active element ID (element in focus). 

I used the JavaScriptExecutor to get the focus on the button - as far as I know, there is no other way to do it using webdriver. JavaScriptExecutor is not ideal because it doesn't return anything (or rather returns `undefined`) but it does the job when the action needs to be made.

I also looked at doing the following:

1) Rewrite existing `waitTillFocused` function but I didn't want to use JavaScriptExecutor in it (for the reason described above) so I passed on that option;

2) Make a separate function out of the loop I wrote but the JavaScriptExecutor stopped me again. It gets the element using `getElementsByClassName` which can not always be applied to all elements. I passed on this option as well. 

After considering the 2 options above, I decided to leave the loop as one-time use. 

**To test:**

The change affects the following specs:

- `wp-jetpack-onboarding-spec.js`
- `wp-jetpack-connect-spec.js`
- `connect-disconnect-spec.js`
- `jetpack-connect-flow.js` which is a part of `gutenberg-markdown-block-spec.js`