### PR TITLE
People: Update CSS selectors for Role tests

### DIFF
--- a/lib/pages/invite-people-page.js
+++ b/lib/pages/invite-people-page.js
@@ -10,7 +10,7 @@ import * as DriverHelper from '../driver-helper.js';
 
 export default class InvitePeoplePage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( 'select#role' ) );
+		super( driver, By.css( 'fieldset#role' ) );
 	}
 
 	async inviteNewUser( email, role, message = '' ) {
@@ -18,7 +18,7 @@ export default class InvitePeoplePage extends AsyncBaseContainer {
 			role = 'follower'; //the select input option uses follower for viewer
 		}
 
-		const roleSelector = By.css( `select#role option[value=${ role }]` );
+		const roleSelector = By.css( `fieldset#role input[value=${ role }]` );
 
 		await DriverHelper.setWhenSettable( this.driver, By.css( 'input.token-field__input' ), email );
 		await DriverHelper.waitTillPresentAndDisplayed( this.driver, roleSelector );


### PR DESCRIPTION
* We're changing the select element to a set of radio inputs for better accessibility/usability.
* This PR updates the CSS selectors to target the radio inputs rather than a select element.
* See Automattic/wp-calypso#31821