### PR TITLE
Signup: Update selector for new site-type step markup.

### DIFF
--- a/lib/pages/signup/site-type-page.js
+++ b/lib/pages/signup/site-type-page.js
@@ -23,7 +23,7 @@ export default class SiteTypePage extends AsyncBaseContainer {
 	async submitForm() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.site-type__submit-wrapper button.is-primary' )
+			By.css( '.site-type__wrapper button.is-primary' )
 		);
 	}
 }


### PR DESCRIPTION
This addresses the markup changes in Automattic/wp-calypso#29568

Update selector so that `[WPCOM] Sign Up (desktop, en) Sign up for an account only (no site) then add a site via new onboarding flow @parallel` will run.