### PR TITLE
Temporarily disable signup from /domains test

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -722,7 +722,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Sign up for a domain only purchase coming in from wordpress.com/domains in EUR currency @parallel', function() {
+	xdescribe( 'Sign up for a domain only purchase coming in from wordpress.com/domains in EUR currency @parallel', function() {
 		const siteName = dataHelper.getNewBlogName();
 		const expectedDomainName = `${ siteName }.live`;
 		const emailAddress = dataHelper.getEmailAddress( siteName, signupInboxId );


### PR DESCRIPTION
Temporarily disable test while we don't find out what is causing [failures](https://circleci.com/gh/Automattic/wp-e2e-tests/26674). 

This is what I caught while running locally:
<img width="1566" alt="screen shot 2019-02-27 at 12 29 37" src="https://user-images.githubusercontent.com/7116222/53495057-6c23b000-3a9f-11e9-9ba5-c2cfb0163ac8.png">
