### PR TITLE
Remove the concluded `skipBusinessInformation` test.

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -72,7 +72,6 @@
 		"removeDomainsStepFromOnboarding",
 		"showConciergeSessionUpsell",
 		"showConciergeSessionUpsellNonGSuite",
-		"skipBusinessInformation",
 		"builderReferralThemesBanner",
 		"domainSearchButtonStyles",
 		"twoYearPlanByDefault",
@@ -93,7 +92,6 @@
 		[ "showConciergeSessionUpsell_20181214", "skip" ],
 		[ "showConciergeSessionUpsellNonGSuite_20190104", "skip" ],
 		[ "improvedOnboarding_20190214", "main" ],
-		[ "skipBusinessInformation_20190130", "hide" ],
 		[ "twoYearPlanByDefault_20190207", "originalFlavor" ],
 	  	[ "builderReferralHelpPopover_20190227", "original" ]
 	]


### PR DESCRIPTION
## Summary
We've concluded the `skipBusinessInformation` test so it's time to retire it. The corresponding calypso-side PR is https://github.com/Automattic/wp-calypso/pull/31260 and this PR simply removes it from the e2e side.