### PR TITLE
Replace the checklist with the site preview as the first thing after signing up

### DIFF
--- a/lib/components/site-preview-component.js
+++ b/lib/components/site-preview-component.js
@@ -1,0 +1,43 @@
+/** @format */
+
+import { By, until } from 'selenium-webdriver';
+import config from 'config';
+
+import AsyncBaseContainer from '../async-base-container';
+import * as driverHelper from '../driver-helper.js';
+
+class SitePreviewComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.preview.main' ) );
+	}
+
+	async toolbar() {
+		return this.driver.findElement( By.css( '.web-preview__toolbar' ) );
+	}
+
+	async contentPlaceholder() {
+		return this.driver.findElement( By.css( '.web-preview__placeholder' ) );
+	}
+
+	async switchToEmbeddedSitePreview() {
+		const iFrameSelector = By.css( '.web-preview__frame' );
+		const explicitWaitMS = config.get( 'explicitWaitMS' );
+
+		await this.driver.switchTo().defaultContent();
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.web-preview__inner.is-visible.is-loaded' )
+		);
+		return this.driver.wait(
+			until.ableToSwitchToFrame( iFrameSelector ),
+			explicitWaitMS,
+			'Could not switch to web preview iFrame'
+		);
+	}
+
+	async siteBody() {
+		return this.driver.findElement( By.css( 'body.home' ) );
+	}
+}
+
+export default SitePreviewComponent;

--- a/lib/components/site-preview-component.js
+++ b/lib/components/site-preview-component.js
@@ -19,7 +19,7 @@ class SitePreviewComponent extends AsyncBaseContainer {
 		return this.driver.findElement( By.css( '.web-preview__placeholder' ) );
 	}
 
