### PR TITLE
Update login-flow to account for development environments

### DIFF
--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -106,6 +106,8 @@ export default class LoginFlow {
 
 		await this.login( { useFreshLogin: useFreshLogin } );
 
+		await this.checkForDevDocsAndRedirectToReader();
+
 		await ReaderPage.Expect( this.driver );
 		await NavBarComponent.Expect( this.driver );
 
@@ -163,14 +165,18 @@ export default class LoginFlow {
 		return await sideBarComponent.selectAddPerson();
 	}
 
+	async checkForDevDocsAndRedirectToReader() {
+		const urlDisplayed = await this.driver.getCurrentUrl();
+		//make sure we navigate to root, in development environments we open devdocs
+		if ( urlDisplayed.indexOf( 'calypso.localhost:3000' !== -1 ) ) {
+			return await ReaderPage.Visit( this.driver );
+		}
+	}
+
 	async loginAndSelectMySite( site = null, { useFreshLogin = false } = {} ) {
 		await this.login( { useFreshLogin: useFreshLogin } );
 
-		let urlDisplayed = await this.driver.getCurrentUrl();
-		//make sure we navigate to root, in development environments we open devdocs
-		if ( urlDisplayed === 'http://calypso.localhost:3000/' ) {
-			await ReaderPage.Visit( this.driver );
-		}
+		await this.checkForDevDocsAndRedirectToReader();
 
 		const readerPage = await ReaderPage.Expect( this.driver );
 		await readerPage.waitForPage();

--- a/lib/flows/login-flow.js
+++ b/lib/flows/login-flow.js
@@ -166,6 +166,12 @@ export default class LoginFlow {
 	async loginAndSelectMySite( site = null, { useFreshLogin = false } = {} ) {
 		await this.login( { useFreshLogin: useFreshLogin } );
 
+		let urlDisplayed = await this.driver.getCurrentUrl();
+		//make sure we navigate to root, in development environments we open devdocs
+		if ( urlDisplayed === 'http://calypso.localhost:3000/' ) {
+			await ReaderPage.Visit( this.driver );
+		}
+
 		const readerPage = await ReaderPage.Expect( this.driver );
 		await readerPage.waitForPage();
 


### PR DESCRIPTION
I was running some tests locally and noticed some failures for local runs, because we visit devdocs instead of the reader after login. I added a check there to account for the case, but let me know if there's something better to compare against.

### Testing Instructions

Try to run the wp-invite-users-spec.js against a local calypso instance, and the config using `"calypsoBaseURL": "http://calypso.localhost:3000",`
