### PR TITLE
Remove and address 2 sleep statements in `post-editor-sidebar-component.js`

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -97,10 +97,10 @@ export default class PostEditorSidebarComponent extends AsyncBaseContainer {
 		const saveCategoryButtonSelector = By.css( 'div.dialog__action-buttons button.is-primary' );
 		const driver = this.driver;
 
-		driver.sleep( 500 );
+		await driverHelper.waitTillPresentAndDisplayed( driver, addNewCategoryButtonSelector );
 		await driverHelper.clickWhenClickable( driver, addNewCategoryButtonSelector );
 		await driverHelper.waitForFieldClearable( driver, categoryNameInputSelector );
-		driver.sleep( 500 );
+		await driverHelper.waitTillFocused( driver, categoryNameInputSelector );
 		await driverHelper.setWhenSettable( driver, categoryNameInputSelector, category );
 		await driverHelper.clickWhenClickable( driver, saveCategoryButtonSelector );
 		return await driverHelper.waitTillNotPresent( driver, saveCategoryButtonSelector );


### PR DESCRIPTION
In this PR, I removed and addressed 2 `sleep` statements:

- the first `sleep` is addressed by using `waitTillPresentAndDispplayed` which provides the necessary wait time to make sure the `Add new category` button is displayed;

- the second `sleep` is addressed by using `waitTillFocused` which provides the wait time to make sure the `Category name input` field is in focus which is needed prior to being able to enter the category name in the next step. 

**To test:**

The change affects `wp-calypso-gutenberg-post-editor-spec.js`. 