### PR TITLE
Increase sleep delay in comments test for Jetpack sites

### DIFF
--- a/specs/wp-comments-spec.js
+++ b/specs/wp-comments-spec.js
@@ -61,7 +61,11 @@ describe( `[${ host }] Comments: (${ screenSize })`, function() {
 
 		step( 'Can post a reply', async function() {
 			// NOTE: we need to wait to prevent "You are posting comments too quickly. Slow down." error
-			await driver.sleep( 10000 );
+			if ( host === 'WPCOM' ) {
+				await driver.sleep( 10000 );
+			} else {
+				await driver.sleep( 15000 );
+			}
 			const commentArea = await CommentsAreaComponent.Expect( driver );
 			await commentArea.reply(
 				{


### PR DESCRIPTION
Sometimes 10sec delay is not enough for Jetpack sites([#](https://circleci.com/gh/Automattic/wp-e2e-tests-jetpack/4189#tests/containers/0)). this PR increases this delay for non-WPCOM hosts