### PR TITLE
Remove and address `sleep` statement in `editor-page.js`

### DIFF
--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -157,6 +157,32 @@ export function waitTillSelected( driver, selector, waitOverride ) {
 	);
 }
 
+export function waitTillEnabled( driver, selector, waitOverride ) {
+	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
+
+	return driver.wait(
+		function() {
+			return driver.findElement( selector ).then(
+				function( element ) {
+					return element.isEnabled().then(
+						function() {
+							return true;
+						},
+						function() {
+							return false;
+						}
+					);
+				},
+				function() {
+					return false;
+				}
+			);
+		},
+		timeoutWait,
+		`Timed out waiting for element with ${ selector.using } of '${ selector.value }' to be enabled`
+	);
+}
+
 export function isEventuallyPresentAndDisplayed( driver, selector, waitOverride ) {
 	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
 

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -240,7 +240,9 @@ export default class EditorPage extends AsyncBaseContainer {
 	}
 
 	async deleteMedia() {
-		await driverHelper.clickWhenClickable( this.driver, by.css( '.editor-media-modal__delete' ) );
+		const deleteSelector = by.css( '.editor-media-modal__delete' );
+		await driverHelper.waitTillEnabled( this.driver, deleteSelector );
+		await driverHelper.clickWhenClickable( this.driver, deleteSelector );
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			by.css( 'button[data-e2e-button="accept"]' )

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -68,7 +68,10 @@ export default class EditorPage extends AsyncBaseContainer {
 
 		await this.chooseInsertMediaOption();
 		await this.sendFile( newFile );
-		return await this.driver.sleep( 1000 );
+		return await driverHelper.waitTillEnabled(
+			this.driver,
+			by.css( 'button[data-e2e-button="confirm"]' )
+		);
 	}
 
 	async sendFile( file ) {
@@ -284,8 +287,10 @@ export default class EditorPage extends AsyncBaseContainer {
 	}
 
 	async errorDisplayed() {
-		await this.driver.sleep( 1000 );
-		return await driverHelper.isElementPresent( this.driver, by.css( '.notice.is-error' ) );
+		return await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			by.css( '.notice.is-error' )
+		);
 	}
 
 	async ensureContactFormDisplayedInPost() {

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -241,7 +241,9 @@ export default class EditorPage extends AsyncBaseContainer {
 
 	async deleteMedia() {
 		const deleteSelector = by.css( '.editor-media-modal__delete' );
+		const trashIconSelector = by.css( '.gridicon.gridicons-trash' );
 		await driverHelper.waitTillEnabled( this.driver, deleteSelector );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, trashIconSelector );
 		await driverHelper.clickWhenClickable( this.driver, deleteSelector );
 		return await driverHelper.clickWhenClickable(
 			this.driver,

--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -287,10 +287,8 @@ export default class EditorPage extends AsyncBaseContainer {
 	}
 
 	async errorDisplayed() {
-		return await driverHelper.waitTillPresentAndDisplayed(
-			this.driver,
-			by.css( '.notice.is-error' )
-		);
+		await this.driver.sleep( 1000 );
+		return await driverHelper.isElementPresent( this.driver, by.css( '.notice.is-error' ) );
 	}
 
 	async ensureContactFormDisplayedInPost() {


### PR DESCRIPTION
Removed and addressed `sleep` statement. See the explanation for the `sleep` statement removal in the comment below. 

In this PR, I also introduced a new driverHelper method `waitTillEnabled` - it finds the element and waits for it to be enabled utilizing `isEnabled()`. 

`isEnabled()` - tests whether this element is enabled, as dictated by the `disabled` attribute of the element.

`waitTillEnabled` can be applied to regular buttons. 

**To test:**

The changes affect `wp-media-upload-spec.js`. 
