### PR TITLE
Revert "Gutenberg iFrame Tests (#1797)"

### DIFF
--- a/lib/async-base-container.js
+++ b/lib/async-base-container.js
@@ -48,9 +48,6 @@ export default class AsyncBaseContainer {
 		if ( global.__JNSite === true ) {
 			await driverHelper.refreshIfJNError( this.driver );
 		}
-		if ( typeof this._preInit === 'function' ) {
-			await this._preInit();
-		}
 		await this.waitForPage();
 		await this.checkForUnknownABTestKeys();
 		await this.checkForConsoleErrors();

--- a/lib/gutenberg/gutenberg-editor-component.js
+++ b/lib/gutenberg/gutenberg-editor-component.js
@@ -1,5 +1,5 @@
 /** @format */
-import { By, until } from 'selenium-webdriver';
+import { By } from 'selenium-webdriver';
 import * as driverHelper from '../driver-helper';
 import * as driverManager from '../driver-manager.js';
 import AsyncBaseContainer from '../async-base-container';
@@ -18,20 +18,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		);
 		this.prePublishButtonSelector = By.css( '.editor-post-publish-panel__toggle' );
 		this.publishHeaderSelector = By.css( '.editor-post-publish-panel__header' );
-		this.editoriFrameSelector = By.css( '.calypsoify.is-iframe iframe' );
 	}
 
 	async _postInit() {
 		await this.removeNUXNotice();
-	}
-
-	async _preInit() {
-		await this.driver.switchTo().defaultContent();
-		await this.driver.wait(
-			until.ableToSwitchToFrame( this.editoriFrameSelector ),
-			this.explicitWaitMS,
-			'Could not locate the editor iFrame.'
-		);
 	}
 
 	async publish( { visit = false } = {} ) {
@@ -209,14 +199,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,
 			By.css( '.components-notice.is-success' )
-		);
-	}
-
-	async dismissSuccessNotice() {
-		await this.waitForSuccessViewPostNotice();
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.components-notice__dismiss' )
 		);
 	}
 

--- a/lib/gutenberg/gutenberg-page-preview-component.js
+++ b/lib/gutenberg/gutenberg-page-preview-component.js
@@ -2,21 +2,10 @@
 import { By } from 'selenium-webdriver';
 import AsyncBaseContainer from '../async-base-container';
 import ViewPagePage from '../pages/view-page-page';
-import * as driverHelper from '../driver-helper';
 
 export default class GutenbergPagePreviewComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '#main.site-main' ) );
-	}
-
-	async _preInit() {
-		await driverHelper.waitForNumberOfWindows( this.driver, 2 );
-		return await driverHelper.switchToWindowByIndex( this.driver, 1 );
-	}
-
-	async close() {
-		await driverHelper.closeCurrentWindow( this.driver );
-		return await driverHelper.switchToWindowByIndex( this.driver, 0 );
 	}
 
 	async pageTitle() {

--- a/lib/gutenberg/gutenberg-post-preview-component.js
+++ b/lib/gutenberg/gutenberg-post-preview-component.js
@@ -2,21 +2,10 @@
 import { By } from 'selenium-webdriver';
 import AsyncBaseContainer from '../async-base-container';
 import ViewPostPage from '../pages/view-post-page';
-import * as driverHelper from '../driver-helper';
 
 export default class GutenbergPostPreviewComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '#main.site-main' ) );
