### PR TITLE
Clean up some unused Gutenberg code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ config/local-*
 
 # http://direnv.net
 .envrc
+/temp-cookies/

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -12,7 +12,6 @@ import NavBarComponent from '../components/nav-bar-component.js';
 
 import * as dataHelper from '../data-helper';
 import * as driverManager from '../driver-manager';
-import GutenbergEditorComponent from '../gutenberg/gutenberg-editor-component';
 import * as loginCookieHelper from '../login-cookie-helper';
 const host = dataHelper.getJetpackHost();
 
@@ -96,7 +95,7 @@ export default class LoginFlow {
 	async loginAndStartNewPost(
 		siteURL = null,
 		usingGutenberg = false,
-		{ forceCalypsoGutenberg = false, useFreshLogin = false } = {}
+		{ useFreshLogin = false } = {}
 	) {
 		if (
 			siteURL ||
@@ -110,12 +109,6 @@ export default class LoginFlow {
 		await ReaderPage.Expect( this.driver );
 		await NavBarComponent.Expect( this.driver );
 
-		if ( forceCalypsoGutenberg ) {
-			return await GutenbergEditorComponent.Visit(
-				this.driver,
-				GutenbergEditorComponent.getCalypsoGutenbergEditorPageURL( { type: 'post', site: siteURL } )
-			);
-		}
 		const navbarComponent = await NavBarComponent.Expect( this.driver );
 		await navbarComponent.clickCreateNewPost( { siteURL: siteURL } );
 
@@ -130,20 +123,13 @@ export default class LoginFlow {
 	async loginAndStartNewPage(
 		site = null,
 		usingGutenberg = false,
-		{ forceCalypsoGutenberg = false, useFreshLogin = false } = {}
+		{ useFreshLogin = false } = {}
 	) {
 		if ( site || ( host !== 'WPCOM' && this.account.legacyAccountName !== 'jetpackConnectUser' ) ) {
 			site = site || dataHelper.getJetpackSiteName();
 		}
 
 		await this.loginAndSelectMySite( site, { useFreshLogin: useFreshLogin } );
-
-		if ( forceCalypsoGutenberg ) {
-			return await GutenbergEditorComponent.Visit(
-				this.driver,
-				GutenbergEditorComponent.getCalypsoGutenbergEditorPageURL( { type: 'page', site: site } )
-			);
-		}
 
 		const sidebarComponent = await SidebarComponent.Expect( this.driver );
 		await sidebarComponent.selectAddNewPage();

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -2,7 +2,6 @@
 import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper';
 import * as driverManager from '../driver-manager.js';
-import * as dataHelper from '../data-helper';
 import AsyncBaseContainer from '../async-base-container';
 import { ContactFormBlockComponent } from './blocks/contact-form-block-component';
 import { ShortcodeBlockComponent } from './blocks/shortcode-block-component';
@@ -258,15 +257,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async closeScheduledPanel() {
 		await driverHelper.clickWhenClickable( this.driver, By.css( '.dashicons-no-alt' ) );
-	}
-
-	static getCalypsoGutenbergEditorPageURL( { type = 'post', site = null } ) {
-		if ( ! site ) {
-			site = '';
-		}
-		return dataHelper.getCalypsoURL( `block-editor/${ type }/${ site }`, [], {
-			forceWpCalypso: true,
-		} );
 	}
 
 	async submitForReview() {


### PR DESCRIPTION
This is the code that forced the specs to use wpcalypso.wordpress.com which is no longer necessary