### PR TITLE
Add processing page step

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1608,6 +1608,13 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			);
 		} );
 
+		step(
+			'Can then see the sign up processing page which will finish automatically move along',
+			async function() {
+				return await new SignUpStep( driver ).continueAlong( userName, passwordForTestAccounts );
+			}
+		);
+
 		step( 'Can then see the site importer pane and preview site to be imported', async function() {
 			const importPage = await ImportPage.Expect( driver );
 


### PR DESCRIPTION
I've added step `Can then see the sign up processing page which will finish automatically move along` which was missing in `Import a site while signing up` spec. This change will catch if signup processing is not finished in expected time and log the appropriate message. [This](https://circleci.com/gh/Automattic/wp-e2e-tests-for-branches/14674#tests/containers/0) is how it looks like when it failed without this step. 

To test:
Make sure that spec `Import a site while signing up` is passing, and if it fails on signup processing message should be `Looks like creating account is taking to long( 150000ms ). Please try again in a while.`