### PR TITLE
Fix signup spec

### DIFF
--- a/lib/components/site-preview-component.js
+++ b/lib/components/site-preview-component.js
@@ -12,11 +12,11 @@ class SitePreviewComponent extends AsyncBaseContainer {
 	}
 
 	async toolbar() {
-		return this.driver.findElement( By.css( '.web-preview__toolbar' ) );
+		return await this.driver.findElement( By.css( '.web-preview__toolbar' ) );
 	}
 
 	async contentPlaceholder() {
-		return this.driver.findElement( By.css( '.web-preview__placeholder' ) );
+		return await this.driver.findElement( By.css( '.web-preview__placeholder' ) );
 	}
 
 	async enterSitePreview() {
@@ -48,7 +48,7 @@ class SitePreviewComponent extends AsyncBaseContainer {
 	}
 
 	async siteBody() {
-		return this.driver.findElement( By.css( 'body.home' ) );
+		return await this.driver.findElement( By.css( 'body.home' ) );
 	}
 }
 

--- a/lib/components/site-preview-component.js
+++ b/lib/components/site-preview-component.js
@@ -11,7 +11,7 @@ class SitePreviewComponent extends AsyncBaseContainer {
 		super( driver, By.css( '.preview.main' ) );
 	}
 
-	async toolbar() {
+	async sitePreviewToolbar() {
 		return await this.driver.findElement( By.css( '.web-preview__toolbar' ) );
 	}
 

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -298,6 +298,11 @@ export async function ensureNotLoggedIn( driver ) {
 	// This makes sure neither auth domain or local domain has any cookies or local storage
 	const calypsoURL = dataHelper.configGet( 'calypsoBaseURL' );
 	const wordPressDotComURL = 'https://wordpress.com';
+
+	let currentURL = await driver.getCurrentUrl();
+	if ( currentURL.startsWith( 'data:' ) === true ) {
+		await driver.sleep( 2000 );
+	}
 	if ( calypsoURL !== wordPressDotComURL ) {
 		await driver.get( wordPressDotComURL );
 		await clearCookiesAndDeleteLocalStorage( driver );

--- a/lib/driver-manager.js
+++ b/lib/driver-manager.js
@@ -299,10 +299,8 @@ export async function ensureNotLoggedIn( driver ) {
 	const calypsoURL = dataHelper.configGet( 'calypsoBaseURL' );
 	const wordPressDotComURL = 'https://wordpress.com';
 
-	let currentURL = await driver.getCurrentUrl();
-	if ( currentURL.startsWith( 'data:' ) === true ) {
-		await driver.sleep( 2000 );
-	}
+	await driver.sleep( 2000 ); // wait before clearing data
+
 	if ( calypsoURL !== wordPressDotComURL ) {
 		await driver.get( wordPressDotComURL );
 		await clearCookiesAndDeleteLocalStorage( driver );

--- a/lib/flows/delete-account-flow.js
+++ b/lib/flows/delete-account-flow.js
@@ -3,9 +3,7 @@
 import CloseAccountPage from '../pages/account/close-account-page';
 import LoggedOutMasterbarComponent from '../components/logged-out-masterbar-component';
 import * as SlackNotifier from '../slack-notifier';
-import NavBarComponent from '../components/nav-bar-component';
 import AccountSettingsPage from '../pages/account/account-settings-page';
-import ProfilePage from '../pages/profile-page';
 
 export default class DeleteAccountFlow {
 	constructor( driver ) {
@@ -13,11 +11,11 @@ export default class DeleteAccountFlow {
 	}
 	async deleteAccount( name ) {
 		return ( async () => {
-			const navBarComponent = await NavBarComponent.Expect( this.driver );
-			await navBarComponent.clickProfileLink();
-			const profilePage = await ProfilePage.Expect( this.driver );
-			await profilePage.chooseAccountSettings();
-			const accountSettingsPage = await AccountSettingsPage.Expect( this.driver );
+			let url = await this.driver.getCurrentUrl();
+			if ( url.startsWith( 'data:' ) === true ) {
+				await this.driver.sleep( 2000 );
+			}
+			const accountSettingsPage = await AccountSettingsPage.Visit( this.driver );
 			await accountSettingsPage.chooseCloseYourAccount();
 			const closeAccountPage = await CloseAccountPage.Expect( this.driver );
 			await closeAccountPage.chooseCloseAccount();

--- a/lib/flows/delete-account-flow.js
+++ b/lib/flows/delete-account-flow.js
@@ -3,6 +3,7 @@
 import CloseAccountPage from '../pages/account/close-account-page';
 import LoggedOutMasterbarComponent from '../components/logged-out-masterbar-component';
 import AccountSettingsPage from '../pages/account/account-settings-page';
+import * as SlackNotifier from '../slack-notifier';
 
 export default class DeleteAccountFlow {
 	constructor( driver ) {
@@ -11,11 +12,18 @@ export default class DeleteAccountFlow {
 	async deleteAccount( name ) {
 		await this.driver.sleep( 2000 ); // wait before open account settings page
 
-		const accountSettingsPage = await AccountSettingsPage.Visit( this.driver );
-		await accountSettingsPage.chooseCloseYourAccount();
-		const closeAccountPage = await CloseAccountPage.Expect( this.driver );
-		await closeAccountPage.chooseCloseAccount();
-		await closeAccountPage.enterAccountNameAndClose( name );
-		return await LoggedOutMasterbarComponent.Expect( this.driver );
+		return ( async () => {
+			const accountSettingsPage = await AccountSettingsPage.Visit( this.driver );
+			await accountSettingsPage.chooseCloseYourAccount();
+			const closeAccountPage = await CloseAccountPage.Expect( this.driver );
+			await closeAccountPage.chooseCloseAccount();
+			await closeAccountPage.enterAccountNameAndClose( name );
+			return await LoggedOutMasterbarComponent.Expect( this.driver );
+		} )().catch( err => {
+			SlackNotifier.warn(
+				`There was an error in the hooks that delete test account, but since it is cleaning up we really don't care: '${ err }'`,
+				{ suppressDuplicateMessages: true }
+			);
+		} );
 	}
 }

--- a/lib/flows/delete-account-flow.js
+++ b/lib/flows/delete-account-flow.js
@@ -11,10 +11,8 @@ export default class DeleteAccountFlow {
 	}
 	async deleteAccount( name ) {
 		return ( async () => {
-			let url = await this.driver.getCurrentUrl();
-			if ( url.startsWith( 'data:' ) === true ) {
-				await this.driver.sleep( 2000 );
-			}
+			await this.driver.sleep( 2000 ); // wait before open account settings page
+
 			const accountSettingsPage = await AccountSettingsPage.Visit( this.driver );
 			await accountSettingsPage.chooseCloseYourAccount();
 			const closeAccountPage = await CloseAccountPage.Expect( this.driver );

--- a/lib/flows/delete-account-flow.js
+++ b/lib/flows/delete-account-flow.js
@@ -2,7 +2,6 @@
 
 import CloseAccountPage from '../pages/account/close-account-page';
 import LoggedOutMasterbarComponent from '../components/logged-out-masterbar-component';
-import * as SlackNotifier from '../slack-notifier';
 import AccountSettingsPage from '../pages/account/account-settings-page';
 
 export default class DeleteAccountFlow {
@@ -10,20 +9,13 @@ export default class DeleteAccountFlow {
 		this.driver = driver;
 	}
 	async deleteAccount( name ) {
-		return ( async () => {
-			await this.driver.sleep( 2000 ); // wait before open account settings page
+		await this.driver.sleep( 2000 ); // wait before open account settings page
 
-			const accountSettingsPage = await AccountSettingsPage.Visit( this.driver );
-			await accountSettingsPage.chooseCloseYourAccount();
-			const closeAccountPage = await CloseAccountPage.Expect( this.driver );
-			await closeAccountPage.chooseCloseAccount();
-			await closeAccountPage.enterAccountNameAndClose( name );
-			return await LoggedOutMasterbarComponent.Expect( this.driver );
-		} )().catch( err => {
-			SlackNotifier.warn(
-				`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-				{ suppressDuplicateMessages: true }
-			);
-		} );
+		const accountSettingsPage = await AccountSettingsPage.Visit( this.driver );
+		await accountSettingsPage.chooseCloseYourAccount();
+		const closeAccountPage = await CloseAccountPage.Expect( this.driver );
+		await closeAccountPage.chooseCloseAccount();
+		await closeAccountPage.enterAccountNameAndClose( name );
+		return await LoggedOutMasterbarComponent.Expect( this.driver );
 	}
 }

--- a/lib/pages/account/account-settings-page.js
+++ b/lib/pages/account/account-settings-page.js
@@ -4,10 +4,11 @@ import { By as by } from 'selenium-webdriver';
 
 import * as driverHelper from '../../driver-helper.js';
 import AsyncBaseContainer from '../../async-base-container';
+import * as dataHelper from '../../data-helper';
 
 export default class AccountSettingsPage extends AsyncBaseContainer {
-	constructor( driver ) {
-		super( driver, by.css( '.account.main' ) );
+	constructor( driver, url = dataHelper.getCalypsoURL( 'me/account' ) ) {
+		super( driver, by.css( '.account.main' ), url );
 	}
 
 	async chooseCloseYourAccount() {

--- a/lib/pages/cancel-domain-page.js
+++ b/lib/pages/cancel-domain-page.js
@@ -14,6 +14,7 @@ export default class CancelDomainPage extends AsyncBaseContainer {
 	}
 
 	async completeSurveyAndConfirm() {
+		await this.driver.sleep( 2000 ); // since this is in after block, wait before open survey
 		await driverHelper.clickWhenClickable( this.driver, by.css( '.select-dropdown__header' ) );
 		await driverHelper.clickWhenClickable( this.driver, by.css( '.select-dropdown__item' ) );
 		await driverHelper.setCheckbox(

--- a/lib/pages/cancel-domain-page.js
+++ b/lib/pages/cancel-domain-page.js
@@ -20,7 +20,17 @@ export default class CancelDomainPage extends AsyncBaseContainer {
 			this.driver,
 			by.css( '.confirm-cancel-domain__confirm-container input[type="checkbox"]' )
 		);
-		return await driverHelper.clickWhenClickable( this.driver, this.confirmButtonSelector );
+		await driverHelper.verifyTextPresent(
+			this.driver,
+			this.confirmButtonSelector,
+			'Cancel Anyway'
+		);
+		await driverHelper.clickWhenClickable( this.driver, this.confirmButtonSelector );
+		return await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			by.css( '.notice.is-success.is-dismissable' ),
+			this.explicitWaitMS * 3
+		);
 	}
 
 	async waitToDisappear() {

--- a/lib/pages/signup/create-your-account-page.js
+++ b/lib/pages/signup/create-your-account-page.js
@@ -17,10 +17,9 @@ export default class CreateYourAccountPage extends AsyncBaseContainer {
 			secureValue: true,
 		} );
 
-		await driverHelper.clickWhenClickable(
+		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( 'button.signup-form__submit:not([disabled])' )
 		);
-		return await this.driver.sleep( 3000 ); // wait in case rate limit is reached
 	}
 }

--- a/lib/pages/signup/create-your-account-page.js
+++ b/lib/pages/signup/create-your-account-page.js
@@ -17,9 +17,10 @@ export default class CreateYourAccountPage extends AsyncBaseContainer {
 			secureValue: true,
 		} );
 
-		return await driverHelper.clickWhenClickable(
+		await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( 'button.signup-form__submit:not([disabled])' )
 		);
+		return await this.driver.sleep( 3000 ); // wait in case rate limit is reached
 	}
 }

--- a/lib/shared-steps/wp-signup-spec.js
+++ b/lib/shared-steps/wp-signup-spec.js
@@ -6,7 +6,7 @@ export const canSeeTheSitePreview = () => {
 	step( 'Can then see the site preview', async function() {
 		const sitePreviewComponent = await SitePreviewComponent.Expect( this.driver );
 
-		const toolbar = await sitePreviewComponent.toolbar();
+		const toolbar = await sitePreviewComponent.sitePreviewToolbar();
 		const placeholder = await sitePreviewComponent.contentPlaceholder();
 
 		assert( toolbar, 'The preview toolbar does not exist.' );

--- a/lib/shared-steps/wp-signup-spec.js
+++ b/lib/shared-steps/wp-signup-spec.js
@@ -17,6 +17,6 @@ export const canSeeTheSitePreview = () => {
 
 		assert( siteBody, 'The site body does not appear in the iframe.' );
 
-		return sitePreviewComponent.leaveSitePreview();
+		return await sitePreviewComponent.leaveSitePreview();
 	} );
 };

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1554,12 +1554,12 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
 				await new SignUpStep( driver ).continueAlong( userName, passwordForTestAccounts );
-				return ( isLoggedIn = true );
 			}
 		);
 
 		step( 'We are then on the Reader page', async function() {
 			await ReaderPage.Expect( driver );
+			isLoggedIn = true;
 		} );
 
 		after( 'Can delete our newly created account', async function() {
@@ -1660,8 +1660,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can then see the site importer pane and preview site to be imported', async function() {
-			isLoggedIn = true;
 			const importPage = await ImportPage.Expect( driver );
+			isLoggedIn = true;
 
 			// Test that we have opened the correct importer and can see the preview.
 			await importPage.siteImporterInputPane();
@@ -1720,8 +1720,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the "Site Type" page, and enter some site information', async function() {
-			isLoggedIn = true;
 			const siteTypePage = await SiteTypePage.Expect( driver );
+			isLoggedIn = true;
 			await siteTypePage.selectBlogType();
 			return await siteTypePage.submitForm();
 		} );
@@ -1812,8 +1812,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
-				await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
-				return ( isLoggedIn = true );
+				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
 			}
 		);
 
@@ -1821,6 +1820,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			'We are then on the Reader page and have no sites - we click Create Site',
 			async function() {
 				await ReaderPage.Expect( driver );
+				isLoggedIn = true;
 				const navBarComponent = await NavBarComponent.Expect( driver );
 				await navBarComponent.clickMySites();
 				const noSitesComponent = await NoSitesComponent.Expect( driver );

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -82,6 +82,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 		let magicLoginLink;
+		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -106,6 +107,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can see the "About" page, and enter some site information', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
+			isLoggedIn = true;
 			await aboutPage.enterSiteDetails( blogName, 'Electronics' );
 			return await aboutPage.submitForm();
 		} );
@@ -144,6 +146,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can log out and request a magic link', async function() {
 			await driverManager.ensureNotLoggedIn( driver );
+			isLoggedIn = false;
 			const loginPage = await LoginPage.Visit( driver );
 			return await loginPage.requestMagicLink( emailAddress );
 		} );
@@ -172,11 +175,15 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			await driver.get( magicLoginLink );
 			const magicLoginPage = await MagicLoginPage.Expect( driver );
 			await magicLoginPage.finishLogin();
-			return await ReaderPage.Expect( driver );
+			await ReaderPage.Expect( driver );
+			return ( isLoggedIn = true );
 		} );
 
-		step( 'Can delete our newly created account', async function() {
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+			}
 		} );
 	} );
 
@@ -184,6 +191,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
+		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -204,6 +212,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can see the "About" page, and enter some site information', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
+			isLoggedIn = true;
 			await aboutPage.enterSiteDetails( blogName, 'Electronics' );
 			return await aboutPage.submitForm();
 		} );
@@ -240,8 +249,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		sharedSteps.canSeeTheSitePreview();
 
-		step( 'Can delete our newly created account', async function() {
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+			}
 		} );
 	} );
 
@@ -250,6 +262,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 		let originalCartAmount;
+		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -270,6 +283,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can see the "About" page, and enter some site information', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
+			isLoggedIn = true;
 			return await aboutPage.enterSiteDetails( blogName, '', {
 				showcase: true,
 			} );
@@ -354,9 +368,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			assert.strictEqual( removedCouponAmount, originalCartAmount, 'Coupon not removed properly' );
 		} );
 
-		step( 'Can delete our newly created account', async function() {
-			await WPHomePage.Visit( driver );
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+			}
 		} );
 	} );
 
@@ -366,6 +382,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 		const currencyValue = 'USD';
 		const expectedCurrencySymbol = '$';
+		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -393,6 +410,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can accept defaults for about page', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
+			isLoggedIn = true;
 			await aboutPage.enterSiteDetails( 'Step Back', 'Store Test Topic', { sell: true } );
 			await aboutPage.submitForm();
 			await driverHelper.waitTillNotPresent( driver, By.css( '.signup is-store-nux' ) ); // Wait for /start/store-nux/themes to load
@@ -480,8 +498,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await new DeletePlanFlow( driver ).deletePlan( 'premium' );
 		} );
 
-		step( 'Can delete our newly created account', async function() {
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+			}
 		} );
 	} );
 
@@ -492,6 +513,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		const currencyValue = 'JPY';
 		const expectedCurrencySymbol = '¥';
+		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -522,6 +544,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can see the about page and accept defaults', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
+			isLoggedIn = true;
 			return await aboutPage.submitForm();
 		} );
 
@@ -599,8 +622,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await new DeletePlanFlow( driver ).deletePlan( 'premium' );
 		} );
 
-		step( 'Can delete our newly created account', async function() {
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+			}
 		} );
 	} );
 
@@ -610,6 +636,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 		const currencyValue = 'GBP';
 		const expectedCurrencySymbol = '£';
+		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -640,6 +667,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can see the about page and accept defaults', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
+			isLoggedIn = true;
 			return await aboutPage.submitForm();
 		} );
 
@@ -718,8 +746,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await new DeletePlanFlow( driver ).deletePlan( 'personal' );
 		} );
 
-		step( 'Can delete our newly created account', async function() {
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+			}
 		} );
 	} );
 
@@ -730,6 +761,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const testDomainRegistarDetails = dataHelper.getTestDomainRegistarDetails( emailAddress );
 		const currencyValue = 'EUR';
 		const expectedCurrencySymbol = '€';
+		let isLoggedIn = false;
 
 		before( async function() {
 			if ( process.env.SKIP_DOMAIN_TESTS === 'true' ) {
@@ -788,6 +820,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			'Can see checkout page, choose domain privacy option and enter registrar details',
 			async function() {
 				let checkOutPage;
+				isLoggedIn = true;
 				try {
 					checkOutPage = await CheckOutPage.Expect( driver );
 				} catch ( err ) {
@@ -916,8 +949,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await cancelDomainPage.completeSurveyAndConfirm();
 		} );
 
-		step( 'Can delete our newly created account', async function() {
-			return await new DeleteAccountFlow( driver ).deleteAccount( siteName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( siteName );
+			}
 		} );
 	} );
 
@@ -928,6 +964,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const testDomainRegistarDetails = dataHelper.getTestDomainRegistarDetails( emailAddress );
 		const currencyValue = 'CAD';
 		const expectedCurrencySymbol = 'C$';
+		let isLoggedIn = false;
 
 		before( async function() {
 			if ( process.env.SKIP_DOMAIN_TESTS === 'true' ) {
@@ -968,6 +1005,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can see the about page and accept defaults', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
+			isLoggedIn = true;
 			return await aboutPage.submitForm();
 		} );
 
@@ -1086,13 +1124,17 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			} );
 		} );
 
-		step( 'Can delete our newly created account', async function() {
-			return await new DeleteAccountFlow( driver ).deleteAccount( siteName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( siteName );
+			}
 		} );
 	} );
 
 	describe( 'Basic sign up for a free site @parallel @email @ie11canary', function() {
 		const blogName = dataHelper.getNewBlogName();
+		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -1114,6 +1156,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can see the about page and accept defaults', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
+			isLoggedIn = true;
 			return await aboutPage.submitForm();
 		} );
 
@@ -1150,8 +1193,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		sharedSteps.canSeeTheSitePreview();
 
-		step( 'Can delete our newly created account', async function() {
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+			}
 		} );
 	} );
 
@@ -1162,6 +1208,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const currencyValue = 'AUD';
 		const expectedCurrencySymbol = 'A$';
 		let chosenThemeName = '';
+		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -1222,6 +1269,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the secure payment page with the chosen theme in the cart',
 			async function() {
+				isLoggedIn = true;
 				const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 				let products = await securePaymentComponent.getProductsNames();
 				assert(
@@ -1274,14 +1322,18 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await new DeletePlanFlow( driver ).deletePlan( 'theme' );
 		} );
 
-		step( 'Can delete our newly created account', async function() {
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+			}
 		} );
 	} );
 
 	describe( 'Sign up for free subdomain site @parallel', function() {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedDomainName = `${ blogName }.art.blog`;
+		let isLoggedIn = false;
 
 		before( async function() {
 			if ( process.env.SKIP_DOMAIN_TESTS === 'true' ) {
@@ -1354,7 +1406,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
-				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+				await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+				return ( isLoggedIn = true );
 			}
 		);
 
@@ -1368,8 +1421,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await settingsPage.deleteSite( expectedDomainName );
 		} );
 
-		step( 'Can delete our newly created account', async function() {
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+			}
 		} );
 	} );
 
@@ -1377,6 +1433,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const userName = dataHelper.getNewBlogName();
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
+		let isLoggedIn = false;
 
 		before( async function() {
 			await driverManager.ensureNotLoggedIn( driver );
@@ -1423,6 +1480,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can see the "About" page, and enter some site information', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
+			isLoggedIn = true;
 			await aboutPage.enterSiteDetails( blogName, 'Electronics' );
 			return await aboutPage.submitForm();
 		} );
@@ -1459,13 +1517,17 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		sharedSteps.canSeeTheSitePreview();
 
-		step( 'Can delete our newly created account', async function() {
-			return await new DeleteAccountFlow( driver ).deleteAccount( userName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
+			}
 		} );
 	} );
 
 	describe( 'Sign up for a Reader account @parallel', function() {
 		const userName = dataHelper.getNewBlogName();
+		let isLoggedIn = false;
 
 		before( async function() {
 			await driverManager.ensureNotLoggedIn( driver );
@@ -1503,7 +1565,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
-				return await new SignUpStep( driver ).continueAlong( userName, passwordForTestAccounts );
+				await new SignUpStep( driver ).continueAlong( userName, passwordForTestAccounts );
+				return ( isLoggedIn = true );
 			}
 		);
 
@@ -1511,8 +1574,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			await ReaderPage.Expect( driver );
 		} );
 
-		step( 'Can delete our newly created account', async function() {
-			return await new DeleteAccountFlow( driver ).deleteAccount( userName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
+			}
 		} );
 	} );
 
@@ -1521,6 +1587,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const siteURL = 'https://hi6822.wixsite.com/eat-here-its-good';
 		const userName = dataHelper.getNewBlogName();
 		const emailAddress = dataHelper.getEmailAddress( userName, signupInboxId );
+		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -1606,6 +1673,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can then see the site importer pane and preview site to be imported', async function() {
+			isLoggedIn = true;
 			const importPage = await ImportPage.Expect( driver );
 
 			// Test that we have opened the correct importer and can see the preview.
@@ -1632,8 +1700,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			await driver.get( activationLink );
 		} );
 
-		step( 'Can delete our newly created account', async function() {
-			return await new DeleteAccountFlow( driver ).deleteAccount( userName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
+			}
 		} );
 	} );
 
@@ -1642,6 +1713,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const blogName = dataHelper.getNewBlogName();
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 		let undo = null;
+		let isLoggedIn = false;
 
 		before( async function() {
 			undo = overrideABTest( 'improvedOnboarding_20181023', 'onboarding' );
@@ -1662,6 +1734,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the "Site Type" page, and enter some site information', async function() {
+			isLoggedIn = true;
 			const siteTypePage = await SiteTypePage.Expect( driver );
 			await siteTypePage.selectBlogType();
 			return await siteTypePage.submitForm();
@@ -1705,8 +1778,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		sharedSteps.canSeeTheSitePreview();
 
-		step( 'Can delete our newly created account', async function() {
-			return await new DeleteAccountFlow( driver ).deleteAccount( userName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
+			}
 		} );
 
 		after( async function() {
@@ -1720,6 +1796,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const userName = dataHelper.getNewBlogName();
 		const blogName = dataHelper.getNewBlogName();
 		let undo = null;
+		let isLoggedIn = false;
 
 		before( async function() {
 			undo = overrideABTest( 'improvedOnboarding_20181023', 'onboarding' );
@@ -1750,7 +1827,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
-				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+				await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+				return ( isLoggedIn = true );
 			}
 		);
 
@@ -1809,8 +1887,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		sharedSteps.canSeeTheSitePreview();
 
-		step( 'Can delete our newly created account', async function() {
-			return await new DeleteAccountFlow( driver ).deleteAccount( userName );
+		after( 'Can delete our newly created account', async function() {
+			if ( isLoggedIn ) {
+				await WPHomePage.Visit( driver );
+				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
+			}
 		} );
 
 		after( async function() {

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -181,7 +181,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 			}
 		} );
@@ -251,7 +250,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 			}
 		} );
@@ -370,7 +368,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 			}
 		} );
@@ -500,7 +497,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 			}
 		} );
@@ -624,7 +620,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 			}
 		} );
@@ -748,7 +743,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 			}
 		} );
@@ -951,7 +945,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( siteName );
 			}
 		} );
@@ -1126,7 +1119,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( siteName );
 			}
 		} );
@@ -1195,7 +1187,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 			}
 		} );
@@ -1324,7 +1315,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 			}
 		} );
@@ -1423,7 +1413,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 			}
 		} );
@@ -1519,7 +1508,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
 			}
 		} );
@@ -1576,7 +1564,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
 			}
 		} );
@@ -1702,7 +1689,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
 			}
 		} );
@@ -1780,7 +1766,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
 			}
 		} );
@@ -1889,7 +1874,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		after( 'Can delete our newly created account', async function() {
 			if ( isLoggedIn ) {
-				await WPHomePage.Visit( driver );
 				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
 			}
 		} );

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -82,7 +82,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 		let magicLoginLink;
-		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -106,7 +105,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the "About" page, and enter some site information', async function() {
-			isLoggedIn = true;
 			const aboutPage = await AboutPage.Expect( driver );
 			await aboutPage.enterSiteDetails( blogName, 'Electronics' );
 			return await aboutPage.submitForm();
@@ -146,7 +144,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can log out and request a magic link', async function() {
 			await driverManager.ensureNotLoggedIn( driver );
-			isLoggedIn = false;
 			const loginPage = await LoginPage.Visit( driver );
 			return await loginPage.requestMagicLink( emailAddress );
 		} );
@@ -179,9 +176,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+			return ( async () => {
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 	} );
 
@@ -189,7 +191,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -209,7 +210,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the "About" page, and enter some site information', async function() {
-			isLoggedIn = true;
 			const aboutPage = await AboutPage.Expect( driver );
 			await aboutPage.enterSiteDetails( blogName, 'Electronics' );
 			return await aboutPage.submitForm();
@@ -248,9 +248,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheSitePreview();
 
 		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+			return ( async () => {
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 	} );
 
@@ -259,7 +264,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 		let originalCartAmount;
-		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -279,7 +283,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the "About" page, and enter some site information', async function() {
-			isLoggedIn = true;
 			const aboutPage = await AboutPage.Expect( driver );
 			return await aboutPage.enterSiteDetails( blogName, '', {
 				showcase: true,
@@ -366,9 +369,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+			return ( async () => {
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 	} );
 
@@ -378,7 +386,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 		const currencyValue = 'USD';
 		const expectedCurrencySymbol = '$';
-		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -405,7 +412,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can accept defaults for about page', async function() {
-			isLoggedIn = true;
 			const aboutPage = await AboutPage.Expect( driver );
 			await aboutPage.enterSiteDetails( 'Step Back', 'Store Test Topic', { sell: true } );
 			await aboutPage.submitForm();
@@ -495,9 +501,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+			return ( async () => {
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 	} );
 
@@ -508,7 +519,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		const currencyValue = 'JPY';
 		const expectedCurrencySymbol = '¥';
-		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -538,7 +548,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the about page and accept defaults', async function() {
-			isLoggedIn = true;
 			const aboutPage = await AboutPage.Expect( driver );
 			return await aboutPage.submitForm();
 		} );
@@ -618,9 +627,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+			return ( async () => {
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 	} );
 
@@ -630,7 +644,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 		const currencyValue = 'GBP';
 		const expectedCurrencySymbol = '£';
-		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -660,7 +673,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the about page and accept defaults', async function() {
-			isLoggedIn = true;
 			const aboutPage = await AboutPage.Expect( driver );
 			return await aboutPage.submitForm();
 		} );
@@ -741,9 +753,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+			return ( async () => {
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 	} );
 
@@ -754,7 +771,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const testDomainRegistarDetails = dataHelper.getTestDomainRegistarDetails( emailAddress );
 		const currencyValue = 'EUR';
 		const expectedCurrencySymbol = '€';
-		let isLoggedIn = false;
 
 		before( async function() {
 			if ( process.env.SKIP_DOMAIN_TESTS === 'true' ) {
@@ -805,7 +821,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
-				isLoggedIn = true;
 				return await new SignUpStep( driver ).continueAlong( siteName, passwordForTestAccounts );
 			}
 		);
@@ -915,37 +930,39 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return assert( exists, 'The settings menu option does not exist' );
 		} );
 
-		step( 'We can cancel the domain', async function() {
-			await ReaderPage.Visit( driver );
-			const navBarComponent = await NavBarComponent.Expect( driver );
-			await navBarComponent.clickMySites();
-			const sidebarComponent = await SideBarComponent.Expect( driver );
-			await sidebarComponent.selectSettings();
-			const domainOnlySettingsPage = await DomainOnlySettingsPage.Expect( driver );
-			await domainOnlySettingsPage.manageDomain();
-			const domainDetailsPage = await DomainDetailsPage.Expect( driver );
-			await domainDetailsPage.viewPaymentSettings();
+		after( 'We can cancel the domain and delete newly created account', async function() {
+			return ( async () => {
+				await ReaderPage.Visit( driver );
+				const navBarComponent = await NavBarComponent.Expect( driver );
+				await navBarComponent.clickMySites();
+				const sidebarComponent = await SideBarComponent.Expect( driver );
+				await sidebarComponent.selectSettings();
+				const domainOnlySettingsPage = await DomainOnlySettingsPage.Expect( driver );
+				await domainOnlySettingsPage.manageDomain();
+				const domainDetailsPage = await DomainDetailsPage.Expect( driver );
+				await domainDetailsPage.viewPaymentSettings();
 
-			const managePurchasePage = await ManagePurchasePage.Expect( driver );
-			let domainDisplayed = await managePurchasePage.domainDisplayed();
-			assert.strictEqual(
-				domainDisplayed,
-				expectedDomainName,
-				'The domain displayed on the manage purchase page is unexpected'
-			);
-			await managePurchasePage.chooseCancelAndRefund();
+				const managePurchasePage = await ManagePurchasePage.Expect( driver );
+				let domainDisplayed = await managePurchasePage.domainDisplayed();
+				assert.strictEqual(
+					domainDisplayed,
+					expectedDomainName,
+					'The domain displayed on the manage purchase page is unexpected'
+				);
+				await managePurchasePage.chooseCancelAndRefund();
 
-			const cancelPurchasePage = await CancelPurchasePage.Expect( driver );
-			await cancelPurchasePage.clickCancelPurchase();
+				const cancelPurchasePage = await CancelPurchasePage.Expect( driver );
+				await cancelPurchasePage.clickCancelPurchase();
 
-			const cancelDomainPage = await CancelDomainPage.Expect( driver );
-			return await cancelDomainPage.completeSurveyAndConfirm();
-		} );
-
-		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+				const cancelDomainPage = await CancelDomainPage.Expect( driver );
+				await cancelDomainPage.completeSurveyAndConfirm();
 				return await new DeleteAccountFlow( driver ).deleteAccount( siteName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 	} );
 
@@ -956,7 +973,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const testDomainRegistarDetails = dataHelper.getTestDomainRegistarDetails( emailAddress );
 		const currencyValue = 'CAD';
 		const expectedCurrencySymbol = 'C$';
-		let isLoggedIn = false;
 
 		before( async function() {
 			if ( process.env.SKIP_DOMAIN_TESTS === 'true' ) {
@@ -996,7 +1012,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the about page and accept defaults', async function() {
-			isLoggedIn = true;
 			const aboutPage = await AboutPage.Expect( driver );
 			return await aboutPage.submitForm();
 		} );
@@ -1117,15 +1132,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+			return ( async () => {
 				return await new DeleteAccountFlow( driver ).deleteAccount( siteName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 	} );
 
 	describe( 'Basic sign up for a free site @parallel @email @ie11canary', function() {
 		const blogName = dataHelper.getNewBlogName();
-		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -1146,7 +1165,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the about page and accept defaults', async function() {
-			isLoggedIn = true;
 			const aboutPage = await AboutPage.Expect( driver );
 			return await aboutPage.submitForm();
 		} );
@@ -1185,9 +1203,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheSitePreview();
 
 		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+			return ( async () => {
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 	} );
 
@@ -1198,7 +1221,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const currencyValue = 'AUD';
 		const expectedCurrencySymbol = 'A$';
 		let chosenThemeName = '';
-		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -1252,7 +1274,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
-				isLoggedIn = true;
 				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
 			}
 		);
@@ -1313,16 +1334,20 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+			return ( async () => {
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 	} );
 
 	describe( 'Sign up for free subdomain site @parallel', function() {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedDomainName = `${ blogName }.art.blog`;
-		let isLoggedIn = false;
 
 		before( async function() {
 			if ( process.env.SKIP_DOMAIN_TESTS === 'true' ) {
@@ -1395,7 +1420,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
-				isLoggedIn = true;
 				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
 			}
 		);
@@ -1411,9 +1435,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+			return ( async () => {
 				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 	} );
 
@@ -1421,7 +1450,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const userName = dataHelper.getNewBlogName();
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
-		let isLoggedIn = false;
 
 		before( async function() {
 			await driverManager.ensureNotLoggedIn( driver );
@@ -1451,7 +1479,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
-				isLoggedIn = true;
 				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
 			}
 		);
@@ -1506,15 +1533,19 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheSitePreview();
 
 		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+			return ( async () => {
 				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 	} );
 
 	describe( 'Sign up for a Reader account @parallel', function() {
 		const userName = dataHelper.getNewBlogName();
-		let isLoggedIn = false;
 
 		before( async function() {
 			await driverManager.ensureNotLoggedIn( driver );
@@ -1552,8 +1583,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
-				isLoggedIn = true;
-				await new SignUpStep( driver ).continueAlong( userName, passwordForTestAccounts );
+				return await new SignUpStep( driver ).continueAlong( userName, passwordForTestAccounts );
 			}
 		);
 
@@ -1562,9 +1592,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+			return ( async () => {
 				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 	} );
 
@@ -1573,7 +1608,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const siteURL = 'https://hi6822.wixsite.com/eat-here-its-good';
 		const userName = dataHelper.getNewBlogName();
 		const emailAddress = dataHelper.getEmailAddress( userName, signupInboxId );
-		let isLoggedIn = false;
 
 		before( async function() {
 			return await driverManager.ensureNotLoggedIn( driver );
@@ -1659,7 +1693,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can then see the site importer pane and preview site to be imported', async function() {
-			isLoggedIn = true;
 			const importPage = await ImportPage.Expect( driver );
 
 			// Test that we have opened the correct importer and can see the preview.
@@ -1687,9 +1720,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+			return ( async () => {
 				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 	} );
 
@@ -1698,7 +1736,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const blogName = dataHelper.getNewBlogName();
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 		let undo = null;
-		let isLoggedIn = false;
 
 		before( async function() {
 			undo = overrideABTest( 'improvedOnboarding_20181023', 'onboarding' );
@@ -1719,7 +1756,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the "Site Type" page, and enter some site information', async function() {
-			isLoggedIn = true;
 			const siteTypePage = await SiteTypePage.Expect( driver );
 			await siteTypePage.selectBlogType();
 			return await siteTypePage.submitForm();
@@ -1764,9 +1800,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheSitePreview();
 
 		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+			return ( async () => {
 				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 
 		after( async function() {
@@ -1780,7 +1821,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const userName = dataHelper.getNewBlogName();
 		const blogName = dataHelper.getNewBlogName();
 		let undo = null;
-		let isLoggedIn = false;
 
 		before( async function() {
 			undo = overrideABTest( 'improvedOnboarding_20181023', 'onboarding' );
@@ -1811,7 +1851,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
-				isLoggedIn = true;
 				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
 			}
 		);
@@ -1872,9 +1911,14 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheSitePreview();
 
 		after( 'Can delete our newly created account', async function() {
-			if ( isLoggedIn ) {
+			return ( async () => {
 				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
-			}
+			} )().catch( err => {
+				SlackNotifier.warn(
+					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
+					{ suppressDuplicateMessages: true }
+				);
+			} );
 		} );
 
 		after( async function() {

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -106,8 +106,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the "About" page, and enter some site information', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
 			isLoggedIn = true;
+			const aboutPage = await AboutPage.Expect( driver );
 			await aboutPage.enterSiteDetails( blogName, 'Electronics' );
 			return await aboutPage.submitForm();
 		} );
@@ -175,8 +175,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			await driver.get( magicLoginLink );
 			const magicLoginPage = await MagicLoginPage.Expect( driver );
 			await magicLoginPage.finishLogin();
-			await ReaderPage.Expect( driver );
-			return ( isLoggedIn = true );
+			return await ReaderPage.Expect( driver );
 		} );
 
 		after( 'Can delete our newly created account', async function() {
@@ -210,8 +209,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the "About" page, and enter some site information', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
 			isLoggedIn = true;
+			const aboutPage = await AboutPage.Expect( driver );
 			await aboutPage.enterSiteDetails( blogName, 'Electronics' );
 			return await aboutPage.submitForm();
 		} );
@@ -280,8 +279,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the "About" page, and enter some site information', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
 			isLoggedIn = true;
+			const aboutPage = await AboutPage.Expect( driver );
 			return await aboutPage.enterSiteDetails( blogName, '', {
 				showcase: true,
 			} );
@@ -406,8 +405,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can accept defaults for about page', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
 			isLoggedIn = true;
+			const aboutPage = await AboutPage.Expect( driver );
 			await aboutPage.enterSiteDetails( 'Step Back', 'Store Test Topic', { sell: true } );
 			await aboutPage.submitForm();
 			await driverHelper.waitTillNotPresent( driver, By.css( '.signup is-store-nux' ) ); // Wait for /start/store-nux/themes to load
@@ -539,8 +538,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the about page and accept defaults', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
 			isLoggedIn = true;
+			const aboutPage = await AboutPage.Expect( driver );
 			return await aboutPage.submitForm();
 		} );
 
@@ -661,8 +660,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the about page and accept defaults', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
 			isLoggedIn = true;
+			const aboutPage = await AboutPage.Expect( driver );
 			return await aboutPage.submitForm();
 		} );
 
@@ -806,6 +805,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
+				isLoggedIn = true;
 				return await new SignUpStep( driver ).continueAlong( siteName, passwordForTestAccounts );
 			}
 		);
@@ -814,7 +814,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			'Can see checkout page, choose domain privacy option and enter registrar details',
 			async function() {
 				let checkOutPage;
-				isLoggedIn = true;
 				try {
 					checkOutPage = await CheckOutPage.Expect( driver );
 				} catch ( err ) {
@@ -997,8 +996,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the about page and accept defaults', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
 			isLoggedIn = true;
+			const aboutPage = await AboutPage.Expect( driver );
 			return await aboutPage.submitForm();
 		} );
 
@@ -1147,8 +1146,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the about page and accept defaults', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
 			isLoggedIn = true;
+			const aboutPage = await AboutPage.Expect( driver );
 			return await aboutPage.submitForm();
 		} );
 
@@ -1253,6 +1252,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
+				isLoggedIn = true;
 				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
 			}
 		);
@@ -1260,7 +1260,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the secure payment page with the chosen theme in the cart',
 			async function() {
-				isLoggedIn = true;
 				const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 				let products = await securePaymentComponent.getProductsNames();
 				assert(
@@ -1396,8 +1395,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
-				await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
-				return ( isLoggedIn = true );
+				isLoggedIn = true;
+				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
 			}
 		);
 
@@ -1452,6 +1451,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
+				isLoggedIn = true;
 				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
 			}
 		);
@@ -1469,7 +1469,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can see the "About" page, and enter some site information', async function() {
 			const aboutPage = await AboutPage.Expect( driver );
-			isLoggedIn = true;
 			await aboutPage.enterSiteDetails( blogName, 'Electronics' );
 			return await aboutPage.submitForm();
 		} );
@@ -1553,13 +1552,13 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
+				isLoggedIn = true;
 				await new SignUpStep( driver ).continueAlong( userName, passwordForTestAccounts );
 			}
 		);
 
 		step( 'We are then on the Reader page', async function() {
-			await ReaderPage.Expect( driver );
-			isLoggedIn = true;
+			return await ReaderPage.Expect( driver );
 		} );
 
 		after( 'Can delete our newly created account', async function() {
@@ -1660,8 +1659,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can then see the site importer pane and preview site to be imported', async function() {
-			const importPage = await ImportPage.Expect( driver );
 			isLoggedIn = true;
+			const importPage = await ImportPage.Expect( driver );
 
 			// Test that we have opened the correct importer and can see the preview.
 			await importPage.siteImporterInputPane();
@@ -1720,8 +1719,8 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the "Site Type" page, and enter some site information', async function() {
-			const siteTypePage = await SiteTypePage.Expect( driver );
 			isLoggedIn = true;
+			const siteTypePage = await SiteTypePage.Expect( driver );
 			await siteTypePage.selectBlogType();
 			return await siteTypePage.submitForm();
 		} );
@@ -1812,6 +1811,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
+				isLoggedIn = true;
 				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
 			}
 		);
@@ -1820,7 +1820,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			'We are then on the Reader page and have no sites - we click Create Site',
 			async function() {
 				await ReaderPage.Expect( driver );
-				isLoggedIn = true;
 				const navBarComponent = await NavBarComponent.Expect( driver );
 				await navBarComponent.clickMySites();
 				const noSitesComponent = await NoSitesComponent.Expect( driver );

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -176,14 +176,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 		} );
 	} );
 
@@ -248,14 +241,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheSitePreview();
 
 		after( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 		} );
 	} );
 
@@ -369,14 +355,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 		} );
 	} );
 
@@ -501,14 +480,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 		} );
 	} );
 
@@ -627,14 +599,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 		} );
 	} );
 
@@ -753,14 +718,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 		} );
 	} );
 
@@ -1132,14 +1090,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				return await new DeleteAccountFlow( driver ).deleteAccount( siteName );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeleteAccountFlow( driver ).deleteAccount( siteName );
 		} );
 	} );
 
@@ -1203,14 +1154,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheSitePreview();
 
 		after( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 		} );
 	} );
 
@@ -1334,14 +1278,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 		} );
 	} );
 
@@ -1435,14 +1372,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 		} );
 	} );
 
@@ -1533,14 +1463,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheSitePreview();
 
 		after( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeleteAccountFlow( driver ).deleteAccount( userName );
 		} );
 	} );
 
@@ -1592,14 +1515,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeleteAccountFlow( driver ).deleteAccount( userName );
 		} );
 	} );
 
@@ -1720,14 +1636,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		after( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeleteAccountFlow( driver ).deleteAccount( userName );
 		} );
 	} );
 
@@ -1800,14 +1709,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheSitePreview();
 
 		after( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeleteAccountFlow( driver ).deleteAccount( userName );
 		} );
 
 		after( async function() {
@@ -1911,14 +1813,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheSitePreview();
 
 		after( 'Can delete our newly created account', async function() {
-			return ( async () => {
-				return await new DeleteAccountFlow( driver ).deleteAccount( userName );
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			return await new DeleteAccountFlow( driver ).deleteAccount( userName );
 		} );
 
 		after( async function() {

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -353,6 +353,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			let removedCouponAmount = await securePaymentComponent.cartTotalAmount();
 			assert.strictEqual( removedCouponAmount, originalCartAmount, 'Coupon not removed properly' );
 		} );
+
+		step( 'Can delete our newly created account', async function() {
+			await WPHomePage.Visit( driver );
+			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+		} );
 	} );
 
 	describe( 'Sign up for a site on a premium paid plan through main flow in USD currency @parallel @canary', function() {
@@ -885,37 +890,34 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'We can cancel the domain', async function() {
-			return ( async () => {
-				await ReaderPage.Visit( driver );
-				const navBarComponent = await NavBarComponent.Expect( driver );
-				await navBarComponent.clickMySites();
-				const sidebarComponent = await SideBarComponent.Expect( driver );
-				await sidebarComponent.selectSettings();
-				const domainOnlySettingsPage = await DomainOnlySettingsPage.Expect( driver );
-				await domainOnlySettingsPage.manageDomain();
-				const domainDetailsPage = await DomainDetailsPage.Expect( driver );
-				await domainDetailsPage.viewPaymentSettings();
+			await ReaderPage.Visit( driver );
+			const navBarComponent = await NavBarComponent.Expect( driver );
+			await navBarComponent.clickMySites();
+			const sidebarComponent = await SideBarComponent.Expect( driver );
+			await sidebarComponent.selectSettings();
+			const domainOnlySettingsPage = await DomainOnlySettingsPage.Expect( driver );
+			await domainOnlySettingsPage.manageDomain();
+			const domainDetailsPage = await DomainDetailsPage.Expect( driver );
+			await domainDetailsPage.viewPaymentSettings();
 
-				const managePurchasePage = await ManagePurchasePage.Expect( driver );
-				let domainDisplayed = await managePurchasePage.domainDisplayed();
-				assert.strictEqual(
-					domainDisplayed,
-					expectedDomainName,
-					'The domain displayed on the manage purchase page is unexpected'
-				);
-				await managePurchasePage.chooseCancelAndRefund();
+			const managePurchasePage = await ManagePurchasePage.Expect( driver );
+			let domainDisplayed = await managePurchasePage.domainDisplayed();
+			assert.strictEqual(
+				domainDisplayed,
+				expectedDomainName,
+				'The domain displayed on the manage purchase page is unexpected'
+			);
+			await managePurchasePage.chooseCancelAndRefund();
 
-				const cancelPurchasePage = await CancelPurchasePage.Expect( driver );
-				await cancelPurchasePage.clickCancelPurchase();
+			const cancelPurchasePage = await CancelPurchasePage.Expect( driver );
+			await cancelPurchasePage.clickCancelPurchase();
 
-				const cancelDomainPage = await CancelDomainPage.Expect( driver );
-				return await cancelDomainPage.completeSurveyAndConfirm();
-			} )().catch( err => {
-				SlackNotifier.warn(
-					`There was an error in the hooks that clean up the test account but since it is cleaning up we really don't care: '${ err }'`,
-					{ suppressDuplicateMessages: true }
-				);
-			} );
+			const cancelDomainPage = await CancelDomainPage.Expect( driver );
+			return await cancelDomainPage.completeSurveyAndConfirm();
+		} );
+
+		step( 'Can delete our newly created account', async function() {
+			return await new DeleteAccountFlow( driver ).deleteAccount( siteName );
 		} );
 	} );
 
@@ -1147,6 +1149,10 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		);
 
 		sharedSteps.canSeeTheSitePreview();
+
+		step( 'Can delete our newly created account', async function() {
+			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+		} );
 	} );
 
 	describe( 'Sign up while purchasing premium theme in AUD currency @parallel @email', function() {
@@ -1360,6 +1366,10 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			await sidebarComponent.selectSettings();
 			const settingsPage = await SettingsPage.Expect( driver );
 			return await settingsPage.deleteSite( expectedDomainName );
+		} );
+
+		step( 'Can delete our newly created account', async function() {
+			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
 		} );
 	} );
 


### PR DESCRIPTION
We had some problems executing `wp-signup-spec.js` locally - if one test fails, it will affect every next test in line and they will fail also. After several different tries and approaches, I concluded that some tests were missing account deletion at the end, newly registered user is not signed out and that makes a problem for flow in the next test. 

This PR ensures that every new account is deleted, and instead of `step`, `deleteAccount()` is in `after` block. That way, if test fails account will be deleted. 

To test:
Run `wp-signup-spec.js` and make sure it passes. If some test fails, next test shouldn't fail. 