### PR TITLE
Add pluginFeaturedTitle to known tests

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -76,7 +76,8 @@
 		"builderReferralThemesBanner",
 		"gSuitePlan",
 		"domainSearchButtonStyles",
-		"twoYearPlanByDefault"
+		"twoYearPlanByDefault",
+		"pluginFeaturedTitle"
 	],
 	"overrideABTests": [
 		[ "businessPlanDescriptionAT_20170605", "original" ],


### PR DESCRIPTION
`pluginFeaturedTitle` varies the title used for the top plugins list in /plugins. See https://github.com/Automattic/wp-calypso/pull/30887.