### PR TITLE
Increase timeout for signup processing to 3mins

### DIFF
--- a/lib/pages/signup/signup-processing-page.js
+++ b/lib/pages/signup/signup-processing-page.js
@@ -20,7 +20,7 @@ export default class SignupProcessingPage extends AsyncBaseContainer {
 		await driverHelper.waitTillNotPresent(
 			this.driver,
 			this.expectedElementSelector,
-			this.explicitWaitMS * 3
+			this.explicitWaitMS * 9
 		);
 		const url = await this.driver.getCurrentUrl();
 		if ( url.indexOf( 'log-in' ) > -1 ) {

--- a/lib/pages/signup/signup-processing-page.js
+++ b/lib/pages/signup/signup-processing-page.js
@@ -17,11 +17,20 @@ export default class SignupProcessingPage extends AsyncBaseContainer {
 	}
 
 	async waitToDisappear( username, password ) {
-		await driverHelper.waitTillNotPresent(
-			this.driver,
-			this.expectedElementSelector,
-			this.explicitWaitMS * 9
-		);
+		let signupProcessingTimeout = this.explicitWaitMS * 9;
+		try {
+			await driverHelper.waitTillNotPresent(
+				this.driver,
+				this.expectedElementSelector,
+				signupProcessingTimeout
+			);
+		} catch ( e ) {
+			throw new Error(
+				'Looks like creating account is taking to long( ' +
+					signupProcessingTimeout +
+					'ms ). Please try again in a while.'
+			);
+		}
 		const url = await this.driver.getCurrentUrl();
 		if ( url.indexOf( 'log-in' ) > -1 ) {
 			SlackNotifier.warn(


### PR DESCRIPTION
Increase timeout for Signup processing and update error message if the test fails on this step. 

To test:
Make sure that Sign up tests are passing. To test if the proper error message is displayed change [this](https://github.com/Automattic/wp-e2e-tests/pull/1802/files#diff-5104b68ba7c85898642fa3a316da807fR20) line to `let signupProcessingTimeout = this.explicitWaitMS / 500;`