### PR TITLE
Scroll into view sectionSelector

### DIFF
--- a/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -93,11 +93,11 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 		const sectionButton = await this.driver.findElement( sectionSelector );
 		let c = await sectionButton.getAttribute( 'aria-expanded' );
 		if ( expand && c === 'false' ) {
-			// TODO: Scroll into view
+			await driverHelper.scrollIntoView( this.driver, sectionSelector );
 			return await sectionButton.click();
 		}
 		if ( ! expand && c === 'true' ) {
-			// TODO: Scroll into view
+			await driverHelper.scrollIntoView( this.driver, sectionSelector );
 			return await sectionButton.click();
 		}
 	}


### PR DESCRIPTION
Test `Calypso Gutenberg Editor: Posts: Public Posts: Preview and Publish a Public Post @parallel` failed locally for @JavonDavis and me, on step `Close categories and tags`. With this fix, the test should pass as usual. 

To test:
Make sure that test is passing locally, both mobile and desktop.