### PR TITLE
Remove and address `sleep` statement in `secure-payment-component.js`

### DIFF
--- a/lib/components/secure-payment-component.js
+++ b/lib/components/secure-payment-component.js
@@ -21,7 +21,12 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 	}
 
 	async _postInit() {
-		await this.driver.sleep( 5000 ); // This is to wait for products to settle down during sign up see - https://github.com/Automattic/wp-calypso/issues/24579
+		// This is to wait for products to settle down during sign up see - https://github.com/Automattic/wp-calypso/issues/24579
+		return await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.checkout__payment-box-container' ),
+			this.explicitWaitMS
+		);
 	}
 
 	async enterTestCreditCardDetails( {


### PR DESCRIPTION
Removed `sleep` statement in `_postInit()` function and addressed it by using `waitTillPresentAndDisplayed` which adds an extra check to make sure that payment form is displayed. 

**To test:**

The change affects `wp-plan-purchase-spec.js`. 