### PR TITLE
AB Tests: Updating known A/B tests and overrides for Automattic/wp-calypso/pull/31198

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -77,7 +77,8 @@
 		"domainSearchButtonStyles",
 		"twoYearPlanByDefault",
 		"pluginFeaturedTitle",
-	  	"builderReferralHelpPopover"
+	  	"builderReferralHelpPopover",
+		"checklistSiteLogo"
 	],
 	"overrideABTests": [
 		[ "businessPlanDescriptionAT_20170605", "original" ],
@@ -95,6 +96,7 @@
 		[ "improvedOnboarding_20190214", "main" ],
 		[ "skipBusinessInformation_20190130", "hide" ],
 		[ "twoYearPlanByDefault_20190207", "originalFlavor" ],
-	  	[ "builderReferralHelpPopover_20190227", "original" ]
+	  	[ "builderReferralHelpPopover_20190227", "original" ],
+		[ "checklistSiteLogo_20190305", "icon" ]
 	]
 }


### PR DESCRIPTION
Telling our e2e tests about an upcoming AB Test, `checklistSiteLogo_ 20190305 ` introduced by https://github.com/Automattic/wp-calypso/pull/31198