### PR TITLE
Fix Coupon specs on tablet

### DIFF
--- a/lib/components/secure-payment-component.js
+++ b/lib/components/secure-payment-component.js
@@ -146,7 +146,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 
 	async clickCouponButton() {
 		// If we're on desktop
-		if ( currentScreenSize() === 'desktop' ) {
+		if ( currentScreenSize() !== 'mobile' ) {
 			return await driverHelper.clickWhenClickable(
 				this.driver,
 				By.css( '.cart__coupon button.cart__toggle-link' )
@@ -196,7 +196,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 
 	async removeCoupon() {
 		// Desktop
-		if ( currentScreenSize() === 'desktop' ) {
+		if ( currentScreenSize() !== 'mobile' ) {
 			return await driverHelper.clickWhenClickable( this.driver, By.css( '.cart__remove-link' ) );
 		}
 


### PR DESCRIPTION
Stumbled across this issue with the coupon tests choosing the wrong selector on tablets. Updated the component to fix that. 

To tests:

wp-plan-purchase-spec and wp-signup-spec with browsersize variable set to tablet. 