-	async switchToEmbeddedSitePreview() {
+	async switchToIFrame() {
 		const iFrameSelector = By.css( '.web-preview__frame' );
 		const explicitWaitMS = config.get( 'explicitWaitMS' );
 

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -36,7 +36,6 @@ import GSuiteUpsellPage from '../lib/pages/gsuite-upsell-page';
 import ThemesPage from '../lib/pages/themes-page';
 import ThemeDetailPage from '../lib/pages/theme-detail-page';
 import DesignTypePage from '../lib/pages/signup/design-type-page';
-import ChecklistPage from '../lib/pages/checklist-page';
 import SettingsPage from '../lib/pages/settings-page';
 import ImportPage from '../lib/pages/import-page';
 
@@ -193,7 +192,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Sign up for a free site, see the onboarding checklist, activate email and can publish @parallel', function() {
+	describe( 'Sign up for a free site, see the site preview, activate email and can publish @parallel', function() {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
@@ -251,14 +250,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			}
 		);
 
-		step( 'Can then see the onboarding checklist', async function() {
-			const checklistPage = await ChecklistPage.Expect( driver );
-			const header = await checklistPage.headerExists();
-			const subheader = await checklistPage.subheaderExists();
+		step( 'Can then see the site preview', async function() {
+			const sitePreviewComponent = await SitePreviewComponent.Expect( driver );
 
-			assert( header, 'The checklist header does not exist.' );
+			const toolbar = await sitePreviewComponent.toolbar();
+			const placeholder = await sitePreviewComponent.contentPlaceholder();
 
-			return assert( subheader, 'The checklist subheader does not exist.' );
+			assert( toolbar, 'The preview toolbar does not exist.' );
+			assert( placeholder, 'The preview content placeholder does not exist.' );
+			await sitePreviewComponent.switchToIFrame();
+
+			const siteBody = await sitePreviewComponent.siteBody();
+
+			return assert( siteBody, 'The site body does not appear in the iframe.' );
 		} );
 
 		step( 'Can delete our newly created account', async function() {
@@ -503,14 +507,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		step( 'Can then see the onboarding checklist', async function() {
-			const checklistPage = await ChecklistPage.Expect( driver );
-			const header = await checklistPage.headerExists();
-			const subheader = await checklistPage.subheaderExists();
+		step( 'Can then see the site preview', async function() {
+			const sitePreviewComponent = await SitePreviewComponent.Expect( driver );
 
-			assert( header, 'The checklist header does not exist.' );
+			const toolbar = await sitePreviewComponent.toolbar();
+			const placeholder = await sitePreviewComponent.contentPlaceholder();
 
-			return assert( subheader, 'The checklist subheader does not exist.' );
+			assert( toolbar, 'The preview toolbar does not exist.' );
+			assert( placeholder, 'The preview content placeholder does not exist.' );
+			await sitePreviewComponent.switchToIFrame();
+
+			const siteBody = await sitePreviewComponent.siteBody();
+
+			return assert( siteBody, 'The site body does not appear in the iframe.' );
 		} );
 
 		step( 'Can delete the plan', async function() {
@@ -630,14 +639,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		step( 'Can then see the onboarding checklist', async function() {
-			const checklistPage = await ChecklistPage.Expect( driver );
-			const header = await checklistPage.headerExists();
-			const subheader = await checklistPage.subheaderExists();
+		step( 'Can then see the site preview', async function() {
+			const sitePreviewComponent = await SitePreviewComponent.Expect( driver );
 
-			assert( header, 'The checklist header does not exist.' );
+			const toolbar = await sitePreviewComponent.toolbar();
+			const placeholder = await sitePreviewComponent.contentPlaceholder();
 
-			return assert( subheader, 'The checklist subheader does not exist.' );
+			assert( toolbar, 'The preview toolbar does not exist.' );
+			assert( placeholder, 'The preview content placeholder does not exist.' );
+			await sitePreviewComponent.switchToIFrame();
+
+			const siteBody = await sitePreviewComponent.siteBody();
+
+			return assert( siteBody, 'The site body does not appear in the iframe.' );
 		} );
 
 		step( 'Can delete the plan', async function() {
@@ -757,14 +771,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		step( 'Can then see the onboarding checklist', async function() {
-			const checklistPage = await ChecklistPage.Expect( driver );
-			const header = await checklistPage.headerExists();
-			const subheader = await checklistPage.subheaderExists();
+		step( 'Can then see the site preview', async function() {
+			const sitePreviewComponent = await SitePreviewComponent.Expect( driver );
 
-			assert( header, 'The checklist header does not exist.' );
+			const toolbar = await sitePreviewComponent.toolbar();
+			const placeholder = await sitePreviewComponent.contentPlaceholder();
 
-			return assert( subheader, 'The checklist subheader does not exist.' );
+			assert( toolbar, 'The preview toolbar does not exist.' );
+			assert( placeholder, 'The preview content placeholder does not exist.' );
+			await sitePreviewComponent.switchToIFrame();
+
+			const siteBody = await sitePreviewComponent.siteBody();
+
+			return assert( siteBody, 'The site body does not appear in the iframe.' );
 		} );
 
 		step( 'Can delete the plan', async function() {
@@ -1134,14 +1153,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await gSuiteUpsellPage.declineEmail();
 		} );
 
-		step( 'Can then see the onboarding checklist', async function() {
-			const checklistPage = await ChecklistPage.Expect( driver );
-			const header = await checklistPage.headerExists();
-			const subheader = await checklistPage.subheaderExists();
+		step( 'Can then see the site preview', async function() {
+			const sitePreviewComponent = await SitePreviewComponent.Expect( driver );
 
-			assert( header, 'The checklist header does not exist.' );
+			const toolbar = await sitePreviewComponent.toolbar();
+			const placeholder = await sitePreviewComponent.contentPlaceholder();
 
-			return assert( subheader, 'The checklist subheader does not exist.' );
+			assert( toolbar, 'The preview toolbar does not exist.' );
+			assert( placeholder, 'The preview content placeholder does not exist.' );
+			await sitePreviewComponent.switchToIFrame();
+
+			const siteBody = await sitePreviewComponent.siteBody();
+
+			return assert( siteBody, 'The site body does not appear in the iframe.' );
 		} );
 
 		step( 'Can delete the plan', async function() {
@@ -1431,13 +1455,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			}
 		);
 
-		step( 'Can then see the onboarding checklist', async function() {
-			const checklistPage = await ChecklistPage.Expect( driver );
-			const header = await checklistPage.headerExists();
-			const subheader = await checklistPage.subheaderExists();
+		step( 'Can then see the site preview', async function() {
+			const sitePreviewComponent = await SitePreviewComponent.Expect( driver );
 
-			assert( header, 'The checklist header does not exist.' );
-			return assert( subheader, 'The checklist subheader does not exist.' );
+			const toolbar = await sitePreviewComponent.toolbar();
+			const placeholder = await sitePreviewComponent.contentPlaceholder();
+
+			assert( toolbar, 'The preview toolbar does not exist.' );
+			assert( placeholder, 'The preview content placeholder does not exist.' );
+			await sitePreviewComponent.switchToIFrame();
+
+			const siteBody = await sitePreviewComponent.siteBody();
+
+			return assert( siteBody, 'The site body does not appear in the iframe.' );
 		} );
 
 		step( 'Can delete site', async function() {
@@ -1533,14 +1563,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			}
 		);
 
-		step( 'Can then see the onboarding checklist', async function() {
-			const checklistPage = await ChecklistPage.Expect( driver );
-			const header = await checklistPage.headerExists();
-			const subheader = await checklistPage.subheaderExists();
+		step( 'Can then see the site preview', async function() {
+			const sitePreviewComponent = await SitePreviewComponent.Expect( driver );
 
-			assert( header, 'The checklist header does not exist.' );
+			const toolbar = await sitePreviewComponent.toolbar();
+			const placeholder = await sitePreviewComponent.contentPlaceholder();
 
-			return assert( subheader, 'The checklist subheader does not exist.' );
+			assert( toolbar, 'The preview toolbar does not exist.' );
+			assert( placeholder, 'The preview content placeholder does not exist.' );
+			await sitePreviewComponent.switchToIFrame();
+
+			const siteBody = await sitePreviewComponent.siteBody();
+
+			return assert( siteBody, 'The site body does not appear in the iframe.' );
 		} );
 
 		step( 'Can delete our newly created account', async function() {
@@ -1787,14 +1822,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await pickAPlanPage.selectFreePlan();
 		} );
 
-		step( 'Can then see the onboarding checklist', async function() {
-			const checklistPage = await ChecklistPage.Expect( driver );
-			const header = await checklistPage.headerExists();
-			const subheader = await checklistPage.subheaderExists();
+		step( 'Can then see the site preview', async function() {
+			const sitePreviewComponent = await SitePreviewComponent.Expect( driver );
 
-			assert( header, 'The checklist header does not exist.' );
+			const toolbar = await sitePreviewComponent.toolbar();
+			const placeholder = await sitePreviewComponent.contentPlaceholder();
 
-			return assert( subheader, 'The checklist subheader does not exist.' );
+			assert( toolbar, 'The preview toolbar does not exist.' );
+			assert( placeholder, 'The preview content placeholder does not exist.' );
+			await sitePreviewComponent.switchToIFrame();
+
+			const siteBody = await sitePreviewComponent.siteBody();
+
+			return assert( siteBody, 'The site body does not appear in the iframe.' );
 		} );
 
 		step( 'Can delete our newly created account', async function() {
@@ -1899,14 +1939,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await pickAPlanPage.selectFreePlan();
 		} );
 
-		step( 'Can then see the onboarding checklist', async function() {
-			const checklistPage = await ChecklistPage.Expect( driver );
-			const header = await checklistPage.headerExists();
-			const subheader = await checklistPage.subheaderExists();
+		step( 'Can then see the site preview', async function() {
+			const sitePreviewComponent = await SitePreviewComponent.Expect( driver );
 
-			assert( header, 'The checklist header does not exist.' );
+			const toolbar = await sitePreviewComponent.toolbar();
+			const placeholder = await sitePreviewComponent.contentPlaceholder();
 
-			return assert( subheader, 'The checklist subheader does not exist.' );
+			assert( toolbar, 'The preview toolbar does not exist.' );
+			assert( placeholder, 'The preview content placeholder does not exist.' );
+			await sitePreviewComponent.switchToIFrame();
+
+			const siteBody = await sitePreviewComponent.siteBody();
+
+			return assert( siteBody, 'The site body does not appear in the iframe.' );
 		} );
 
 		step( 'Can delete our newly created account', async function() {

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -46,6 +46,7 @@ import NavBarComponent from '../lib/components/nav-bar-component';
 import SideBarComponent from '../lib/components/sidebar-component';
 import NoSitesComponent from '../lib/components/no-sites-component';
 import SidebarComponent from '../lib/components/sidebar-component';
+import SitePreviewComponent from '../lib/components/site-preview-component.js';
 
 import * as SlackNotifier from '../lib/slack-notifier';
 
@@ -1149,7 +1150,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Basic sign up for a free site @parallel @email @ie11canary', function() {
+	describe.only( 'Basic sign up for a free site @parallel @email @ie11canary', function() {
 		const blogName = dataHelper.getNewBlogName();
 
 		before( async function() {
@@ -1206,14 +1207,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			}
 		);
 
-		step( 'Can then see the onboarding checklist', async function() {
-			const checklistPage = await ChecklistPage.Expect( driver );
-			const header = await checklistPage.headerExists();
-			const subheader = await checklistPage.subheaderExists();
+		step( 'Can then see the site preview', async function() {
+			const sitePreviewComponent = await SitePreviewComponent.Expect( driver );
 
-			assert( header, 'The checklist header does not exist.' );
+			const toolbar = await sitePreviewComponent.toolbar();
+			const placeholder = await sitePreviewComponent.contentPlaceholder();
 
-			return assert( subheader, 'The checklist subheader does not exist.' );
+			assert( toolbar, 'The preview toolbar does not exist.' );
+			assert( placeholder, 'The preview content placeholder does not exist.' );
+			await sitePreviewComponent.switchToIFrame();
+
+			const siteBody = await sitePreviewComponent.siteBody();
+
+			return assert( siteBody, 'The site body does not appear in the iframe.' );
 		} );
 	} );
 

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -140,14 +140,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			}
 		);
 
-		step( 'Can then see the onboarding checklist', async function() {
-			const checklistPage = await ChecklistPage.Expect( driver );
-			const header = await checklistPage.headerExists();
-			const subheader = await checklistPage.subheaderExists();
+		step( 'Can then see the site preview', async function() {
+			const sitePreviewComponent = await SitePreviewComponent.Expect( driver );
 
-			assert( header, 'The checklist header does not exist.' );
+			const toolbar = await sitePreviewComponent.toolbar();
+			const placeholder = await sitePreviewComponent.contentPlaceholder();
 
-			return assert( subheader, 'The checklist subheader does not exist.' );
+			assert( toolbar, 'The preview toolbar does not exist.' );
+			assert( placeholder, 'The preview content placeholder does not exist.' );
+			await sitePreviewComponent.switchToIFrame();
+
+			const siteBody = await sitePreviewComponent.siteBody();
+
+			return assert( siteBody, 'The site body does not appear in the iframe.' );
 		} );
 
 		step( 'Can log out and request a magic link', async function() {
@@ -1150,7 +1155,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe.only( 'Basic sign up for a free site @parallel @email @ie11canary', function() {
+	describe( 'Basic sign up for a free site @parallel @email @ie11canary', function() {
 		const blogName = dataHelper.getNewBlogName();
 
 		before( async function() {


### PR DESCRIPTION
### Summary

This PR attempts to update all the tests affected by the change introduced by https://github.com/Automattic/wp-calypso/pull/29031/ , which uses the site preview as the first view after signing up instead of the checklist.
