### PR TITLE
Update the datestamp of improved onboarding abtest

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -92,7 +92,7 @@
 		[ "removeDomainsStepFromOnboarding_20181221", "keep" ],
 		[ "showConciergeSessionUpsell_20181214", "skip" ],
 		[ "showConciergeSessionUpsellNonGSuite_20190104", "skip" ],
-		[ "improvedOnboarding_20190214", "main" ],
+		[ "improvedOnboarding_20190314", "main" ],
 		[ "twoYearPlanByDefault_20190207", "originalFlavor" ],
 	  	[ "builderReferralHelpPopover_20190227", "original" ],
 		[ "checklistSiteLogo_20190305", "icon" ]


### PR DESCRIPTION
This PR will update the name of improved onboarding test since we're going to roll out the test to all English users with new datestamp.
See https://github.com/Automattic/wp-calypso/pull/31384