### PR TITLE
Remove `sleep` statement in `comments-area-component.js`

### DIFF
--- a/lib/pages/frontend/comments-area-component.js
+++ b/lib/pages/frontend/comments-area-component.js
@@ -58,7 +58,6 @@ export default class CommentsAreaComponent extends AsyncBaseContainer {
 			return false;
 		}
 		const iFrameSelector = By.css( 'iframe.jetpack_remote_comment' );
-		await this.driver.sleep( 1000 ); // To make sure that iFrame already there
 
 		await this.driver.switchTo().defaultContent();
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, iFrameSelector );


### PR DESCRIPTION
I removed `sleep` statement in this PR. I didn't replace it with anything as I think the `sleep` was not necessary because:

a) there is `waitTillPresentAndDisplayed()` that provides the wait time for the comment's iFrame to be displayed;
b) there is `ableToSwitchToFrame()` that has an `explicitWaitMS` (20 sec) to wait until able to switch to the comment's iFrame. 

With these 2 functions, there is enough wait time provided to make sure that iFrame is fully loaded prior to being intrectable with.

I tested without `sleep` numerous times - the test never failed. `sleep` was added in initial commit here: 

https://github.com/Automattic/wp-e2e-tests/pull/1406/files#diff-c257a3c87aa5c11e808c6014584111c7R66

There is no prior history where test failed without `sleep`. 

**To test:**

The change affects `wp-comments-spec.js`. 

The `sleep` was in `switchToFrameIfJetpack()` - in order to test it, you'd need to override Jetpack host. I used `export JETPACKHOST=PRESSABLE` and then `unset JETPACKHOST` when I was done.

<hr>

**Question:** 

There are commented out lines of code in `comments-area-component.js`:

1) here: https://github.com/Automattic/wp-e2e-tests/blob/master/lib/pages/frontend/comments-area-component.js#L23
2) here: https://github.com/Automattic/wp-e2e-tests/blob/master/lib/pages/frontend/comments-area-component.js#L32

It looks like it could be removed. Let me know if it is OK and I will push another commit in this PR to clean it up. 