### PR TITLE
Use the new NUX verticals

### DIFF
--- a/specs/wp-signup-spec.js
+++ b/specs/wp-signup-spec.js
@@ -1294,7 +1294,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 				StartPage.getStartURL( {
 					culture: locale,
 					flow: 'subdomain',
-					query: 'vertical=a8c.1',
+					query: 'vertical=Art',
 				} )
 			);
 			const designTypePage = await DesignTypePage.Expect( driver );


### PR DESCRIPTION
We don't use the old a8c.something codes anymore. Now the verticals have their own IDs and the API accepts verticals by name. I've updated the only place I found a vertical in the e2e tests

see D24910-code