### PR TITLE
AB Tests: update `improvedOnboarding` test date.

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -91,7 +91,7 @@
 		[ "showConciergeSessionUpsell_20181214", "skip" ],
 		[ "showConciergeSessionUpsellNonGSuite_20190104", "skip" ],
 		[ "gSuitePlan_20190117", "basic" ],
-		[ "improvedOnboarding_20190131", "main" ],
+		[ "improvedOnboarding_20190214", "main" ],
 		[ "twoYearPlanByDefault_20190207", "originalFlavor" ]
 	]
 }

--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1647,7 +1647,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		let undo = null;
 
 		before( async function() {
-			undo = overrideABTest( 'improvedOnboarding_20190131', 'onboarding' );
+			undo = overrideABTest( 'improvedOnboarding_20190214', 'onboarding' );
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
@@ -1725,7 +1725,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		let undo = null;
 
 		before( async function() {
-			undo = overrideABTest( 'improvedOnboarding_20190131', 'onboarding' );
+			undo = overrideABTest( 'improvedOnboarding_20190214', 'onboarding' );
 			await driverManager.ensureNotLoggedIn( driver );
 		} );
 


### PR DESCRIPTION
We're bumping the date of the `improvedOnboarding` test in: Automattic/wp-calypso#30795