### PR TITLE
Set the expected currency

### DIFF
--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -364,16 +364,15 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				await gSidebarComponent.trashPost();
 			} );
 
-			// Not working https://github.com/Automattic/wp-calypso/issues/28813
-			// step( 'Can then see the Posts page with a confirmation message', async function() {
-			// 	const postsPage = await PostsPage.Expect( driver );
-			// 	const displayed = await postsPage.successNoticeDisplayed();
-			// 	return assert.strictEqual(
-			// 		displayed,
-			// 		true,
-			// 		'The Posts page success notice for deleting the post is not displayed'
-			// 	);
-			// } );
+			step( 'Can then see the Posts page with a confirmation message', async function() {
+				const postsPage = await PostsPage.Expect( driver );
+				const displayed = await postsPage.successNoticeDisplayed();
+				return assert.strictEqual(
+					displayed,
+					true,
+					'The Posts page success notice for deleting the post is not displayed'
+				);
+			} );
 		} );
 	} );
 
@@ -756,7 +755,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	xdescribe( 'Trash Post: @parallel', function() {
+	describe( 'Trash Post: @parallel', function() {
 		describe( 'Trash a New Post', function() {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =
@@ -779,16 +778,15 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				return await gSidebarComponent.trashPost();
 			} );
 
-			// Not working https://github.com/Automattic/wp-calypso/issues/28813
-			// step( 'Can then see the Posts page with a confirmation message', async function() {
-			// 	const postsPage = await PostsPage.Expect( driver );
-			// 	const displayed = await postsPage.successNoticeDisplayed();
-			// 	return assert.strictEqual(
-			// 		displayed,
-			// 		true,
-			// 		'The Posts page success notice for deleting the post is not displayed'
-			// 	);
-			// } );
+			step( 'Can then see the Posts page with a confirmation message', async function() {
+				const postsPage = await PostsPage.Expect( driver );
+				const displayed = await postsPage.successNoticeDisplayed();
+				return assert.strictEqual(
+					displayed,
+					true,
+					'The Posts page success notice for deleting the post is not displayed'
+				);
+			} );
 		} );
 	} );
 

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -264,11 +264,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
+		const currencyValue = 'USD';
 		const expectedCurrencySymbol = '$';
 		let originalCartAmount;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
+		} );
+
+		step( 'We can set the sandbox cookie for payments', async function() {
+			const wPHomePage = await WPHomePage.Visit( driver );
+			await wPHomePage.checkURL( locale );
+			await wPHomePage.setSandboxModeForPayments( sandboxCookieValue );
+			return await wPHomePage.setCurrencyForPayments( currencyValue );
 		} );
 
 		step( 'Can visit the start page', async function() {

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1805,7 +1805,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Sign up for an account only (no site) then add a site via new onboarding flow @parallel', () => {
+	describe.only( 'Sign up for an account only (no site) then add a site via new onboarding flow @parallel', () => {
 		const userName = dataHelper.getNewBlogName();
 		const blogName = dataHelper.getNewBlogName();
 		let undo = null;

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1784,7 +1784,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe.only( 'Sign up for an account only (no site) then add a site via new onboarding flow @parallel', () => {
+	describe( 'Sign up for an account only (no site) then add a site via new onboarding flow @parallel', () => {
 		const userName = dataHelper.getNewBlogName();
 		const blogName = dataHelper.getNewBlogName();
 		let undo = null;


### PR DESCRIPTION
## Summary

This PR adds the expected currency through `setCurrencyForPayments()` for the `Sign up for a non-blog site on a premium paid plan through main flow in USD currency using a coupon` test, so that the test result won't be affected due to geo IP.

## How to reproduce

1. Use a VPN to change your IP address to somewhere non-US, e.g. Japan.
1. Run the test, and it will fail at the currency matching step, since the currency will be in JPY.

## Test plan

Run the test from this branch, and the currency matching step should pass as expected.