### PR TITLE
Add `onlyJetpackMonthly` to known A/B tests

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -83,6 +83,7 @@
 		[ "skipThemesSelectionModal_20170904", "show" ],
 		[ "springSale30PercentOff_20180413", "control" ],
 		[ "jetpackSignupGoogleTop_20180427", "original" ],
+		[ "onlyJetpackMonthly_20190212", "original" ],
 		[ "cartNudgeUpdateToPremium_20180903", "control" ],
 		[ "signupAtomicStoreVsPressable_20171101", "atomic" ],
 		[ "privateByDefault_20181113", "public" ],

--- a/config/default.json
+++ b/config/default.json
@@ -63,6 +63,7 @@
 		"skipThemesSelectionModal",
 		"springSale30PercentOff",
 		"jetpackSignupGoogleTop",
+		"onlyJetpackMonthly",
 		"cartNudgeUpdateToPremium",
 		"signupAtomicStoreVsPressable",
 		"improvedOnboarding",


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/30766 introduces a new `onlyJetpackMonthly` A/B test, and this PR adds it to the list of known tests.