### PR TITLE
Remove and address 2 `sleep` statements in `wp-calypso-gutenberg-post-editor-spec.js`

### DIFF
--- a/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -20,10 +20,7 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 		);
 	}
 	async selectDocumentTab() {
-		return await this.selectTab( 'Document' );
-	}
-
-	async waitTillComponentsPanelIsDisplayed() {
+		await this.selectTab( 'Document' );
 		return await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,
 			By.css( '.components-panel' )

--- a/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -23,6 +23,13 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 		return await this.selectTab( 'Document' );
 	}
 
+	async waitTillComponentsPanelIsDisplayed() {
+		return await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.components-panel' )
+		);
+	}
+
 	async expandStatusAndVisibility() {
 		return await this._expandOrCollapseSectionByText( 'Status & Visibility', true );
 	}

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -84,7 +84,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			await gEditorComponent.openSidebar();
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.selectDocumentTab();
-			await driver.sleep( 3000 );
+			await gEditorSidebarComponent.waitTillComponentsPanelIsDisplayed();
 			await gEditorSidebarComponent.collapseStatusAndVisibility(); // Status and visibility starts opened
 			await gEditorSidebarComponent.expandCategories();
 			await gEditorSidebarComponent.expandTags();
@@ -412,7 +412,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				await gEditorComponent.openSidebar();
 				const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 				await gEditorSidebarComponent.selectDocumentTab();
-				await driver.sleep( 3000 );
+				await gEditorSidebarComponent.waitTillComponentsPanelIsDisplayed();
 				await gEditorSidebarComponent.collapseStatusAndVisibility(); // Status and visibility starts opened
 				await gEditorSidebarComponent.expandDiscussion();
 				return await gEditorSidebarComponent.setCommentsPreference( { allow: true } );

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -84,7 +84,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			await gEditorComponent.openSidebar();
 			const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 			await gEditorSidebarComponent.selectDocumentTab();
-			await gEditorSidebarComponent.waitTillComponentsPanelIsDisplayed();
 			await gEditorSidebarComponent.collapseStatusAndVisibility(); // Status and visibility starts opened
 			await gEditorSidebarComponent.expandCategories();
 			await gEditorSidebarComponent.expandTags();
@@ -412,7 +411,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				await gEditorComponent.openSidebar();
 				const gEditorSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
 				await gEditorSidebarComponent.selectDocumentTab();
-				await gEditorSidebarComponent.waitTillComponentsPanelIsDisplayed();
 				await gEditorSidebarComponent.collapseStatusAndVisibility(); // Status and visibility starts opened
 				await gEditorSidebarComponent.expandDiscussion();
 				return await gEditorSidebarComponent.setCommentsPreference( { allow: true } );


### PR DESCRIPTION
In this PR I removed 2 `sleep` statements and addressed them by using new function `waitTillComponentsPanelIsDisplayed()`. 

Both `sleep` statements were introduced in the initial commit here: 

1) https://github.com/Automattic/wp-e2e-tests/pull/1652/files#diff-a831d02cf373c3e40058cda81fd99b67R85

2) https://github.com/Automattic/wp-e2e-tests/pull/1652/files#diff-a831d02cf373c3e40058cda81fd99b67R416

There is no history that shows failing tests without `sleep` statements. However, my guess is that they were added to make sure that components panel is ready to interact with when `Document` tab is selected on the sidebar. Therefore I wrote a new function `waitTillComponentsPanelIsDisplayed()` which waits for the components panel to be displayed. I replaced both `sleep` statements with the new function.

**To test:** 

The change affects `wp-calypso-gutenberg-post-editor-spec.js`. 