### PR TITLE
Update gdpr cookie to account for live branch tests

### DIFF
--- a/lib/components/nav-bar-component.js
+++ b/lib/components/nav-bar-component.js
@@ -53,7 +53,8 @@ export default class NavBarComponent extends AsyncBaseContainer {
 		}
 	}
 	async openNotificationsShortcut() {
-		return await this.driver.findElement( by.tagName( 'body' ) ).sendKeys( 'n' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, by.css( '.masterbar__notifications' ) );
+		return await this.driver.findElement( by.css( 'body' ) ).sendKeys( 'n' );
 	}
 	async confirmNotificationsOpen() {
 		const selector = by.css( '.wpnt-open' );

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -298,7 +298,6 @@ export async function ensureNotLoggedIn( driver ) {
 	// This makes sure neither auth domain or local domain has any cookies or local storage
 	const calypsoURL = dataHelper.configGet( 'calypsoBaseURL' );
 	const wordPressDotComURL = 'https://wordpress.com';
-	const cookieDomain = calypsoURL.replace( /(^\w+:|^)\/\//, '' );
 	if ( calypsoURL !== wordPressDotComURL ) {
 		await driver.get( wordPressDotComURL );
 		await this.clearCookiesAndDeleteLocalStorage( driver );
@@ -309,12 +308,12 @@ export async function ensureNotLoggedIn( driver ) {
 	// Set cookie to prevent GDPR banner from appearing
 	if ( dataHelper.isRunningOnLiveBranch() ) {
 		await driver.executeScript(
-			`window.document.cookie = "sensitive_pixel_option=yes;domain=${cookieDomain}";`
+			'window.document.cookie = "sensitive_pixel_option=no;";'
 		);
 	}
 
 	await driver.executeScript(
-		'window.document.cookie = "sensitive_pixel_option=yes;domain=.wordpress.com";'
+		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com";'
 	);
 
 	return console.log( await driver.manage().getCookies() );

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -307,14 +307,8 @@ export async function ensureNotLoggedIn( driver ) {
 	await this.clearCookiesAndDeleteLocalStorage( driver );
 
 	// Set cookie to prevent GDPR banner from appearing
-	if ( dataHelper.isRunningOnLiveBranch() ) {
-		await driver.executeScript(
-			`window.document.cookie = "sensitive_pixel_option=no;domain=${cookieDomain}";`
-		);
-	}
-
 	return await driver.executeScript(
-		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com";'
+		`window.document.cookie = "sensitive_pixel_option=yes;domain=${cookieDomain}";`
 	);
 }
 

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -307,8 +307,14 @@ export async function ensureNotLoggedIn( driver ) {
 	await this.clearCookiesAndDeleteLocalStorage( driver );
 
 	// Set cookie to prevent GDPR banner from appearing
+	if ( dataHelper.isRunningOnLiveBranch() ) {
+		await driver.executeScript(
+			`window.document.cookie = "sensitive_pixel_option=no;domain=${cookieDomain}";`
+		);
+	}
+
 	return await driver.executeScript(
-		`window.document.cookie = "sensitive_pixel_option=no;domain=${cookieDomain}";`
+		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com";'
 	);
 }
 

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -298,7 +298,7 @@ export async function ensureNotLoggedIn( driver ) {
 	// This makes sure neither auth domain or local domain has any cookies or local storage
 	const calypsoURL = dataHelper.configGet( 'calypsoBaseURL' );
 	const wordPressDotComURL = 'https://wordpress.com';
-	let cookieDomain = dataHelper.isRunningOnLiveBranch() ? '.calypso.live' : '.wordpress.com';
+	const cookieDomain = calypsoURL.replace(/(^\w+:|^)\/\//, '');
 	if ( calypsoURL !== wordPressDotComURL ) {
 		await driver.get( wordPressDotComURL );
 		await this.clearCookiesAndDeleteLocalStorage( driver );
@@ -308,7 +308,7 @@ export async function ensureNotLoggedIn( driver ) {
 
 	// Set cookie to prevent GDPR banner from appearing
 	return await driver.executeScript(
-		`window.document.cookie = "sensitive_pixel_option=no;domain=${cookieDomain}";`
+		`window.document.cookie = "sensitive_pixel_option=no;domain=.${cookieDomain}";`
 	);
 }
 

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -311,7 +311,7 @@ export async function ensureNotLoggedIn( driver ) {
 	);
 
 	return await driver.executeScript(
-		'window.document.cookie = "country_code=unknown;domain=.wordpress.com";'
+		'window.document.cookie = "country_code=US;domain=.wordpress.com";'
 	);
 }
 

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -306,8 +306,12 @@ export async function ensureNotLoggedIn( driver ) {
 	await this.clearCookiesAndDeleteLocalStorage( driver );
 
 	// Set cookie to prevent GDPR banner from appearing
-	return await driver.executeScript(
+	await driver.executeScript(
 		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com";'
+	);
+
+	return await driver.executeScript(
+		'window.document.cookie = "country_code=US;domain=.wordpress.com";'
 	);
 }
 

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -310,9 +310,9 @@ export async function ensureNotLoggedIn( driver ) {
 		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com";'
 	);
 
-	//return await driver.executeScript(
-	//	'window.document.cookie = "country_code=US;domain=.wordpress.com";'
-	//);
+	return await driver.executeScript(
+		'window.document.cookie = "country_code=unknown;domain=.wordpress.com";'
+	);
 }
 
 export function dismissAllAlerts( driver ) {

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -298,6 +298,7 @@ export async function ensureNotLoggedIn( driver ) {
 	// This makes sure neither auth domain or local domain has any cookies or local storage
 	const calypsoURL = dataHelper.configGet( 'calypsoBaseURL' );
 	const wordPressDotComURL = 'https://wordpress.com';
+	let cookieDomain = dataHelper.isRunningOnLiveBranch() ? '.calypso.live' : '.wordpress.com';
 	if ( calypsoURL !== wordPressDotComURL ) {
 		await driver.get( wordPressDotComURL );
 		await this.clearCookiesAndDeleteLocalStorage( driver );
@@ -307,7 +308,7 @@ export async function ensureNotLoggedIn( driver ) {
 
 	// Set cookie to prevent GDPR banner from appearing
 	return await driver.executeScript(
-		'window.document.cookie = "sensitive_pixel_option=yes;domain=.wordpress.com";'
+		`window.document.cookie = "sensitive_pixel_option=no;domain=${cookieDomain}";`
 	);
 }
 

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -307,9 +307,17 @@ export async function ensureNotLoggedIn( driver ) {
 	await this.clearCookiesAndDeleteLocalStorage( driver );
 
 	// Set cookie to prevent GDPR banner from appearing
-	return await driver.executeScript(
-		`window.document.cookie = "sensitive_pixel_option=yes;domain=${cookieDomain}";`
+	if ( dataHelper.isRunningOnLiveBranch() ) {
+		await driver.executeScript(
+			`window.document.cookie = "sensitive_pixel_option=yes;domain=${cookieDomain}";`
+		);
+	}
+
+	await driver.executeScript(
+		'window.document.cookie = "sensitive_pixel_option=yes;domain=.wordpress.com";'
 	);
+
+	return console.log( await driver.manage().getCookies() );
 }
 
 export function dismissAllAlerts( driver ) {

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -312,11 +312,9 @@ export async function ensureNotLoggedIn( driver ) {
 		);
 	}
 
-	await driver.executeScript(
+	return await driver.executeScript(
 		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com";'
 	);
-
-	return console.log( await driver.manage().getCookies() );
 }
 
 export function dismissAllAlerts( driver ) {

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -298,7 +298,7 @@ export async function ensureNotLoggedIn( driver ) {
 	// This makes sure neither auth domain or local domain has any cookies or local storage
 	const calypsoURL = dataHelper.configGet( 'calypsoBaseURL' );
 	const wordPressDotComURL = 'https://wordpress.com';
-	const cookieDomain = calypsoURL.replace(/(^\w+:|^)\/\//, '');
+	const cookieDomain = calypsoURL.replace( /(^\w+:|^)\/\//, '' );
 	if ( calypsoURL !== wordPressDotComURL ) {
 		await driver.get( wordPressDotComURL );
 		await this.clearCookiesAndDeleteLocalStorage( driver );

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -308,7 +308,7 @@ export async function ensureNotLoggedIn( driver ) {
 
 	// Set cookie to prevent GDPR banner from appearing
 	return await driver.executeScript(
-		`window.document.cookie = "sensitive_pixel_option=no;domain=.${cookieDomain}";`
+		`window.document.cookie = "sensitive_pixel_option=no;domain=${cookieDomain}";`
 	);
 }
 

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -310,9 +310,9 @@ export async function ensureNotLoggedIn( driver ) {
 		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com";'
 	);
 
-	return await driver.executeScript(
-		'window.document.cookie = "country_code=US;domain=.wordpress.com";'
-	);
+	//return await driver.executeScript(
+	//	'window.document.cookie = "country_code=US;domain=.wordpress.com";'
+	//);
 }
 
 export function dismissAllAlerts( driver ) {

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -306,12 +306,8 @@ export async function ensureNotLoggedIn( driver ) {
 	await this.clearCookiesAndDeleteLocalStorage( driver );
 
 	// Set cookie to prevent GDPR banner from appearing
-	await driver.executeScript(
-		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com";'
-	);
-
 	return await driver.executeScript(
-		'window.document.cookie = "country_code=US;domain=.wordpress.com";'
+		'window.document.cookie = "sensitive_pixel_option=yes;domain=.wordpress.com";'
 	);
 }
 

--- a/lib/login-cookie-helper.js
+++ b/lib/login-cookie-helper.js
@@ -21,7 +21,6 @@ export async function saveLogin( driver, username ) {
 export async function loadLoginCookies( driver, filePath ) {
 	const rawData = await fs.readFileSync( filePath );
 	const cookies = await JSON.parse( rawData );
-	await driver.manage().deleteAllCookies();
 	for ( const cookie of cookies ) {
 		await driver.manage().addCookie( cookie );
 	}


### PR DESCRIPTION
Thought of this idea over the weekend so I decided to give it a shot.
It is to keep the cookie banner from showing when running against livebranches. It should also work against wordpress.com