### PR TITLE
Add "skipBusinessInformation" to the known abtest configuration.

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -73,6 +73,7 @@
 		"removeDomainsStepFromOnboarding",
 		"showConciergeSessionUpsell",
 		"showConciergeSessionUpsellNonGSuite",
+		"skipBusinessInformation",
 		"builderReferralThemesBanner",
 		"domainSearchButtonStyles",
 		"twoYearPlanByDefault",
@@ -93,6 +94,7 @@
 		[ "showConciergeSessionUpsell_20181214", "skip" ],
 		[ "showConciergeSessionUpsellNonGSuite_20190104", "skip" ],
 		[ "improvedOnboarding_20190214", "main" ],
+		[ "skipSiteInformation_20190130", "hide" ],
 		[ "twoYearPlanByDefault_20190207", "originalFlavor" ]
 	]
 }


### PR DESCRIPTION
## Summary
This is the e2e part of change pairing with https://github.com/Automattic/wp-calypso/pull/30488, which introduces a new a/b test: `skipBusinessInformation`.