### PR TITLE
Remove unused code

### DIFF
--- a/lib/pages/frontend/comments-area-component.js
+++ b/lib/pages/frontend/comments-area-component.js
@@ -19,23 +19,11 @@ export default class CommentsAreaComponent extends AsyncBaseContainer {
 		const commentContent = By.xpath( `//div[@class='comment-content']/p[.='${ comment }']` );
 
 		await this.switchToFrameIfJetpack();
-
-		// await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '#hc_post_as' ) );
-		// const isLoggedIn = await this.driver.findElement( By.css( '#hc_post_as' ) ).getAttribute( 'value' ) !== 'guest';
-
 		await driverHelper.clickWhenClickable( this.driver, commentForm );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, commentFormWordPress );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, submitButton );
 		await driverHelper.scrollIntoView( this.driver, submitButton );
 		await driverHelper.setWhenSettable( this.driver, commentField, comment );
-
-		// Not needed when logged in:
-		// await driverHelper.setWhenSettable( this.driver, By.css( '#author' ), name );
-		// await driverHelper.setWhenSettable( this.driver, By.css( '#email' ), email );
-		// if ( site ) {
-		// 	await driverHelper.setWhenSettable( this.driver, By.css( '#site' ), site );
-		// }
-
 		await driverHelper.clickWhenClickable( this.driver, submitButton );
 		await this.driver.switchTo().defaultContent();
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, commentContent );


### PR DESCRIPTION
In this PR I removed the code that was unused (commented out) as per conversation here: https://github.com/Automattic/wp-e2e-tests/pull/1748#issuecomment-450658280. 

**To test:**

I didn't change anything so there is really nothing to test but just in case, the comments area component is being used in `wp-comments-spec.js`. 