### PR TITLE
Fixing secure payment failures

### DIFF
--- a/lib/components/secure-payment-component.js
+++ b/lib/components/secure-payment-component.js
@@ -13,7 +13,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 			driver,
 			By.css( '.checkout__secure-payment-form,.secure-payment-form' ),
 			null,
-			2 * config.get( 'explicitWaitMS' )
+			config.get( 'explicitWaitMS' ) * 2
 		);
 		this.paymentButtonSelector = By.css(
 			'.credit-card-payment-box button.is-primary:not([disabled])'

--- a/lib/components/secure-payment-component.js
+++ b/lib/components/secure-payment-component.js
@@ -30,7 +30,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 		// This is to wait for products to settle down during sign up see - https://github.com/Automattic/wp-calypso/issues/24579
 		return await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,
-			By.css( '.checkout__payment-box-container' ),
+			this.paymentButtonSelector,
 			this.explicitWaitMS
 		);
 	}
@@ -219,7 +219,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 	}
 
 	async paymentButtonText() {
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.paymentButtonSelector, this.explicitWaitMS * 2 );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.paymentButtonSelector );
 		await driverHelper.scrollIntoView( this.driver, this.paymentButtonSelector );
 		return await this.driver.findElement( this.paymentButtonSelector ).getText();
 	}

--- a/lib/components/secure-payment-component.js
+++ b/lib/components/secure-payment-component.js
@@ -13,7 +13,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 			driver,
 			By.css( '.checkout__secure-payment-form,.secure-payment-form' ),
 			null,
-			config.get( 'explicitWaitMS' ) * 2
+			2 * config.get( 'explicitWaitMS' )
 		);
 		this.paymentButtonSelector = By.css(
 			'.credit-card-payment-box button.is-primary:not([disabled])'
@@ -72,7 +72,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 		const disabledPaymentButton = By.css( '.credit-card-payment-box button[disabled]' );
 
 		await driverHelper.waitTillNotPresent( this.driver, disabledPaymentButton );
-		return await driverHelper.clickWhenClickable( this.driver, this.paymentButtonSelector );
+		return await driverHelper.clickWhenClickable( this.driver, this.paymentButtonSelector, this.explicitWaitMS * 2 );
 	}
 
 	async waitForCreditCardPaymentProcessing() {

--- a/lib/components/secure-payment-component.js
+++ b/lib/components/secure-payment-component.js
@@ -72,7 +72,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 		const disabledPaymentButton = By.css( '.credit-card-payment-box button[disabled]' );
 
 		await driverHelper.waitTillNotPresent( this.driver, disabledPaymentButton );
-		return await driverHelper.clickWhenClickable( this.driver, this.paymentButtonSelector, this.explicitWaitMS * 2 );
+		return await driverHelper.clickWhenClickable( this.driver, this.paymentButtonSelector );
 	}
 
 	async waitForCreditCardPaymentProcessing() {
@@ -219,7 +219,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 	}
 
 	async paymentButtonText() {
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.paymentButtonSelector );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.paymentButtonSelector, this.explicitWaitMS * 2 );
 		await driverHelper.scrollIntoView( this.driver, this.paymentButtonSelector );
 		return await this.driver.findElement( this.paymentButtonSelector ).getText();
 	}


### PR DESCRIPTION
Two of the signup tests are failing fairly regularly with the error
`no such element: Unable to locate element: {"method":"css selector","selector":".credit-card-payment-box button.is-primary:not([disabled])"}`

This small change seems to fix that. I suspect the sleep removed in this file was masking it and we just needed to find the right selector to check for to ensure things are ready.

Tests that were failing:
- Sign Up (mobile, en) Sign up for a site on a personal paid plan coming in via /create as personal flow in GBP currency
- Sign Up (mobile, en) Sign up for a site on a premium paid plan coming in via /create as premium flow in JPY currency