### PR TITLE
Restart concierge session upsell test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -88,7 +88,7 @@
 		[ "removeUsername_20181213", "showUsername" ],
 		[ "removeDomainsStepFromOnboarding_20181221", "keep" ],
 		[ "showConciergeSessionUpsell_20181214", "skip" ],
-		[ "showConciergeSessionUpsellNonGSuite_20181228", "skip" ],
+		[ "showConciergeSessionUpsellNonGSuite_20190104", "skip" ],
 		[ "gSuitePlan_20190117", "basic" ],
 		[ "improvedOnboarding_20190131", "main" ]
 	]


### PR DESCRIPTION
We'll be restarting this test, so updating it here too.
The existing test is currently disabled via a feature flag.

PR for restart in Calypso: https://github.com/Automattic/wp-calypso/pull/30581