### PR TITLE
Fix/few more jetpack failures

### DIFF
--- a/lib/components/post-editor-sidebar-component.js
+++ b/lib/components/post-editor-sidebar-component.js
@@ -129,7 +129,7 @@ export default class PostEditorSidebarComponent extends AsyncBaseContainer {
 	async setCommentsForPost( allow = true ) {
 		let driver = this.driver;
 		const selector = By.css( 'input[name=comment_status]' );
-		driverHelper.waitTillPresentAndDisplayed( driver, selector );
+		await driverHelper.waitTillPresentAndDisplayed( driver, selector );
 		let enabled = await driver.findElement( selector ).isEnabled();
 		if ( ( allow && ! enabled ) || ( ! allow && enabled ) ) {
 			return await driverHelper.clickWhenClickable( driver, selector );

--- a/lib/driver-helper.js
+++ b/lib/driver-helper.js
@@ -374,9 +374,10 @@ export function checkForConsoleErrors( driver ) {
 	}
 }
 
-export function ensureMobileMenuOpen( driver ) {
+export async function ensureMobileMenuOpen( driver ) {
 	const self = this;
 	const mobileHeaderSelector = by.css( '.section-nav__mobile-header' );
+	await waitTillPresentAndDisplayed( driver, mobileHeaderSelector );
 	return driver
 		.findElement( mobileHeaderSelector )
 		.isDisplayed()

--- a/lib/pages/external/jetpackcom-features-design-page.js
+++ b/lib/pages/external/jetpackcom-features-design-page.js
@@ -16,7 +16,7 @@ export default class JetpackComFeaturesDesignPage extends AsyncBaseContainer {
 	async installJetpack() {
 		const getStartedSelector = By.css( 'a#btn-mast-getstarted' );
 		const installJetpackSelector = By.css(
-			'.feature-letsgetstarted-main #btn-singlefeature-install'
+			".feature-letsgetstarted-main .feature-button-cta[href*='connect']"
 		);
 
 		await driverHelper.clickWhenClickable( this.driver, getStartedSelector );

--- a/lib/pages/settings-page.js
+++ b/lib/pages/settings-page.js
@@ -19,6 +19,14 @@ export default class SettingsPage extends AsyncBaseContainer {
 		);
 	}
 
+	async selectPerformance() {
+		await DriverHelper.ensureMobileMenuOpen( this.driver );
+		return await DriverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.section-nav-tabs__list a[href*=performance]' )
+		);
+	}
+
 	async mediaSettingsSectionDisplayed() {
 		return await DriverHelper.isEventuallyPresentAndDisplayed(
 			this.driver,

--- a/lib/pages/themes-page.js
+++ b/lib/pages/themes-page.js
@@ -60,13 +60,13 @@ export default class ThemesPage extends AsyncBaseContainer {
 
 	async getFirstThemeName() {
 		const selector = by.css( '.is-actionable:not(.is-active) h2' );
-		driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
 		return await this.driver.findElement( selector ).getText();
 	}
 
 	async getActiveThemeName() {
 		const selector = by.css( '.is-actionable.is-active h2' );
-		driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
 		return await this.driver.findElement( selector ).getText();
 	}
 

--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -6,13 +6,11 @@ import * as driverHelper from '../driver-helper';
 import * as dataHelper from '../data-helper';
 import AsyncBaseContainer from '../async-base-container';
 
+const host = dataHelper.getJetpackHost();
 const jurassicNinjaCreateURL = 'http://jurassic.ninja/create';
-
 const TEMPLATES = {
 	default: `${ jurassicNinjaCreateURL }?shortlived`,
 	noJetpack: `${ jurassicNinjaCreateURL }?shortlived&nojetpack`,
-	jetpackMaster: `${ jurassicNinjaCreateURL }?shortlived&jetpack-beta`,
-	branch: `${ jurassicNinjaCreateURL }?shortlived&jetpack-beta`,
 	wooCommerceNoJetpack: `${ jurassicNinjaCreateURL }?shortlived&nojetpack&woocommerce`,
 	gutenpack: `${ jurassicNinjaCreateURL }?shortlived&gutenberg&gutenpack`,
 };
@@ -79,6 +77,11 @@ export default class WporgCreatorPage extends AsyncBaseContainer {
 		}
 		if ( template === 'gutenpack' && dataHelper.isRunningOnLiveBranch() ) {
 			url += `&calypsobranch=${ config.get( 'branchName' ) }`;
+		}
+
+		// Automatically add jetpack-beta param when running bleeding edge tests
+		if ( template === 'default' && host === 'PRESSABLEBLEEDINGEDGE' ) {
+			url += '&jetpack-beta';
 		}
 		return url;
 	}

--- a/lib/pages/wporg-creator-page.js
+++ b/lib/pages/wporg-creator-page.js
@@ -54,7 +54,7 @@ export default class WporgCreatorPage extends AsyncBaseContainer {
 	}
 
 	async getUsername() {
-		driverHelper.waitTillPresentAndDisplayed( this.driver, USERNAME_ELEMENT );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, USERNAME_ELEMENT );
 		return await this.driver.findElement( USERNAME_ELEMENT ).getText();
 	}
 

--- a/scripts/jetpack/wp-jetpack-jn-activate.js
+++ b/scripts/jetpack/wp-jetpack-jn-activate.js
@@ -44,7 +44,7 @@ describe( `[${ host }] Jurassic Ninja Connection: (${ screenSize }) @jetpack`, f
 	this.timeout( mochaTimeOut );
 
 	step( 'Can connect from WP Admin', async function() {
-		this.jnFlow = new JetpackConnectFlow( driver, 'jetpackUserJN', 'jetpackMaster' );
+		this.jnFlow = new JetpackConnectFlow( driver, 'jetpackUserJN' );
 		return await this.jnFlow.connectFromWPAdmin();
 	} );
 

--- a/specs-blocks/gutenberg-markdown-block-spec.js
+++ b/specs-blocks/gutenberg-markdown-block-spec.js
@@ -48,8 +48,7 @@ if ( screenSize !== 'mobile' ) {
 
 			step( 'Can create wporg site and connect Jetpack', async function() {
 				this.timeout( mochaTimeOut * 12 );
-				// const jnFlow = new JetpackConnectFlow( driver, 'jetpackConnectUser' );
-				const jnFlow = new JetpackConnectFlow( driver, 'jetpackConnectUser', 'gutenpack' );
+				const jnFlow = new JetpackConnectFlow( driver, 'jetpackConnectUser' );
 				await jnFlow.connectFromWPAdmin();
 				url = jnFlow.url;
 			} );

--- a/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -45,8 +45,6 @@ const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 const sandboxCookieValue = config.get( 'storeSandboxCookieValue' );
 const locale = driverManager.currentLocale();
 const siteName = dataHelper.getJetpackSiteName();
-const host = dataHelper.getJetpackHost();
-const defaultSiteTemplate = host === 'PRESSABLE' ? 'default' : 'jetpackMaster';
 
 let driver;
 
@@ -80,8 +78,7 @@ describe( `Jetpack Connect: (${ screenSize })`, function() {
 		step( 'Can create wporg site', async function() {
 			this.timeout( mochaTimeOut * 12 );
 
-			const template = dataHelper.isRunningOnJetpackBranch() ? 'branch' : defaultSiteTemplate;
-			this.jnFlow = new JetpackConnectFlow( driver, null, template );
+			this.jnFlow = new JetpackConnectFlow( driver, null );
 			return await this.jnFlow.createJNSite();
 		} );
 
@@ -120,8 +117,7 @@ describe( `Jetpack Connect: (${ screenSize })`, function() {
 		step( 'Can create wporg site', async function() {
 			this.timeout( mochaTimeOut * 12 );
 
-			const template = dataHelper.isRunningOnJetpackBranch() ? 'branch' : defaultSiteTemplate;
-			this.jnFlow = new JetpackConnectFlow( driver, null, template );
+			this.jnFlow = new JetpackConnectFlow( driver, null );
 			return await this.jnFlow.createJNSite();
 		} );
 

--- a/specs-jetpack-calypso/wp-jetpack-settings-writing-media-spec.js
+++ b/specs-jetpack-calypso/wp-jetpack-settings-writing-media-spec.js
@@ -42,11 +42,6 @@ describe( `[${ host }] Jetpack Settings on Calypso: (${ screenSize }) @jetpack`,
 			assert( shown, "Can't see the media settings section under the Writing settings" );
 		} );
 
-		step( 'Can see the Photon toggle switch', async function() {
-			let shown = await this.settingsPage.photonToggleDisplayed();
-			assert( shown, "Can't see the Photon setting toggle under the Writing settings" );
-		} );
-
 		step( 'Can see the Carousel toggle switch', async function() {
 			let shown = await this.settingsPage.carouselToggleDisplayed();
 			assert( shown, "Can't see the carousel setting toggle under the Writing settings" );
@@ -58,6 +53,12 @@ describe( `[${ host }] Jetpack Settings on Calypso: (${ screenSize }) @jetpack`,
 				shown,
 				"Can't see the carousel background color setting toggle under the Writing settings"
 			);
+		} );
+
+		step( 'Can see the Photon toggle switch', async function() {
+			await this.settingsPage.selectPerformance();
+			let shown = await this.settingsPage.photonToggleDisplayed();
+			assert( shown, "Can't see the Photon setting toggle under the Writing settings" );
 		} );
 	} );
 } );

--- a/specs/wp-comments-spec.js
+++ b/specs/wp-comments-spec.js
@@ -60,6 +60,8 @@ describe( `[${ host }] Comments: (${ screenSize })`, function() {
 		} );
 
 		step( 'Can post a reply', async function() {
+			// NOTE: we need to wait to prevent "You are posting comments too quickly. Slow down." error
+			await driver.sleep( 10000 );
 			const commentArea = await CommentsAreaComponent.Expect( driver );
 			await commentArea.reply(
 				{


### PR DESCRIPTION
Fixes two failing Jetpack tests. Also, I noticed some missing `await` calls, so I added them. Also, I updated the Markdown block test to use default JN template instead of gutenpack, since it is not needed anymore.

To test locally:
`BROWSERSIZE=mobile JETPACKHOST=PRESSABLE npx mocha specs/wp-post-editor-spec.js -g 'Edit a Post:'`
`JETPACKHOST=PRESSABLE npx mocha specs-jetpack-calypso/wp-jetpack-connect-spec.js -g 'Pre-connect from Jetpack.com using "Install Jetpack" button:'`
`JETPACKHOST=PRESSABLE npx mocha specs/wp-comments-spec.js -g 'newly created post:'`