-	}
-
-	async _preInit() {
-		await driverHelper.waitForNumberOfWindows( this.driver, 2 );
-		return await driverHelper.switchToWindowByIndex( this.driver, 1 );
-	}
-
-	async close() {
-		await driverHelper.closeCurrentWindow( this.driver );
-		return await driverHelper.switchToWindowByIndex( this.driver, 0 );
 	}
 
 	async postTitle() {

--- a/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -11,7 +11,7 @@ import NotFoundPage from '../lib/pages/not-found-page.js';
 import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
-import GutenbergPagePreviewComponent from '../lib/gutenberg/gutenberg-page-preview-component';
+import PagePreviewComponent from '../lib/components/page-preview-component';
 import SimplePaymentsBlockComponent from '../lib/gutenberg/blocks/payment-block-component';
 
 import * as driverManager from '../lib/driver-manager.js';
@@ -90,9 +90,9 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct page title in preview', async function() {
-			const gPagePreviewComponent = await GutenbergPagePreviewComponent.Expect( driver );
-			await gPagePreviewComponent.displayed();
-			let actualPageTitle = await gPagePreviewComponent.pageTitle();
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			await pagePreviewComponent.displayed();
+			let actualPageTitle = await pagePreviewComponent.pageTitle();
 			assert.strictEqual(
 				actualPageTitle.toUpperCase(),
 				pageTitle.toUpperCase(),
@@ -101,8 +101,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct page content in preview', async function() {
-			const gPagePreviewComponent = await GutenbergPagePreviewComponent.Expect( driver );
-			let content = await gPagePreviewComponent.pageContent();
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			let content = await pagePreviewComponent.pageContent();
 			assert.strictEqual(
 				content.indexOf( pageQuote ) > -1,
 				true,
@@ -115,8 +115,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see the image uploaded in the preview', async function() {
-			const gPagePreviewComponent = await GutenbergPagePreviewComponent.Expect( driver );
-			const imageDisplayed = await gPagePreviewComponent.imageDisplayed( fileDetails );
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			const imageDisplayed = await pagePreviewComponent.imageDisplayed( fileDetails );
 			return assert.strictEqual(
 				imageDisplayed,
 				true,
@@ -125,8 +125,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can close page preview', async function() {
-			const gPagePreviewComponent = await GutenbergPagePreviewComponent.Expect( driver );
-			await gPagePreviewComponent.close();
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			await pagePreviewComponent.close();
 		} );
 
 		step( 'Can publish and preview published content', async function() {

--- a/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -14,7 +14,7 @@ import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
 
 import SidebarComponent from '../lib/components/sidebar-component.js';
 import NavBarComponent from '../lib/components/nav-bar-component.js';
-import GutenbergPostPreviewComponent from '../lib/gutenberg/gutenberg-post-preview-component';
+import PostPreviewComponent from '../lib/components/post-preview-component';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
 import SimplePaymentsBlockComponent from '../lib/gutenberg/blocks/payment-block-component';
@@ -121,8 +121,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct post title in preview', async function() {
-			this.gPostPreviewComponent = await GutenbergPostPreviewComponent.Expect( driver );
-			let postTitle = await this.gPostPreviewComponent.postTitle();
+			this.postPreviewComponent = await PostPreviewComponent.Expect( driver );
+			let postTitle = await this.postPreviewComponent.postTitle();
 			assert.strictEqual(
 				postTitle.toLowerCase(),
 				blogPostTitle.toLowerCase(),
@@ -131,7 +131,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct post content in preview', async function() {
-			let content = await this.gPostPreviewComponent.postContent();
+			let content = await this.postPreviewComponent.postContent();
 			assert.strictEqual(
 				content.indexOf( blogPostQuote ) > -1,
 				true,
@@ -144,7 +144,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		step( 'Can see the post category in preview', async function() {
-			let categoryDisplayed = await this.gPostPreviewComponent.categoryDisplayed();
+			let categoryDisplayed = await this.postPreviewComponent.categoryDisplayed();
 			assert.strictEqual(
 				categoryDisplayed.toUpperCase(),
 				newCategoryName.toUpperCase(),
@@ -163,12 +163,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		// } );
 
 		step( 'Can see the image in preview', async function() {
-			let imageDisplayed = await this.gPostPreviewComponent.imageDisplayed( fileDetails );
+			let imageDisplayed = await this.postPreviewComponent.imageDisplayed( fileDetails );
 			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the web preview' );
 		} );
 
 		step( 'Can close post preview', async function() {
-			await this.gPostPreviewComponent.close();
+			await this.postPreviewComponent.close();
 		} );
 
 		step( 'Can publish and view content', async function() {
@@ -1076,7 +1076,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		describe( 'Revert the post to draft', function() {
 			step( 'Can revert the post to draft', async function() {
 				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
-				await gHeaderComponent.dismissSuccessNotice();
 				await gHeaderComponent.revertToDraft();
 				let isDraft = await gHeaderComponent.isDraft();
 				assert.strictEqual( isDraft, true, 'The post is not set as draft' );


### PR DESCRIPTION
This reverts commit 94c7c8b

Revert changes related to Block editor in iFrame because it's still not on production. 