### PR TITLE
Fix: Update expiry date for credit card

### DIFF
--- a/lib/data-helper.js
+++ b/lib/data-helper.js
@@ -231,7 +231,7 @@ export function getTestCreditCardDetails() {
 		cardHolder: 'End To End Testing',
 		cardType: 'VISA',
 		cardNumber: '4242 4242 4242 4242', // https://stripe.com/docs/testing#cards
-		cardExpiry: '02/19',
+		cardExpiry: '02/49',
 		cardCVV: '300',
 		cardCountryCode: 'TR', // using Turkey to force Stripe as payment processor
 		cardPostCode: '4000',


### PR DESCRIPTION
Currently tests fail whenever a credit card info is expected, since the expiry date for the card is set to 02/19. 

<img width="1287" alt="screen shot 2019-03-01 at 16 57 47" src="https://user-images.githubusercontent.com/1269602/53622741-d7e15680-3c20-11e9-8c1c-51b1357d177e.png">

This PR fixes the issue by updating the expiry date.