### PR TITLE
Remove parallel tag from "Plans" test

### DIFF
--- a/specs/wp-plan-purchase-spec.js
+++ b/specs/wp-plan-purchase-spec.js
@@ -26,7 +26,7 @@ before( async function() {
 	driver = await driverManager.startBrowser();
 } );
 
-describe( `[${ host }] Plans: (${ screenSize }) @parallel @jetpack`, function() {
+describe( `[${ host }] Plans: (${ screenSize }) @jetpack`, function() {
 	this.timeout( mochaTimeOut );
 
 	describe( 'Comparing Plans:', function() {


### PR DESCRIPTION
From time to time `Plans:` test is [failing](https://circleci.com/gh/Automattic/wp-e2e-tests/25475) on master branch on step `Remove any existing coupon`. Here are the screenshots from [failed test](https://25467-57936731-gh.circle-artifacts.com/1/home/circleci/wp-e2e-tests/screenshots/FAILED-EN-DESKTOP-remove-any-existing-coupon-1545848669328.png) on CircleCI and [same step](https://cloudup.com/cfwFYnKskBC) from local execution. My guess is, I'm not 100% sure, it's race condition somewhere. Removing `@parallel` tag will reduce noise from CircleCI while we find solution for this issue. 

To test:
Just be sure that test is not failing with same error on master branch.