### PR TITLE
Domains: Add .home.blog as one of the expected addresses

### DIFF
--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -23,7 +23,7 @@ export function getEmailAddress( prefix, inboxId ) {
 }
 
 export function getExpectedFreeAddresses( searchTerm ) {
-	const suffixes = [ '.wordpress.com', 'blog.wordpress.com', 'site.wordpress.com' ];
+	const suffixes = [ '.wordpress.com', 'blog.wordpress.com', 'site.wordpress.com', '.home.blog' ];
 	return map( suffixes, suffix => {
 		return searchTerm + suffix;
 	} );


### PR DESCRIPTION
We also return .blog subdomains, so look for that too