### PR TITLE
Reduce number of screenshot failure slack messages

### DIFF
--- a/lib/mocha-hooks.js
+++ b/lib/mocha-hooks.js
@@ -86,7 +86,9 @@ afterEach( async function() {
 			} );
 		},
 		err => {
-			slackNotifier.warn( `Could not take screenshot due to error: '${ err }'` );
+			slackNotifier.warn( `Could not take screenshot due to error: '${ err }'`,
+				{ suppressDuplicateMessages: true }
+			);
 		}
 	);
 } );


### PR DESCRIPTION
We were getting double messages when a screenshot didn't work for some reason. This supresses the second one..