### PR TITLE
Wait payment modal to disappear

### DIFF
--- a/lib/pages/editor-page.js
+++ b/lib/pages/editor-page.js
@@ -200,9 +200,14 @@ export default class EditorPage extends AsyncBaseContainer {
 				by.css( '.editor-simple-payments-modal__form .form-toggle__switch' )
 			);
 		}
-		return driverHelper.clickWhenClickable(
+		await driverHelper.clickWhenClickable(
 			this.driver,
 			by.css( '.editor-simple-payments-modal button.is-primary' )
+		);
+		return await driverHelper.waitTillNotPresent(
+			this.driver,
+			by.css( '.editor-simple-payments-modal' ),
+			this.explicitWaitMS * 3
 		);
 	}
 


### PR DESCRIPTION
We had [this failure](https://circleci.com/gh/Automattic/wp-e2e-tests/26274#tests/containers/1) several times. It failed on the step `Can see the payment button inserted into the visual editor` but failure happened on the previous step, `Can insert the payment button`, because payment modal didn't disappear in an expected time frame. 

I added additional `waitTillNotPresent` in `insertPaymentButton()` and increased timeout. This way, test will show an appropriate error message, if it fails for the same reason. 

To test:
Make sure that `Editor: Pages: Insert a payment button: @parallel @jetpack` and `Editor: Posts: Insert a payment button: @parallel @jetpack` are passing, both desktop and mobile 