### PR TITLE
Add entry for new test: twoYearPlanByDefault

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -74,7 +74,8 @@
 		"showConciergeSessionUpsellNonGSuite",
 		"builderReferralThemesBanner",
 		"gSuitePlan",
-		"domainSearchButtonStyles"
+		"domainSearchButtonStyles",
+		"twoYearPlanByDefault"
 	],
 	"overrideABTests": [
 		[ "businessPlanDescriptionAT_20170605", "original" ],
@@ -90,6 +91,7 @@
 		[ "showConciergeSessionUpsell_20181214", "skip" ],
 		[ "showConciergeSessionUpsellNonGSuite_20190104", "skip" ],
 		[ "gSuitePlan_20190117", "basic" ],
-		[ "improvedOnboarding_20190131", "main" ]
+		[ "improvedOnboarding_20190131", "main" ],
+		[ "twoYearPlanByDefault_20190207", "originalFlavor" ]
 	]
 }


### PR DESCRIPTION
We'll be running a new Calypso test (`twoYearPlanByDefault`) to select the 2 year billing term option as the default when purchasing a wpcom plan. 

Calypso PR: https://github.com/Automattic/wp-calypso/pull/30676