### PR TITLE
Add test config for showConciergeSessionUpsellNonGSuite

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -69,7 +69,8 @@
 		"privateByDefault",
 		"jetpackFreePlanButtonPosition",
 		"removeUsername",
-		"showConciergeSessionUpsell"
+		"showConciergeSessionUpsell",
+		"showConciergeSessionUpsellNonGSuite"
 	],
 	"overrideABTests": [
 		[ "businessPlanDescriptionAT_20170605", "original" ],
@@ -82,6 +83,7 @@
 		[ "privateByDefault_20181113", "public" ],
 		[ "jetpackFreePlanButtonPosition_20181212", "locationBottom" ],
 		[ "removeUsername_20181213", "showUsername" ],
-		[ "showConciergeSessionUpsell_20181214", "skip" ]
+		[ "showConciergeSessionUpsell_20181214", "skip" ],
+		[ "showConciergeSessionUpsellNonGSuite_20181228", "skip" ]
 	]
 }


### PR DESCRIPTION
Add test config for the `showConciergeSessionUpsellNonGSuite` test.

Calypso PR: https://github.com/Automattic/wp-calypso/pull/29798