### PR TITLE
Remove 2 `sleep` statements in `wp-comments-spec.js`

### DIFF
--- a/specs/wp-comments-spec.js
+++ b/specs/wp-comments-spec.js
@@ -60,7 +60,6 @@ describe( `[${ host }] Comments: (${ screenSize })`, function() {
 		} );
 
 		step( 'Can post a reply', async function() {
-			await driver.sleep( 10000 ); // Wait to not to post too quickly
 			const commentArea = await CommentsAreaComponent.Expect( driver );
 			await commentArea.reply(
 				{
@@ -97,7 +96,6 @@ describe( `[${ host }] Comments: (${ screenSize })`, function() {
 		} );
 
 		step( 'Can post a reply', async function() {
-			await driver.sleep( 10000 ); // Wait to not to post too quickly
 			const commentArea = await CommentsAreaComponent.Expect( driver );
 			await commentArea.reply(
 				{


### PR DESCRIPTION
In this PR I removed 2 `sleep` statements from `Can post a reply` step. As discussed here https://github.com/Automattic/wp-e2e-tests/pull/1729#discussion_r243273748,  the idea was to address them by making sure the comment shows up prior to replying to it. 

I can see, however, that it is already implemented in `Can post a comment` step via `_postComment()` function. It ends with waiting for the comment content to be displayed. Once done, the spec moves on to `Can post a reply` step:

https://github.com/Automattic/wp-e2e-tests/blob/398724be39f074dc5dbeef4c76459750cee4c16f/lib/pages/frontend/comments-area-component.js#L41

This spec is good to go without `sleep` statemements as-is. 

**To test:**

The change affects `wp-comments-spec.js`. 